### PR TITLE
chore: add community health files and repo settings

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [trueorc]

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Report a bug in ClaudeVN
+title: "[Bug] "
+labels: bug
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- ClaudeVN version:
+- OS:
+- Docker version (if applicable):
+
+## Logs
+
+```
+Paste relevant logs here
+```

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: "[Feature] "
+labels: enhancement
+---
+
+## Problem
+
+What problem does this solve?
+
+## Proposed Solution
+
+Describe the feature or change you'd like.
+
+## Alternatives Considered
+
+Any alternative approaches you've thought about.
+
+## Additional Context
+
+Any other context, screenshots, or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+Brief description of changes.
+
+## Changes
+
+-
+
+## Testing
+
+- [ ] Unit tests added/updated
+- [ ] All unit tests passing (`./scripts/run_unit_tests.sh`)
+
+## Issue
+
+Closes #

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,60 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project team at **conduct@claudevn.com**.
+
+All complaints will be reviewed and investigated promptly and fairly. The
+project team is obligated to maintain confidentiality with regard to the
+reporter of an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 1.x     | Yes                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in ClaudeVN, please report it
+responsibly. **Do not open a public GitHub issue.**
+
+Email **security@claudevn.com** with:
+
+1. A description of the vulnerability
+2. Steps to reproduce
+3. Potential impact
+4. Any suggested fixes (optional)
+
+We will acknowledge receipt within 48 hours and aim to provide a fix or
+mitigation plan within 7 days for critical issues.
+
+## Scope
+
+This policy covers the ClaudeVN codebase and its official Docker images.
+Third-party dependencies should be reported to their respective maintainers.


### PR DESCRIPTION
## Summary

- Add missing community health files to reach full GitHub community health score
- Apply repo settings for discoverability and maintenance

## Files Added

- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1 (referenced by CONTRIBUTING.md)
- `SECURITY.md` — Vulnerability reporting policy
- `.github/PULL_REQUEST_TEMPLATE.md` — Standardized PR descriptions
- `.github/ISSUE_TEMPLATE/bug-report.md` — Bug report template
- `.github/ISSUE_TEMPLATE/feature-request.md` — Feature request template
- `.github/FUNDING.yml` — GitHub Sponsors config

## Repo Settings Applied

- Homepage set to `https://claudevn.com`
- Topics: `ai-agents`, `claude`, `distributed-systems`, `mcp`, `orchestration`, `python`, `fastapi`, `llm`, `developer-tools`, `ai-collaboration`
- Delete branch on merge: enabled
- Discussions: enabled

## Test plan

- [x] No code changes — documentation and config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)