### PR TITLE
fix: remove profile sidebar link and fix planner dropdown alignment

### DIFF
--- a/serving/frontend/src/components/layout/Sidebar.jsx
+++ b/serving/frontend/src/components/layout/Sidebar.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { NavLink } from 'react-router-dom'
-import { Radio, Sparkles, FolderGit2, ListTodo, Play, Target, User, ChevronDown, Check } from 'lucide-react'
+import { Radio, Sparkles, FolderGit2, ListTodo, Play, Target, ChevronDown, Check } from 'lucide-react'
 import useSystemHealth from '../../hooks/useSystemHealth'
 import { useProjectContext } from '../../contexts/ProjectContext'
 import NotificationBell from '../notifications/NotificationBell'
@@ -172,16 +172,6 @@ function Sidebar() {
           </NavLink>
         ))}
       </div>
-
-      <div className="sidebar-divider" />
-      <NavLink
-        to="/settings/profile"
-        className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}
-        title="Profile"
-      >
-        <User size={18} strokeWidth={1.5} />
-        <span className="nav-item-label">Profile</span>
-      </NavLink>
 
       <div className="sidebar-footer">
         <div className="sidebar-footer-row">

--- a/serving/frontend/src/components/plan/ProfileSwitcher.css
+++ b/serving/frontend/src/components/plan/ProfileSwitcher.css
@@ -36,7 +36,7 @@
 .profile-switcher-dropdown {
   position: absolute;
   top: calc(100% + 4px);
-  right: 0;
+  left: 0;
   z-index: 50;
   min-width: 280px;
   background: var(--bg-elevated);


### PR DESCRIPTION
## Summary
Two small UI fixes.

## Changes

**1. Remove Profile sidebar menu item**
- Removed the Profile `NavLink` and its preceding divider from `Sidebar.jsx`
- Removed the now-unused `User` icon import
- Profile/login is not yet implemented — item is hidden until it is

**2. Fix planner profile dropdown alignment**
- Changed `.profile-switcher-dropdown` from `right: 0` to `left: 0`
- Dropdown now extends to the **right** of the trigger button instead of to the left, where it was clipping under the sidebar

## Files Changed
- `serving/frontend/src/components/layout/Sidebar.jsx`
- `serving/frontend/src/components/plan/ProfileSwitcher.css`