### PR TITLE
feat: SSH Key Management API (#22)

### DIFF
--- a/serving/api/git.py
+++ b/serving/api/git.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 
 from git.pr_service import PRService, PRStatus, PullRequest
 from git.repo_manager import RepoManager
+from git.ssh_key_service import SSHKeyService, get_ssh_key_service
 
 logger = logging.getLogger(__name__)
 
@@ -175,6 +176,37 @@ class DeleteBranchResponse(BaseModel):
     project: str
     branch: str
     deleted: bool
+
+
+class GenerateSSHKeyRequest(BaseModel):
+    """Request to generate a new SSH key pair."""
+    description: str = Field(default="", description="Label for the key")
+
+
+class SSHKeyResponse(BaseModel):
+    """SSH key response with public key."""
+    key_id: str
+    public_key: str
+    fingerprint: str
+    description: str = ""
+
+
+class SSHKeyListItem(BaseModel):
+    """SSH key metadata (no private key material)."""
+    key_id: str
+    description: str = ""
+    fingerprint: str = ""
+    created_at: str = ""
+
+
+class SSHKeyDeleteResponse(BaseModel):
+    """Response from SSH key deletion."""
+    key_id: str
+    deleted: bool
+    referencing_repos: List[str] = Field(
+        default_factory=list,
+        description="Repos that reference this key_id (if any)",
+    )
 
 
 def pr_to_response(pr: PullRequest) -> PRResponse:
@@ -717,3 +749,97 @@ async def cleanup_compute(compute_id: str):
         "compute_id": compute_id,
         "prs_closed": closed
     }
+
+
+# ==========================================================================
+# SSH Key Management Endpoints
+# ==========================================================================
+
+@router.post("/ssh-keys", response_model=SSHKeyResponse, status_code=status.HTTP_201_CREATED)
+async def generate_ssh_key(request: GenerateSSHKeyRequest):
+    """Generate a new SSH key pair for external repo authentication."""
+    service = get_ssh_key_service()
+
+    try:
+        result = service.generate_key(description=request.description)
+        return SSHKeyResponse(
+            key_id=result["key_id"],
+            public_key=result["public_key"],
+            fingerprint=result["fingerprint"],
+            description=result.get("description", ""),
+        )
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="ssh-keygen not found on this system",
+        )
+    except Exception as e:
+        logger.error(f"Failed to generate SSH key: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        )
+
+
+@router.get("/ssh-keys", response_model=List[SSHKeyListItem])
+async def list_ssh_keys():
+    """List all SSH keys (metadata only, no private key material)."""
+    service = get_ssh_key_service()
+    keys = service.list_keys()
+    return [SSHKeyListItem(**k) for k in keys]
+
+
+@router.get("/ssh-keys/{key_id}", response_model=SSHKeyResponse)
+async def get_ssh_key(key_id: str):
+    """Get a specific SSH key's public key (for adding as deploy key)."""
+    service = get_ssh_key_service()
+    result = service.get_key(key_id)
+
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"SSH key not found: {key_id}",
+        )
+
+    return SSHKeyResponse(
+        key_id=result["key_id"],
+        public_key=result["public_key"],
+        fingerprint=result["fingerprint"],
+        description=result.get("description", ""),
+    )
+
+
+@router.delete("/ssh-keys/{key_id}", response_model=SSHKeyDeleteResponse)
+async def delete_ssh_key(key_id: str):
+    """Delete an SSH key pair.
+
+    Returns a warning list of repos that reference this key_id.
+    """
+    service = get_ssh_key_service()
+
+    if not service.key_exists(key_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"SSH key not found: {key_id}",
+        )
+
+    # Check for repos referencing this key (best-effort)
+    referencing: List[str] = []
+    try:
+        from services.project_service import get_project_service
+        project_service = get_project_service()
+        if project_service:
+            projects = await project_service.list_projects()
+            for project in projects:
+                for repo in project.repos:
+                    if repo.ssh_key_id == key_id:
+                        referencing.append(f"{project.name}/{repo.name}")
+    except Exception:
+        pass  # Best-effort warning
+
+    deleted = service.delete_key(key_id)
+    return SSHKeyDeleteResponse(
+        key_id=key_id,
+        deleted=deleted,
+        referencing_repos=referencing,
+    )

--- a/serving/git/ssh_key_service.py
+++ b/serving/git/ssh_key_service.py
@@ -1,0 +1,233 @@
+"""SSH key management service for ClaudeVN.
+
+Generates, stores, and retrieves SSH key pairs for authenticating with
+external Git hosts (GitHub, GitLab, etc.). Users add the public key as a
+deploy key on the remote repo; Serving uses the private key for
+clone/fetch/push operations via GIT_SSH_COMMAND.
+"""
+
+import json
+import logging
+import os
+import subprocess
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from config import get_config
+
+logger = logging.getLogger(__name__)
+
+SSH_KEY_ID_PREFIX = "sshk_"
+
+
+class SSHKeyService:
+    """Service for managing SSH key pairs."""
+
+    def __init__(self, ssh_keys_path: Optional[str] = None):
+        """Initialize the SSH key service.
+
+        Args:
+            ssh_keys_path: Path to SSH keys directory.
+                          Defaults to config value.
+        """
+        if ssh_keys_path:
+            self._keys_path = Path(ssh_keys_path)
+        else:
+            config = get_config()
+            self._keys_path = Path(config.git.ssh_keys_path)
+
+    def _ensure_keys_dir(self) -> None:
+        """Ensure the SSH keys directory exists."""
+        self._keys_path.mkdir(parents=True, exist_ok=True)
+
+    def _generate_key_id(self) -> str:
+        """Generate a unique SSH key ID."""
+        return f"{SSH_KEY_ID_PREFIX}{uuid.uuid4().hex[:12]}"
+
+    def _private_key_path(self, key_id: str) -> Path:
+        """Get private key file path."""
+        return self._keys_path / f"{key_id}_key"
+
+    def _public_key_path(self, key_id: str) -> Path:
+        """Get public key file path."""
+        return self._keys_path / f"{key_id}_key.pub"
+
+    def _metadata_path(self, key_id: str) -> Path:
+        """Get metadata sidecar file path."""
+        return self._keys_path / f"{key_id}_key.json"
+
+    def generate_key(self, description: str = "") -> Dict[str, Any]:
+        """Generate a new ed25519 SSH key pair.
+
+        Args:
+            description: Optional label for the key.
+
+        Returns:
+            Dict with key_id, public_key, and fingerprint.
+        """
+        self._ensure_keys_dir()
+
+        key_id = self._generate_key_id()
+        private_path = self._private_key_path(key_id)
+        public_path = self._public_key_path(key_id)
+
+        # Generate ed25519 key pair with ssh-keygen
+        subprocess.run(
+            [
+                "ssh-keygen",
+                "-t", "ed25519",
+                "-f", str(private_path),
+                "-N", "",  # No passphrase
+                "-C", f"claudevn-{key_id}",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        # Set correct file permissions
+        os.chmod(private_path, 0o600)
+        os.chmod(public_path, 0o644)
+
+        # Read public key and fingerprint
+        public_key = public_path.read_text().strip()
+        fingerprint = self._get_fingerprint(public_path)
+
+        # Write metadata sidecar
+        metadata = {
+            "key_id": key_id,
+            "description": description,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._metadata_path(key_id).write_text(json.dumps(metadata))
+
+        logger.info(f"Generated SSH key: {key_id} ({description})")
+
+        return {
+            "key_id": key_id,
+            "public_key": public_key,
+            "fingerprint": fingerprint,
+            "description": description,
+        }
+
+    def _get_fingerprint(self, public_key_path: Path) -> str:
+        """Get the fingerprint of a public key."""
+        result = subprocess.run(
+            ["ssh-keygen", "-lf", str(public_key_path)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+        return ""
+
+    def list_keys(self) -> List[Dict[str, Any]]:
+        """List all SSH keys (metadata only, no private key material).
+
+        Returns:
+            List of key metadata dicts.
+        """
+        results = []
+
+        if not self._keys_path.exists():
+            return results
+
+        for meta_file in sorted(self._keys_path.glob("sshk_*_key.json")):
+            try:
+                metadata = json.loads(meta_file.read_text())
+                key_id = metadata["key_id"]
+                public_path = self._public_key_path(key_id)
+
+                entry = {
+                    "key_id": key_id,
+                    "description": metadata.get("description", ""),
+                    "created_at": metadata.get("created_at", ""),
+                }
+
+                if public_path.exists():
+                    entry["fingerprint"] = self._get_fingerprint(public_path)
+
+                results.append(entry)
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.warning(f"Skipping malformed metadata: {meta_file}: {e}")
+
+        return results
+
+    def get_key(self, key_id: str) -> Optional[Dict[str, Any]]:
+        """Get a specific key's public key and metadata.
+
+        Args:
+            key_id: The SSH key identifier.
+
+        Returns:
+            Dict with key_id, public_key, fingerprint, description or None.
+        """
+        public_path = self._public_key_path(key_id)
+        meta_path = self._metadata_path(key_id)
+
+        if not public_path.exists():
+            return None
+
+        public_key = public_path.read_text().strip()
+        fingerprint = self._get_fingerprint(public_path)
+
+        metadata: Dict[str, Any] = {}
+        if meta_path.exists():
+            try:
+                metadata = json.loads(meta_path.read_text())
+            except json.JSONDecodeError:
+                pass
+
+        return {
+            "key_id": key_id,
+            "public_key": public_key,
+            "fingerprint": fingerprint,
+            "description": metadata.get("description", ""),
+            "created_at": metadata.get("created_at", ""),
+        }
+
+    def delete_key(self, key_id: str) -> bool:
+        """Delete an SSH key pair.
+
+        Args:
+            key_id: The SSH key identifier.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        private_path = self._private_key_path(key_id)
+        public_path = self._public_key_path(key_id)
+        meta_path = self._metadata_path(key_id)
+
+        if not private_path.exists() and not public_path.exists():
+            return False
+
+        for path in (private_path, public_path, meta_path):
+            if path.exists():
+                path.unlink()
+
+        logger.info(f"Deleted SSH key: {key_id}")
+        return True
+
+    def key_exists(self, key_id: str) -> bool:
+        """Check if an SSH key exists."""
+        return self._private_key_path(key_id).exists()
+
+
+# Global instance
+_ssh_key_service: Optional[SSHKeyService] = None
+
+
+def get_ssh_key_service() -> SSHKeyService:
+    """Get the global SSH key service (creates if needed)."""
+    global _ssh_key_service
+    if _ssh_key_service is None:
+        _ssh_key_service = SSHKeyService()
+    return _ssh_key_service
+
+
+def set_ssh_key_service(service: Optional[SSHKeyService]) -> None:
+    """Set the global SSH key service."""
+    global _ssh_key_service
+    _ssh_key_service = service

--- a/serving/tests/unit/test_ssh_key_api.py
+++ b/serving/tests/unit/test_ssh_key_api.py
@@ -1,0 +1,180 @@
+"""Tests for SSH key management API endpoints.
+
+Unit tests for:
+- POST /git/ssh-keys — Generate SSH key pair
+- GET /git/ssh-keys — List SSH keys
+- GET /git/ssh-keys/{key_id} — Get specific key
+- DELETE /git/ssh-keys/{key_id} — Delete key pair
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app import app
+import api.git as git_module
+
+API_BASE = "/api/v1/git"
+
+
+@pytest.fixture
+def client():
+    """Create a test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_ssh_service():
+    """Mock SSHKeyService by replacing the module-level getter."""
+    mock_service = MagicMock()
+    with patch.object(git_module, "get_ssh_key_service", return_value=mock_service):
+        yield mock_service
+
+
+class TestGenerateSSHKey:
+    """Test POST /git/ssh-keys endpoint."""
+
+    def test_generate_key_success(self, client, mock_ssh_service):
+        """Test successful key generation."""
+        mock_ssh_service.generate_key.return_value = {
+            "key_id": "sshk_abc123def456",
+            "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... claudevn-sshk_abc123def456",
+            "fingerprint": "256 SHA256:abc123 claudevn-sshk_abc123def456 (ED25519)",
+            "description": "My deploy key",
+        }
+
+        response = client.post(
+            f"{API_BASE}/ssh-keys",
+            json={"description": "My deploy key"},
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["key_id"] == "sshk_abc123def456"
+        assert data["public_key"].startswith("ssh-ed25519 ")
+        assert data["description"] == "My deploy key"
+        assert "fingerprint" in data
+
+    def test_generate_key_no_description(self, client, mock_ssh_service):
+        """Test key generation with empty description."""
+        mock_ssh_service.generate_key.return_value = {
+            "key_id": "sshk_000000000000",
+            "public_key": "ssh-ed25519 AAAA...",
+            "fingerprint": "256 SHA256:xyz",
+            "description": "",
+        }
+
+        response = client.post(f"{API_BASE}/ssh-keys", json={})
+
+        assert response.status_code == 201
+        mock_ssh_service.generate_key.assert_called_once_with(description="")
+
+    def test_generate_key_ssh_keygen_missing(self, client, mock_ssh_service):
+        """Test error when ssh-keygen is not found."""
+        mock_ssh_service.generate_key.side_effect = FileNotFoundError("ssh-keygen")
+
+        response = client.post(f"{API_BASE}/ssh-keys", json={})
+
+        assert response.status_code == 500
+        assert "ssh-keygen" in response.json()["detail"]
+
+    def test_generate_key_internal_error(self, client, mock_ssh_service):
+        """Test error during key generation."""
+        mock_ssh_service.generate_key.side_effect = RuntimeError("disk full")
+
+        response = client.post(f"{API_BASE}/ssh-keys", json={})
+
+        assert response.status_code == 500
+
+
+class TestListSSHKeys:
+    """Test GET /git/ssh-keys endpoint."""
+
+    def test_list_keys_success(self, client, mock_ssh_service):
+        """Test listing keys returns metadata."""
+        mock_ssh_service.list_keys.return_value = [
+            {
+                "key_id": "sshk_aaa111",
+                "description": "GitHub key",
+                "fingerprint": "256 SHA256:aaa",
+                "created_at": "2024-01-01T00:00:00+00:00",
+            },
+            {
+                "key_id": "sshk_bbb222",
+                "description": "GitLab key",
+                "fingerprint": "256 SHA256:bbb",
+                "created_at": "2024-01-02T00:00:00+00:00",
+            },
+        ]
+
+        response = client.get(f"{API_BASE}/ssh-keys")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        assert data[0]["key_id"] == "sshk_aaa111"
+        assert data[1]["description"] == "GitLab key"
+
+    def test_list_keys_empty(self, client, mock_ssh_service):
+        """Test listing when no keys exist."""
+        mock_ssh_service.list_keys.return_value = []
+
+        response = client.get(f"{API_BASE}/ssh-keys")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+class TestGetSSHKey:
+    """Test GET /git/ssh-keys/{key_id} endpoint."""
+
+    def test_get_key_success(self, client, mock_ssh_service):
+        """Test retrieving a specific key's public key."""
+        mock_ssh_service.get_key.return_value = {
+            "key_id": "sshk_abc123def456",
+            "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...",
+            "fingerprint": "256 SHA256:abc123",
+            "description": "My key",
+            "created_at": "2024-01-01T00:00:00+00:00",
+        }
+
+        response = client.get(f"{API_BASE}/ssh-keys/sshk_abc123def456")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["key_id"] == "sshk_abc123def456"
+        assert data["public_key"].startswith("ssh-ed25519 ")
+
+    def test_get_key_not_found(self, client, mock_ssh_service):
+        """Test 404 for nonexistent key."""
+        mock_ssh_service.get_key.return_value = None
+
+        response = client.get(f"{API_BASE}/ssh-keys/sshk_nonexistent")
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+
+class TestDeleteSSHKey:
+    """Test DELETE /git/ssh-keys/{key_id} endpoint."""
+
+    def test_delete_key_success(self, client, mock_ssh_service):
+        """Test successful key deletion."""
+        mock_ssh_service.key_exists.return_value = True
+        mock_ssh_service.delete_key.return_value = True
+
+        response = client.delete(f"{API_BASE}/ssh-keys/sshk_abc123")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["key_id"] == "sshk_abc123"
+        assert data["deleted"] is True
+
+    def test_delete_key_not_found(self, client, mock_ssh_service):
+        """Test 404 for deleting nonexistent key."""
+        mock_ssh_service.key_exists.return_value = False
+
+        response = client.delete(f"{API_BASE}/ssh-keys/sshk_nonexistent")
+
+        assert response.status_code == 404

--- a/serving/tests/unit/test_ssh_key_service.py
+++ b/serving/tests/unit/test_ssh_key_service.py
@@ -1,0 +1,253 @@
+"""Unit tests for SSH key management service."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from git.ssh_key_service import SSHKeyService, SSH_KEY_ID_PREFIX
+
+
+class TestSSHKeyServiceInit:
+    """Test SSHKeyService initialization."""
+
+    def test_init_with_explicit_path(self, tmp_path):
+        """Test service with explicit keys path."""
+        service = SSHKeyService(ssh_keys_path=str(tmp_path))
+        assert service._keys_path == tmp_path
+
+    def test_init_with_config_default(self):
+        """Test service falls back to config."""
+        with patch("git.ssh_key_service.get_config") as mock_config:
+            mock_config.return_value.git.ssh_keys_path = "/tmp/test_keys"
+            service = SSHKeyService()
+            assert service._keys_path == Path("/tmp/test_keys")
+
+
+class TestSSHKeyGeneration:
+    """Test SSH key generation."""
+
+    @pytest.fixture
+    def service(self, tmp_path):
+        """Create service with temp directory."""
+        return SSHKeyService(ssh_keys_path=str(tmp_path))
+
+    @pytest.fixture
+    def keys_dir(self, tmp_path):
+        return tmp_path
+
+    def test_generate_key_creates_files(self, service, keys_dir):
+        """Test that key generation creates private, public, and metadata files."""
+        result = service.generate_key(description="test key")
+
+        key_id = result["key_id"]
+        assert key_id.startswith(SSH_KEY_ID_PREFIX)
+
+        private_path = keys_dir / f"{key_id}_key"
+        public_path = keys_dir / f"{key_id}_key.pub"
+        meta_path = keys_dir / f"{key_id}_key.json"
+
+        assert private_path.exists()
+        assert public_path.exists()
+        assert meta_path.exists()
+
+    def test_generate_key_returns_public_key(self, service):
+        """Test that result includes public key text."""
+        result = service.generate_key()
+
+        assert "public_key" in result
+        assert result["public_key"].startswith("ssh-ed25519 ")
+
+    def test_generate_key_returns_fingerprint(self, service):
+        """Test that result includes a fingerprint."""
+        result = service.generate_key()
+
+        assert "fingerprint" in result
+        assert len(result["fingerprint"]) > 0
+
+    def test_generate_key_preserves_description(self, service):
+        """Test that description is stored and returned."""
+        result = service.generate_key(description="My GitHub deploy key")
+
+        assert result["description"] == "My GitHub deploy key"
+
+    def test_generate_key_private_permissions(self, service, keys_dir):
+        """Test that private key has 0600 permissions."""
+        result = service.generate_key()
+        key_id = result["key_id"]
+
+        private_path = keys_dir / f"{key_id}_key"
+        mode = oct(private_path.stat().st_mode & 0o777)
+        assert mode == "0o600"
+
+    def test_generate_key_public_permissions(self, service, keys_dir):
+        """Test that public key has 0644 permissions."""
+        result = service.generate_key()
+        key_id = result["key_id"]
+
+        public_path = keys_dir / f"{key_id}_key.pub"
+        mode = oct(public_path.stat().st_mode & 0o777)
+        assert mode == "0o644"
+
+    def test_generate_key_metadata_sidecar(self, service, keys_dir):
+        """Test that metadata JSON sidecar is written correctly."""
+        result = service.generate_key(description="test")
+        key_id = result["key_id"]
+
+        meta_path = keys_dir / f"{key_id}_key.json"
+        metadata = json.loads(meta_path.read_text())
+
+        assert metadata["key_id"] == key_id
+        assert metadata["description"] == "test"
+        assert "created_at" in metadata
+
+    def test_generate_key_unique_ids(self, service):
+        """Test that each key gets a unique ID."""
+        result1 = service.generate_key()
+        result2 = service.generate_key()
+
+        assert result1["key_id"] != result2["key_id"]
+
+    def test_generate_key_creates_directory(self, tmp_path):
+        """Test that keys directory is created if it doesn't exist."""
+        nested = tmp_path / "nested" / "keys"
+        service = SSHKeyService(ssh_keys_path=str(nested))
+
+        result = service.generate_key()
+        assert nested.exists()
+        assert (nested / f"{result['key_id']}_key").exists()
+
+
+class TestSSHKeyListing:
+    """Test SSH key listing."""
+
+    @pytest.fixture
+    def service(self, tmp_path):
+        return SSHKeyService(ssh_keys_path=str(tmp_path))
+
+    def test_list_keys_empty(self, service):
+        """Test listing when no keys exist."""
+        assert service.list_keys() == []
+
+    def test_list_keys_returns_metadata(self, service):
+        """Test listing returns key metadata."""
+        service.generate_key(description="key one")
+        service.generate_key(description="key two")
+
+        keys = service.list_keys()
+        assert len(keys) == 2
+
+        descriptions = {k["description"] for k in keys}
+        assert "key one" in descriptions
+        assert "key two" in descriptions
+
+    def test_list_keys_no_private_material(self, service):
+        """Test that list does not include private key content."""
+        service.generate_key()
+        keys = service.list_keys()
+
+        for key in keys:
+            assert "private_key" not in key
+            assert "public_key" not in key
+
+    def test_list_keys_nonexistent_directory(self, tmp_path):
+        """Test listing when directory doesn't exist yet."""
+        service = SSHKeyService(ssh_keys_path=str(tmp_path / "nonexistent"))
+        assert service.list_keys() == []
+
+
+class TestSSHKeyRetrieval:
+    """Test SSH key retrieval."""
+
+    @pytest.fixture
+    def service(self, tmp_path):
+        return SSHKeyService(ssh_keys_path=str(tmp_path))
+
+    def test_get_key_returns_public_key(self, service):
+        """Test getting a key returns public key text."""
+        generated = service.generate_key(description="test")
+        key_id = generated["key_id"]
+
+        result = service.get_key(key_id)
+        assert result is not None
+        assert result["public_key"].startswith("ssh-ed25519 ")
+        assert result["key_id"] == key_id
+        assert result["description"] == "test"
+
+    def test_get_key_not_found(self, service):
+        """Test getting a nonexistent key returns None."""
+        assert service.get_key("sshk_nonexistent") is None
+
+    def test_get_key_fingerprint_matches(self, service):
+        """Test that fingerprint matches between generate and get."""
+        generated = service.generate_key()
+        retrieved = service.get_key(generated["key_id"])
+
+        assert retrieved["fingerprint"] == generated["fingerprint"]
+
+
+class TestSSHKeyDeletion:
+    """Test SSH key deletion."""
+
+    @pytest.fixture
+    def service(self, tmp_path):
+        return SSHKeyService(ssh_keys_path=str(tmp_path))
+
+    @pytest.fixture
+    def keys_dir(self, tmp_path):
+        return tmp_path
+
+    def test_delete_key_removes_files(self, service, keys_dir):
+        """Test that deletion removes all key files."""
+        result = service.generate_key()
+        key_id = result["key_id"]
+
+        assert service.delete_key(key_id) is True
+
+        assert not (keys_dir / f"{key_id}_key").exists()
+        assert not (keys_dir / f"{key_id}_key.pub").exists()
+        assert not (keys_dir / f"{key_id}_key.json").exists()
+
+    def test_delete_key_not_found(self, service):
+        """Test deleting a nonexistent key returns False."""
+        assert service.delete_key("sshk_nonexistent") is False
+
+    def test_delete_key_then_get_returns_none(self, service):
+        """Test that a deleted key cannot be retrieved."""
+        result = service.generate_key()
+        service.delete_key(result["key_id"])
+
+        assert service.get_key(result["key_id"]) is None
+
+    def test_delete_key_then_list_excludes(self, service):
+        """Test that a deleted key is excluded from listing."""
+        r1 = service.generate_key(description="keep")
+        r2 = service.generate_key(description="delete me")
+
+        service.delete_key(r2["key_id"])
+
+        keys = service.list_keys()
+        assert len(keys) == 1
+        assert keys[0]["key_id"] == r1["key_id"]
+
+
+class TestSSHKeyExists:
+    """Test key existence check."""
+
+    @pytest.fixture
+    def service(self, tmp_path):
+        return SSHKeyService(ssh_keys_path=str(tmp_path))
+
+    def test_key_exists_true(self, service):
+        result = service.generate_key()
+        assert service.key_exists(result["key_id"]) is True
+
+    def test_key_exists_false(self, service):
+        assert service.key_exists("sshk_nonexistent") is False
+
+    def test_key_exists_after_delete(self, service):
+        result = service.generate_key()
+        service.delete_key(result["key_id"])
+        assert service.key_exists(result["key_id"]) is False


### PR DESCRIPTION
## Summary
- Add `SSHKeyService` for generating, storing, and retrieving ed25519 SSH key pairs
- Add REST API endpoints: `POST/GET /git/ssh-keys`, `GET/DELETE /git/ssh-keys/{key_id}`
- Keys stored with JSON metadata sidecars; private key permissions set to 0600
- Delete endpoint warns about repos referencing the key

## Changes
- `serving/git/ssh_key_service.py` — New service with key generation (ssh-keygen), listing, retrieval, deletion
- `serving/api/git.py` — Four new SSH key endpoints with request/response models
- `serving/tests/unit/test_ssh_key_service.py` — 25 unit tests for service layer
- `serving/tests/unit/test_ssh_key_api.py` — 10 unit tests for API endpoints

## Testing
- [x] Tier 1 unit tests added (35 tests, all passing)
- [x] All Tier 1 unit tests passing

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issue
Closes #22