### PR TITLE
docs: add Anthropic affiliation disclaimer (#11)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 TrueOrc - AI Agent Orchestration Platform
 Copyright (C) 2025-2026 Guarrdon
 
+Claude and Claude Code are trademarks of Anthropic PBC. This project is
+independent and not affiliated with or endorsed by Anthropic PBC.
+
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or

--- a/README.md
+++ b/README.md
@@ -241,6 +241,16 @@ See `CONTRIBUTING.md` for guidelines.
 
 ---
 
+## Independent Project
+
+ClaudeVN is an independent open-source project and is not affiliated with, endorsed by, or sponsored by Anthropic PBC. Claude and Claude Code are trademarks of Anthropic PBC.
+
+We built ClaudeVN because we believe Claude Code is the most capable AI coding tool in existence, and we wanted to explore what becomes possible when multiple instances work together as a distributed network. This project exists to extend those capabilities — not to replicate Anthropic's work, but to build on top of it.
+
+If you're from Anthropic and you found this: we think what you're building matters. We'd love to connect.
+
+---
+
 ## License
 
 AGPL-3.0 License — See `LICENSE` file.


### PR DESCRIPTION
## Summary

Adds a clear, warm affiliation disclaimer acknowledging that ClaudeVN is independent of Anthropic, while positioning it as complementary to their work.

## Changes

**README.md** — new `## Independent Project` section just above `## License`:
> ClaudeVN is an independent open-source project and is not affiliated with, endorsed by, or sponsored by Anthropic PBC. Claude and Claude Code are trademarks of Anthropic PBC.
>
> We built ClaudeVN because we believe Claude Code is the most capable AI coding tool in existence...
>
> If you're from Anthropic and you found this: we think what you're building matters. We'd love to connect.

**LICENSE** — two-line trademark notice added to the header above the GPL text, alongside the existing copyright.

## Testing
- No unit tests required (documentation only)

## Issue
Closes #11