### PR TITLE
fix: re-chown bare repo after serving-side git writes

### DIFF
--- a/serving/git/pr_service.py
+++ b/serving/git/pr_service.py
@@ -848,6 +848,9 @@ class PRService:
                 logger.error(f"Push failed for {project}/{branch}: {push_result.stderr}")
                 raise ValueError(f"Push failed: {push_result.stderr}")
 
+            # Re-chown bare repo so SSH pushes (as git user) still work
+            self._repo_manager._chown_to_git_user(repo_path)
+
             # 5. Get merge commit
             commit_result = subprocess.run(
                 ["git", "-C", str(work_dir), "rev-parse", "HEAD"],

--- a/serving/git/repo_manager.py
+++ b/serving/git/repo_manager.py
@@ -671,6 +671,9 @@ exit 0
                 result.stderr
             )
 
+        # Re-chown so SSH pushes (as git user) still work after fetch
+        self._chown_to_git_user(repo_path)
+
         return {
             "success": True,
             "project": project,


### PR DESCRIPTION
## Summary

Fixes #7

- Add `_chown_to_git_user()` call after `pr_service.merge()` pushes merged main back to the bare repo
- Add `_chown_to_git_user()` call after `repo_manager.pull_from_origin()` fetches from remote

Serving runs as root, so these operations create objects owned by `root:root`. Without re-chowning, subsequent SSH pushes from compute (running as git user) fail with `Permission denied`.

`_chown_to_git_user` was already called on repo creation and clone, but these two write paths were missed.

## Test plan

- [ ] Start platform with `docker compose up`
- [ ] Submit a goal that generates compute work
- [ ] Verify compute pushes feature branch successfully
- [ ] Approve and merge the PR via UI (triggers `pr_service.merge()`)
- [ ] Verify bare repo objects are owned by git user after merge
- [ ] Submit another goal — verify compute can push a new branch without Permission denied
- [ ] Test `pull_from_origin` path if serving repo sync is configured