### PR TITLE
fix: handle rate_limit_event in claude-agent-sdk to prevent compute crash

### DIFF
--- a/compute/services/claude_sdk_executor.py
+++ b/compute/services/claude_sdk_executor.py
@@ -19,37 +19,35 @@ from claude_agent_sdk import (
     ClaudeAgentOptions,
     AssistantMessage,
     ResultMessage,
+    SystemMessage,
     TextBlock,
     ToolUseBlock,
     query,
 )
+import claude_agent_sdk._internal.message_parser as _message_parser
 
-# Monkey-patch for SDK v0.1.39 rate_limit_event handling
-# SDK v0.1.39 doesn't have a case for "rate_limit_event" in message_parser.parse_message,
-# causing MessageParseError when Claude Code hits API rate limits. This kills the entire
-# compute task instead of letting Claude Code retry internally.
-# 
-# We patch parse_message to treat rate_limit_event as a SystemMessage (which execute_task
-# already ignores), allowing the SDK stream to continue.
-try:
-    from claude_agent_sdk._internal import message_parser
-    
-    _original_parse_message = message_parser.parse_message
-    
-    def _patched_parse_message(data: dict) -> Any:
-        """Patched parse_message that handles rate_limit_event."""
-        if data.get("type") == "rate_limit_event":
-            # Return a SystemMessage for rate_limit_event
-            # The SDK ignores SystemMessage in streams, so this allows the stream to continue
-            logger.info("rate_limit_event received — Claude Code will retry automatically")
-            return message_parser.SystemMessage(subtype="rate_limit_event")
-        return _original_parse_message(data)
-    
-    message_parser.parse_message = _patched_parse_message
-except Exception as e:
-    # If patching fails, log it but don't break initialization
-    logger = logging.getLogger(__name__)
-    logger.warning(f"Failed to patch SDK message_parser: {e}")
+# Patch: SDK 0.1.39 doesn't handle `rate_limit_event` messages emitted by the
+# Claude Code CLI when the API rate-limits a request.  The CLI handles the retry
+# internally and resumes the session — so we only need to stop the SDK from
+# raising `MessageParseError: Unknown message type: rate_limit_event` and killing
+# the whole execution.  We do this by patching `parse_message` to surface
+# rate_limit_event as a SystemMessage (which execute_task already ignores).
+_original_parse_message = _message_parser.parse_message
+
+
+def _patched_parse_message(data: dict) -> Any:
+    if isinstance(data, dict) and data.get("type") == "rate_limit_event":
+        logger_patch = logging.getLogger(__name__)
+        retry_after = data.get("retry_after_ms") or data.get("retry_after")
+        logger_patch.info(
+            f"[sdk] rate_limit_event received (retry_after={retry_after}ms) — "
+            "Claude Code will retry automatically"
+        )
+        return SystemMessage(subtype="rate_limit_event", data=data)
+    return _original_parse_message(data)
+
+
+_message_parser.parse_message = _patched_parse_message
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Patches `claude_agent_sdk._internal.message_parser.parse_message` at import time to handle `rate_limit_event` messages
- SDK v0.1.39 has no `case "rate_limit_event":` in its match statement — falls through to `case _:` and raises `MessageParseError`
- This caused compute workers to fail immediately when Claude Code hit an API rate limit, reporting `claude_code_failed` to serving instead of waiting for retry
- Fix returns a `SystemMessage` for `rate_limit_event`, which `execute_task` already ignores — the SDK stream continues, Claude Code retries the API call internally

## Test plan
- [ ] Submit a goal directive and verify compute workers survive rate limit events without crashing
- [ ] Check compute logs for `rate_limit_event received — Claude Code will retry automatically` instead of `SDK execution failed`
- [ ] Verify decomposition tasks complete successfully end-to-end

Closes #16

Generated with Claude Code