### PR TITLE
fix: recover stale ASSIGNED work items that were never started

### DIFF
--- a/serving/services/assignment_service.py
+++ b/serving/services/assignment_service.py
@@ -676,6 +676,106 @@ class AssignmentService:
 
         return stale_items
 
+    async def get_stale_assigned_work(self, assigned_timeout_minutes: int) -> List[WorkItem]:
+        """Get ASSIGNED work items that were never started by a compute.
+
+        Detects work items stuck in ASSIGNED status — typically caused by a
+        race between PR auto-merge resetting the SSE connection to idle and
+        the compute's claude_code_completed event clobbering the assignment,
+        or by an assigned compute failing on a different task without
+        touching this work item.
+
+        Args:
+            assigned_timeout_minutes: Minutes after which an ASSIGNED item
+                with no started_at is considered stale.
+
+        Returns:
+            List of stale ASSIGNED work items.
+        """
+        stale_threshold = datetime.now(timezone.utc) - timedelta(minutes=assigned_timeout_minutes)
+        stale_items = []
+
+        for work in self._work_items.values():
+            if work.status != WorkStatus.ASSIGNED:
+                continue
+
+            # Only recover items that were never started
+            if work.started_at is not None:
+                continue
+
+            assigned_at = work.assigned_at or work.updated_at
+            if assigned_at < stale_threshold:
+                stale_items.append(work)
+
+        return stale_items
+
+    async def reset_assigned_to_pending(
+        self,
+        work_id: str,
+        save_callback=None
+    ) -> Optional[WorkItem]:
+        """Reset a stale ASSIGNED work item back to PENDING for re-dispatch.
+
+        Args:
+            work_id: Work item ID
+            save_callback: Async callback to persist the work item
+
+        Returns:
+            Updated work item, or None if not found / wrong status.
+        """
+        work = self._work_items.get(work_id)
+        if not work:
+            return None
+
+        if work.status != WorkStatus.ASSIGNED:
+            logger.warning(
+                f"Cannot reset work {work_id}: expected ASSIGNED, got {work.status}"
+            )
+            return None
+
+        old_assignee = work.assigned_to
+
+        # Clean up Redis indices
+        if self._redis:
+            await self._redis._redis.srem(
+                self._key("work:status:assigned"),
+                work_id
+            )
+            if old_assignee:
+                await self._redis._redis.srem(
+                    self._key(f"work:assignee:{old_assignee}"),
+                    work_id
+                )
+                await self._redis._redis.delete(
+                    self._key(f"workmap:compute:{old_assignee}:current")
+                )
+
+        recovery_note = (
+            f"[{datetime.now(timezone.utc).isoformat()}] "
+            f"Stale ASSIGNED recovery: reset to PENDING "
+            f"(was assigned to {old_assignee})"
+        )
+        work.progress_notes.append(recovery_note)
+
+        work.status = WorkStatus.PENDING
+        work.assigned_to = None
+        work.assigned_skills = []
+        work.assigned_at = None
+        work.started_at = None
+        work.last_activity_at = None
+        work.updated_at = datetime.now(timezone.utc)
+
+        if save_callback:
+            await save_callback(work)
+
+        await self._emit_status_change_event(work, WorkStatus.ASSIGNED, WorkStatus.PENDING)
+
+        logger.info(
+            f"Work {work_id} reset from ASSIGNED to PENDING "
+            f"(was assigned to {old_assignee})"
+        )
+        return work
+
     async def mark_work_timed_out(
         self,
         work_id: str,

--- a/serving/services/work_map_service.py
+++ b/serving/services/work_map_service.py
@@ -1285,6 +1285,16 @@ class WorkMapService:
         """Get work items that have been IN_PROGRESS for too long without activity."""
         return await self._assignment_service.get_stale_work(timeout_minutes)
 
+    async def get_stale_assigned_work(self, assigned_timeout_minutes: int) -> List[WorkItem]:
+        """Get ASSIGNED work items that were never started by a compute."""
+        return await self._assignment_service.get_stale_assigned_work(assigned_timeout_minutes)
+
+    async def reset_assigned_to_pending(self, work_id: str) -> Optional[WorkItem]:
+        """Reset a stale ASSIGNED work item back to PENDING for re-dispatch."""
+        return await self._assignment_service.reset_assigned_to_pending(
+            work_id, save_callback=self._save_to_redis
+        )
+
     async def mark_work_timed_out(
         self,
         work_id: str,

--- a/serving/services/work_orchestrator.py
+++ b/serving/services/work_orchestrator.py
@@ -85,7 +85,8 @@ class WorkOrchestrator:
         timeout_minutes: int = 30,
         timeout_check_interval: int = 60,
         timeout_max_retries: int = 3,
-        timeout_enabled: bool = True
+        timeout_enabled: bool = True,
+        assigned_timeout_minutes: int = 3,
     ):
         """Initialize the work orchestrator.
 
@@ -98,6 +99,8 @@ class WorkOrchestrator:
             timeout_check_interval: Seconds between timeout checks
             timeout_max_retries: Maximum retries before marking work as FAILED
             timeout_enabled: Whether to enable stuck-work detection
+            assigned_timeout_minutes: Minutes before ASSIGNED work with no
+                started_at is considered orphaned and reset to PENDING
         """
         self.poll_interval = poll_interval
         self.max_concurrent_spawns = max_concurrent_spawns
@@ -109,6 +112,7 @@ class WorkOrchestrator:
         self.timeout_check_interval = timeout_check_interval
         self.timeout_max_retries = timeout_max_retries
         self.timeout_enabled = timeout_enabled
+        self.assigned_timeout_minutes = assigned_timeout_minutes
 
         self._task: Optional[asyncio.Task] = None
         self._timeout_task: Optional[asyncio.Task] = None
@@ -136,6 +140,7 @@ class WorkOrchestrator:
             "total_timeout_retries": 0,
             "total_resource_conflicts": 0,
             "total_circuit_breaks": 0,
+            "total_assigned_recoveries": 0,
             "last_poll": None,
             "last_spawn": None,
             "last_timeout_check": None,
@@ -217,7 +222,8 @@ class WorkOrchestrator:
             "active_spawns": len(self._active_spawns),
             "pending_retries": len(self._retry_after),
             "timeout_monitoring_enabled": self.timeout_enabled,
-            "timeout_minutes": self.timeout_minutes
+            "timeout_minutes": self.timeout_minutes,
+            "assigned_timeout_minutes": self.assigned_timeout_minutes
         }
 
     async def _orchestration_loop(self) -> None:
@@ -271,20 +277,55 @@ class WorkOrchestrator:
                 await asyncio.sleep(self.timeout_check_interval)
 
     async def _detect_and_handle_stale_work(self) -> None:
-        """Detect work that has been IN_PROGRESS too long and handle it."""
+        """Detect stuck work and handle it.
+
+        Checks two categories:
+        1. IN_PROGRESS items with no activity beyond timeout_minutes.
+        2. ASSIGNED items that were never started (started_at is None)
+           beyond assigned_timeout_minutes — typically caused by SSE
+           connection state races where a compute's idle reset clobbers
+           a pending assignment.
+        """
         from services.work_map_service import get_work_map_service
 
         try:
             work_map = get_work_map_service()
 
-            # Get stale work items
+            # --- Recover stale ASSIGNED items ---
+            stale_assigned = await work_map.get_stale_assigned_work(
+                self.assigned_timeout_minutes
+            )
+            if stale_assigned:
+                logger.info(
+                    f"Found {len(stale_assigned)} stale ASSIGNED work items"
+                )
+            for work in stale_assigned:
+                try:
+                    updated = await work_map.reset_assigned_to_pending(
+                        work.work_id
+                    )
+                    if updated:
+                        self._stats["total_assigned_recoveries"] += 1
+                        logger.warning(
+                            f"Recovered stale ASSIGNED work {work.work_id} "
+                            f"(was assigned to {work.assigned_to}, "
+                            f"assigned_at={work.assigned_at})"
+                        )
+                except Exception as e:
+                    logger.error(
+                        f"Error recovering stale assigned work "
+                        f"{work.work_id}: {e}"
+                    )
+
+            # --- Handle stale IN_PROGRESS items ---
             stale_work = await work_map.get_stale_work(self.timeout_minutes)
 
-            if not stale_work:
+            if not stale_work and not stale_assigned:
                 logger.debug("No stale work detected")
                 return
 
-            logger.info(f"Found {len(stale_work)} stale work items")
+            if stale_work:
+                logger.info(f"Found {len(stale_work)} stale IN_PROGRESS work items")
 
             for work in stale_work:
                 try:
@@ -1289,7 +1330,8 @@ async def start_work_orchestration(
     timeout_minutes: int = 30,
     timeout_check_interval: int = 60,
     timeout_max_retries: int = 3,
-    timeout_enabled: bool = True
+    timeout_enabled: bool = True,
+    assigned_timeout_minutes: int = 3,
 ) -> None:
     """Start the global work orchestrator.
 
@@ -1302,6 +1344,8 @@ async def start_work_orchestration(
         timeout_check_interval: Seconds between timeout checks
         timeout_max_retries: Maximum retries before marking work as FAILED
         timeout_enabled: Whether to enable stuck-work detection
+        assigned_timeout_minutes: Minutes before ASSIGNED work with no
+            started_at is considered orphaned and reset to PENDING
     """
     global _orchestrator
 
@@ -1317,7 +1361,8 @@ async def start_work_orchestration(
         timeout_minutes=timeout_minutes,
         timeout_check_interval=timeout_check_interval,
         timeout_max_retries=timeout_max_retries,
-        timeout_enabled=timeout_enabled
+        timeout_enabled=timeout_enabled,
+        assigned_timeout_minutes=assigned_timeout_minutes,
     )
 
     await _orchestrator.start()

--- a/serving/tests/unit/test_assignment_service.py
+++ b/serving/tests/unit/test_assignment_service.py
@@ -825,3 +825,175 @@ class TestMarkWorkForRetry:
         mock_redis._redis.delete.assert_any_call(
             "claudevn:workmap:workmap:compute:compute-001:current"
         )
+
+
+class TestGetStaleAssignedWork:
+    """Test detection of ASSIGNED work items that were never started."""
+
+    @pytest.mark.asyncio
+    async def test_returns_stale_assigned_items(self, service):
+        """ASSIGNED items older than threshold with no started_at are returned."""
+        work = WorkItem(
+            work_id="work_stale",
+            title="Stale Assigned",
+            description="desc",
+            project_id="proj-001",
+            status=WorkStatus.ASSIGNED,
+            assigned_to="compute-001",
+            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+            started_at=None,
+        )
+        service._work_items = {"work_stale": work}
+
+        result = await service.get_stale_assigned_work(assigned_timeout_minutes=3)
+        assert len(result) == 1
+        assert result[0].work_id == "work_stale"
+
+    @pytest.mark.asyncio
+    async def test_ignores_recently_assigned(self, service):
+        """ASSIGNED items within the threshold are not returned."""
+        work = WorkItem(
+            work_id="work_fresh",
+            title="Fresh Assigned",
+            description="desc",
+            project_id="proj-001",
+            status=WorkStatus.ASSIGNED,
+            assigned_to="compute-001",
+            assigned_at=datetime.now(timezone.utc) - timedelta(seconds=30),
+            started_at=None,
+        )
+        service._work_items = {"work_fresh": work}
+
+        result = await service.get_stale_assigned_work(assigned_timeout_minutes=3)
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_ignores_started_items(self, service):
+        """ASSIGNED items with started_at set are not returned."""
+        work = WorkItem(
+            work_id="work_started",
+            title="Started",
+            description="desc",
+            project_id="proj-001",
+            status=WorkStatus.ASSIGNED,
+            assigned_to="compute-001",
+            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+            started_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+        )
+        service._work_items = {"work_started": work}
+
+        result = await service.get_stale_assigned_work(assigned_timeout_minutes=3)
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_assigned_statuses(self, service):
+        """Only ASSIGNED items are returned, not PENDING or IN_PROGRESS."""
+        pending = WorkItem(
+            work_id="work_pending",
+            title="Pending",
+            description="desc",
+            project_id="proj-001",
+            status=WorkStatus.PENDING,
+        )
+        in_progress = WorkItem(
+            work_id="work_ip",
+            title="In Progress",
+            description="desc",
+            project_id="proj-001",
+            status=WorkStatus.IN_PROGRESS,
+            assigned_to="compute-001",
+            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+            started_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+        )
+        service._work_items = {
+            "work_pending": pending,
+            "work_ip": in_progress,
+        }
+
+        result = await service.get_stale_assigned_work(assigned_timeout_minutes=3)
+        assert len(result) == 0
+
+
+class TestResetAssignedToPending:
+    """Test resetting stale ASSIGNED work items back to PENDING."""
+
+    @pytest.mark.asyncio
+    async def test_resets_to_pending(self, service):
+        """Successfully resets ASSIGNED item to PENDING."""
+        work = WorkItem(
+            work_id="work_reset",
+            title="Reset Me",
+            description="desc",
+            project_id="proj-001",
+            status=WorkStatus.ASSIGNED,
+            assigned_to="compute-001",
+            assigned_skills=["code-writer"],
+            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+        )
+        service._work_items = {"work_reset": work}
+
+        result = await service.reset_assigned_to_pending("work_reset")
+
+        assert result is not None
+        assert result.status == WorkStatus.PENDING
+        assert result.assigned_to is None
+        assert result.assigned_skills == []
+        assert result.assigned_at is None
+        assert result.started_at is None
+        assert len(result.progress_notes) == 1
+        assert "Stale ASSIGNED recovery" in result.progress_notes[0]
+        assert "compute-001" in result.progress_notes[0]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_missing(self, service):
+        """Returns None when work_id not found."""
+        service._work_items = {}
+        result = await service.reset_assigned_to_pending("nonexistent")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_assigned_status(self, service):
+        """Returns None when work item is not in ASSIGNED status."""
+        work = WorkItem(
+            work_id="work_pending",
+            title="Pending",
+            description="desc",
+            project_id="proj-001",
+            status=WorkStatus.PENDING,
+        )
+        service._work_items = {"work_pending": work}
+
+        result = await service.reset_assigned_to_pending("work_pending")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_cleans_up_redis(self, service_with_redis, mock_redis):
+        """Verifies Redis index cleanup on reset."""
+        work = WorkItem(
+            work_id="work_redis",
+            title="Redis Reset",
+            description="desc",
+            project_id="proj-001",
+            status=WorkStatus.ASSIGNED,
+            assigned_to="compute-002",
+            assigned_skills=["code-writer"],
+            assigned_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+        )
+        service_with_redis._work_items = {"work_redis": work}
+
+        save_cb = AsyncMock()
+        result = await service_with_redis.reset_assigned_to_pending(
+            "work_redis", save_callback=save_cb
+        )
+
+        assert result.status == WorkStatus.PENDING
+        mock_redis._redis.srem.assert_any_call(
+            "claudevn:workmap:work:status:assigned", "work_redis"
+        )
+        mock_redis._redis.srem.assert_any_call(
+            "claudevn:workmap:work:assignee:compute-002", "work_redis"
+        )
+        mock_redis._redis.delete.assert_any_call(
+            "claudevn:workmap:workmap:compute:compute-002:current"
+        )
+        save_cb.assert_awaited_once()

--- a/serving/tests/unit/test_work_orchestrator.py
+++ b/serving/tests/unit/test_work_orchestrator.py
@@ -308,6 +308,7 @@ class TestOrchestratorStaleWorkDetection:
         with patch("services.work_map_service.get_work_map_service") as mock_get_service:
             mock_service = MagicMock()
             mock_service.get_stale_work = AsyncMock(return_value=[mock_work])
+            mock_service.get_stale_assigned_work = AsyncMock(return_value=[])
             mock_service.mark_work_timed_out = AsyncMock(return_value=MagicMock(
                 status=WorkStatus.PENDING,
                 retry_count=1
@@ -330,6 +331,7 @@ class TestOrchestratorStaleWorkDetection:
         with patch("services.work_map_service.get_work_map_service") as mock_get_service:
             mock_service = MagicMock()
             mock_service.get_stale_work = AsyncMock(return_value=[mock_work])
+            mock_service.get_stale_assigned_work = AsyncMock(return_value=[])
             mock_service.mark_work_timed_out = AsyncMock(return_value=MagicMock(
                 status=WorkStatus.PENDING,
                 retry_count=1
@@ -349,6 +351,7 @@ class TestOrchestratorStaleWorkDetection:
         with patch("services.work_map_service.get_work_map_service") as mock_get_service:
             mock_service = MagicMock()
             mock_service.get_stale_work = AsyncMock(return_value=[])
+            mock_service.get_stale_assigned_work = AsyncMock(return_value=[])
             mock_get_service.return_value = mock_service
 
             await orch._detect_and_handle_stale_work()
@@ -366,6 +369,7 @@ class TestOrchestratorStaleWorkDetection:
         with patch("services.work_map_service.get_work_map_service") as mock_get_service:
             mock_service = MagicMock()
             mock_service.get_stale_work = AsyncMock(return_value=[mock_work])
+            mock_service.get_stale_assigned_work = AsyncMock(return_value=[])
             mock_service.mark_work_timed_out = AsyncMock(return_value=MagicMock(
                 status=WorkStatus.FAILED,
                 retry_count=3
@@ -377,6 +381,31 @@ class TestOrchestratorStaleWorkDetection:
             assert orch._stats["total_timeouts"] == 1
             # FAILED status should not increment retry count
             assert orch._stats["total_timeout_retries"] == 0
+
+    @pytest.mark.asyncio
+    async def test_detect_stale_assigned_work_recovers(self):
+        """Test that stale ASSIGNED items are recovered to PENDING."""
+        orch = WorkOrchestrator(timeout_minutes=30, assigned_timeout_minutes=3)
+
+        mock_stale = MagicMock()
+        mock_stale.work_id = "work_orphan"
+        mock_stale.assigned_to = "compute-001"
+        mock_stale.assigned_at = "2026-01-01T00:00:00Z"
+
+        with patch("services.work_map_service.get_work_map_service") as mock_get_service:
+            mock_service = MagicMock()
+            mock_service.get_stale_work = AsyncMock(return_value=[])
+            mock_service.get_stale_assigned_work = AsyncMock(return_value=[mock_stale])
+            mock_service.reset_assigned_to_pending = AsyncMock(return_value=MagicMock(
+                status=WorkStatus.PENDING
+            ))
+            mock_get_service.return_value = mock_service
+
+            await orch._detect_and_handle_stale_work()
+
+            mock_service.get_stale_assigned_work.assert_called_once_with(3)
+            mock_service.reset_assigned_to_pending.assert_called_once_with("work_orphan")
+            assert orch._stats["total_assigned_recoveries"] == 1
 
 
 class TestOrchestratorSSEWorkAssignment:


### PR DESCRIPTION
## Summary

- Work items could get stuck in ASSIGNED status indefinitely when SSE connection state races caused the compute assignment to be clobbered before the task actually started
- The existing `_detect_and_handle_stale_work()` only checked IN_PROGRESS items, completely missing ASSIGNED-but-never-started orphans
- Adds `get_stale_assigned_work()` and `reset_assigned_to_pending()` to the assignment service with a 3-minute default threshold
- The orchestrator's timeout monitoring loop now recovers these items back to PENDING for re-dispatch on each cycle

## Root Cause

Two race conditions can orphan work items in ASSIGNED status:

1. **PR auto-merge resets SSE connection**: When a task's PR auto-merges, `send_work_completed` resets the compute's SSE connection to "idle". The orchestrator sees the idle compute and assigns new work (setting status to ASSIGNED in Redis). But the compute's `claude_code_completed` event then arrives and resets the connection to idle *again*, clobbering the new assignment. The next task gets dispatched to the now-"idle" compute while the first assignment stays stuck.

2. **Compute fails on a different task**: If a compute fails on task A (e.g., conflict resolution), the failure handler resets the SSE connection to idle and processes task A's work item. But task B, which was assigned to the same compute, is never touched — it remains in ASSIGNED status with no compute executing it.

## Test plan

- [x] 8 new unit tests for `AssignmentService.get_stale_assigned_work()` and `reset_assigned_to_pending()` (including Redis cleanup verification)
- [x] 1 new unit test for orchestrator integration (`test_detect_stale_assigned_work_recovers`)
- [x] All 43 assignment service tests pass
- [x] All 89/90 orchestrator tests pass (1 pre-existing failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)