### PR TITLE
fix: update stale references in CLAUDE.md and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,10 +16,10 @@ ENVIRONMENT=development
 LOG_LEVEL=INFO
 
 # ============================================
-# Marketplace Configuration (Port 8001)
+# Marketplace Configuration (Port 8003)
 # ============================================
 MARKETPLACE_HOST=0.0.0.0
-MARKETPLACE_PORT=8001
+MARKETPLACE_PORT=8003
 
 # Authentication (enabled by default; set to false for local dev only)
 MARKETPLACE_REQUIRE_AUTH=false
@@ -77,11 +77,8 @@ AUTO_DEREGISTER=false
 SESSION_TIMEOUT=60
 MAX_SESSIONS=100
 
-# SSH Git Server (for compute Git access)
-GIT_ENABLE_SSH=true
-SSH_GIT_PORT=2222
-SSH_GIT_HOST=localhost
-#SSH_HOST_KEY_PATH=./data/ssh_keys/ssh_host_ed25519_key
+# Git Smart HTTP (for compute Git access, served on SERVING_PORT)
+GIT_ENABLE_HTTP=true
 
 # Serving logging
 SERVING_LOG_FILE=./logs/serving.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Two-tier architecture: Serving (central hub) + Compute (Claude Code instances)
 ```
 serving/              # Central coordination hub (v1.0) - port 8002
   ├── services/       # Core services including ComputeSpawner
-  ├── git/            # Git infrastructure (SSH, hooks, PR management)
+  ├── git/            # Git infrastructure (Smart HTTP, hooks, PR management)
   ├── mcp/            # MCP server for compute communication
   └── frontend/       # React monitoring UI
 marketplace/          # Skill marketplace service (v1.0) - port 8003
@@ -49,7 +49,7 @@ docs/                 # Comprehensive documentation
   ├── design/architecture/v1.0-architecture.md  # New architecture
   ├── design/specifications/                     # Component specs
   ├── design/adr/                                # Architecture decisions
-  └── archive/v0.x/                              # Legacy docs
+  └── archive/                                    # Legacy docs
 ```
 
 ## Authoritative Documentation (v1.0)
@@ -81,7 +81,7 @@ docs/                 # Comprehensive documentation
 
 ```yaml
 github_project:
-  owner: Guarrdon
+  owner: trueorc
   number: 2
   project_id: PVT_kwHOAP6mx84BNtCx
   fields:
@@ -113,7 +113,7 @@ github_project:
 ## Issue Creation Requirements
 
 All issues MUST include:
-1. **Title**: `[PRIORITY] Brief description` (e.g., `[P0] Implement SSH Git Server`)
+1. **Title**: `[PRIORITY] Brief description` (e.g., `[P0] Implement Git Smart HTTP Server`)
 2. **Labels**:
    - Priority: `P0`, `P1`, `P2`, or `P3`
    - Type: `bug`, `enhancement`, or `documentation`
@@ -125,4 +125,4 @@ See `docs/guides/issue-creation-guide.md` for complete instructions.
 
 ## Legacy Documentation
 
-v0.x documentation is preserved in `docs/archive/v0.x/` for reference.
+Legacy documentation is preserved in `docs/archive/` for reference.


### PR DESCRIPTION
## Summary
- SSH → Smart HTTP references in CLAUDE.md (git infra description, issue example)
- Project owner `Guarrdon` → `trueorc` in GitHub project board config
- Archive path `docs/archive/v0.x/` → `docs/archive/` (actual directory)
- Marketplace port `8001` → `8003` in `.env.example` (matches docker-compose)
- Remove stale SSH Git env vars from `.env.example`

## Test plan
- [ ] Verify all paths in CLAUDE.md resolve to existing files/directories
- [ ] Verify `.env.example` ports match `docker-compose.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)