### PR TITLE
fix: Replace --mirror with safe bare clone for linked repos (#23)

### DIFF
--- a/serving/git/repo_manager.py
+++ b/serving/git/repo_manager.py
@@ -531,16 +531,20 @@ exit 0
         project: str,
         url: str,
         ssh_key_path: Optional[str] = None,
+        ssh_key_id: Optional[str] = None,
         default_branch: str = "main"
     ) -> Path:
         """Clone a repository from a URL into Serving's Git infrastructure.
 
-        Creates a bare mirror clone that can receive pushes and push back to origin.
+        Creates a bare clone with a restricted fetch refspec so that
+        ``git fetch`` only updates the default branch and tags — compute
+        feature branches are never overwritten.
 
         Args:
             project: Project name for the local repo
             url: Git URL to clone from (SSH or HTTPS)
             ssh_key_path: Path to SSH key for authentication (optional)
+            ssh_key_id: SSH key identifier to store in repo config (optional)
             default_branch: Default branch name
 
         Returns:
@@ -563,12 +567,28 @@ exit 0
         if ssh_key_path:
             env["GIT_SSH_COMMAND"] = f'ssh -i {ssh_key_path} -o StrictHostKeyChecking=no'
 
-        # Clone as a bare mirror
+        # Clone as bare (NOT --mirror, which sets a dangerous catch-all refspec)
         subprocess.run(
-            ["git", "clone", "--bare", "--mirror", url, str(repo_path)],
+            ["git", "clone", "--bare", url, str(repo_path)],
             check=True,
             capture_output=True,
             env=env
+        )
+
+        # Restrict fetch refspec to default branch + tags only.
+        # A --mirror clone sets +refs/*:refs/* which overwrites ALL refs
+        # on fetch, destroying compute feature branches.
+        subprocess.run(
+            ["git", "-C", str(repo_path), "config", "remote.origin.fetch",
+             f"+refs/heads/{default_branch}:refs/heads/{default_branch}"],
+            check=True,
+            capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo_path), "config", "--add", "remote.origin.fetch",
+             "+refs/tags/*:refs/tags/*"],
+            check=True,
+            capture_output=True
         )
 
         # Configure origin for push
@@ -592,6 +612,21 @@ exit 0
             check=True,
             capture_output=True
         )
+
+        # Store linked repo metadata in git config so downstream services
+        # (e.g. PR service) can determine post-merge behavior without
+        # querying the project model.
+        subprocess.run(
+            ["git", "-C", str(repo_path), "config", "claudevn.isLinked", "true"],
+            check=True,
+            capture_output=True
+        )
+        if ssh_key_id:
+            subprocess.run(
+                ["git", "-C", str(repo_path), "config", "claudevn.sshKeyId", ssh_key_id],
+                check=True,
+                capture_output=True
+            )
 
         # Install hooks
         self.install_hooks(project)
@@ -764,15 +799,25 @@ exit 0
         if head_result.returncode == 0:
             default_branch = head_result.stdout.strip().replace("refs/heads/", "")
 
-        # Check if it's a mirror clone
+        # Check if it's a mirror clone (legacy)
         is_mirror = False
-        config_result = subprocess.run(
+        mirror_result = subprocess.run(
             ["git", "-C", str(repo_path), "config", "--get", "remote.origin.mirror"],
             capture_output=True,
             text=True
         )
-        if config_result.returncode == 0 and config_result.stdout.strip() == "true":
+        if mirror_result.returncode == 0 and mirror_result.stdout.strip() == "true":
             is_mirror = True
+
+        # Check if it's a linked repository (v1.0 safe bare clone)
+        is_linked = False
+        linked_result = subprocess.run(
+            ["git", "-C", str(repo_path), "config", "--get", "claudevn.isLinked"],
+            capture_output=True,
+            text=True
+        )
+        if linked_result.returncode == 0 and linked_result.stdout.strip() == "true":
+            is_linked = True
 
         return {
             "project": project,
@@ -782,6 +827,7 @@ exit 0
             "branches": branches,
             "branch_count": len(branches),
             "is_mirror": is_mirror,
+            "is_linked": is_linked,
             "exists": True
         }
 

--- a/serving/models/project.py
+++ b/serving/models/project.py
@@ -181,6 +181,7 @@ class RepoStatusResponse(BaseModel):
     branches: List[str] = Field(default_factory=list)
     branch_count: int = 0
     is_mirror: bool = False
+    is_linked: bool = False
     last_sync: Optional[datetime] = None
     error_message: Optional[str] = None
 

--- a/serving/services/repo_sync_service.py
+++ b/serving/services/repo_sync_service.py
@@ -127,6 +127,7 @@ class RepoSyncService:
                 project=local_name,
                 url=repo_config.url,
                 ssh_key_path=ssh_key_path,
+                ssh_key_id=repo_config.ssh_key_id,
                 default_branch=repo_config.default_branch
             )
 
@@ -420,6 +421,7 @@ class RepoSyncService:
             branches=status.get("branches", []),
             branch_count=status.get("branch_count", 0),
             is_mirror=status.get("is_mirror", False),
+            is_linked=status.get("is_linked", False),
             last_sync=last_sync
         )
 

--- a/serving/tests/unit/test_repo_manager_clone.py
+++ b/serving/tests/unit/test_repo_manager_clone.py
@@ -1,0 +1,237 @@
+"""Tests for RepoManager.clone_from_url safe bare clone behavior."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+from git.repo_manager import RepoManager
+
+
+@pytest.fixture
+def repo_manager(tmp_path):
+    """Create a RepoManager with a temp repos directory."""
+    config = MagicMock()
+    config.repos_path = str(tmp_path / "repos")
+    return RepoManager(config=config)
+
+
+class TestCloneFromUrl:
+    """Test clone_from_url uses safe bare clone (not mirror)."""
+
+    @patch.object(RepoManager, "install_hooks")
+    @patch("git.repo_manager.subprocess.run")
+    def test_clone_uses_bare_not_mirror(self, mock_run, mock_hooks, repo_manager):
+        """Verify clone uses --bare without --mirror."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        repo_manager.clone_from_url(
+            project="test-project",
+            url="git@github.com:test/repo.git",
+        )
+
+        # First subprocess call is the clone
+        clone_call = mock_run.call_args_list[0]
+        clone_cmd = clone_call[0][0]
+
+        assert "--bare" in clone_cmd
+        assert "--mirror" not in clone_cmd
+
+    @patch.object(RepoManager, "install_hooks")
+    @patch("git.repo_manager.subprocess.run")
+    def test_clone_sets_restricted_fetch_refspec(self, mock_run, mock_hooks, repo_manager):
+        """Verify fetch refspec is restricted to default branch + tags."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        repo_manager.clone_from_url(
+            project="test-project",
+            url="git@github.com:test/repo.git",
+            default_branch="main",
+        )
+
+        # Collect all git config calls
+        config_calls = [
+            c for c in mock_run.call_args_list
+            if "config" in c[0][0]
+        ]
+
+        # Find the fetch refspec calls
+        fetch_refspec_cmds = [
+            c[0][0] for c in config_calls
+            if "remote.origin.fetch" in c[0][0]
+        ]
+
+        assert len(fetch_refspec_cmds) == 2, (
+            f"Expected 2 fetch refspec config calls, got {len(fetch_refspec_cmds)}"
+        )
+
+        # First: default branch only
+        assert "+refs/heads/main:refs/heads/main" in fetch_refspec_cmds[0]
+
+        # Second: tags (with --add)
+        assert "--add" in fetch_refspec_cmds[1]
+        assert "+refs/tags/*:refs/tags/*" in fetch_refspec_cmds[1]
+
+    @patch.object(RepoManager, "install_hooks")
+    @patch("git.repo_manager.subprocess.run")
+    def test_clone_respects_custom_default_branch(self, mock_run, mock_hooks, repo_manager):
+        """Verify refspec uses the provided default_branch, not hardcoded main."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        repo_manager.clone_from_url(
+            project="test-project",
+            url="git@github.com:test/repo.git",
+            default_branch="develop",
+        )
+
+        config_calls = [
+            c[0][0] for c in mock_run.call_args_list
+            if "remote.origin.fetch" in c[0][0]
+        ]
+
+        assert "+refs/heads/develop:refs/heads/develop" in config_calls[0]
+
+    @patch.object(RepoManager, "install_hooks")
+    @patch("git.repo_manager.subprocess.run")
+    def test_clone_stores_linked_metadata(self, mock_run, mock_hooks, repo_manager):
+        """Verify claudevn.isLinked is set in git config."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        repo_manager.clone_from_url(
+            project="test-project",
+            url="git@github.com:test/repo.git",
+        )
+
+        config_calls = [
+            c[0][0] for c in mock_run.call_args_list
+            if "config" in c[0][0]
+        ]
+
+        is_linked_cmds = [
+            c for c in config_calls
+            if "claudevn.isLinked" in c
+        ]
+
+        assert len(is_linked_cmds) == 1
+        assert "true" in is_linked_cmds[0]
+
+    @patch.object(RepoManager, "install_hooks")
+    @patch("git.repo_manager.subprocess.run")
+    def test_clone_stores_ssh_key_id(self, mock_run, mock_hooks, repo_manager):
+        """Verify claudevn.sshKeyId is stored when provided."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        repo_manager.clone_from_url(
+            project="test-project",
+            url="git@github.com:test/repo.git",
+            ssh_key_id="key-42",
+        )
+
+        config_calls = [
+            c[0][0] for c in mock_run.call_args_list
+            if "config" in c[0][0]
+        ]
+
+        ssh_key_cmds = [
+            c for c in config_calls
+            if "claudevn.sshKeyId" in c
+        ]
+
+        assert len(ssh_key_cmds) == 1
+        assert "key-42" in ssh_key_cmds[0]
+
+    @patch.object(RepoManager, "install_hooks")
+    @patch("git.repo_manager.subprocess.run")
+    def test_clone_omits_ssh_key_id_when_not_provided(self, mock_run, mock_hooks, repo_manager):
+        """Verify claudevn.sshKeyId is NOT set when ssh_key_id is None."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        repo_manager.clone_from_url(
+            project="test-project",
+            url="git@github.com:test/repo.git",
+        )
+
+        config_calls = [
+            c[0][0] for c in mock_run.call_args_list
+            if "config" in c[0][0]
+        ]
+
+        ssh_key_cmds = [
+            c for c in config_calls
+            if "claudevn.sshKeyId" in c
+        ]
+
+        assert len(ssh_key_cmds) == 0
+
+    @patch("git.repo_manager.subprocess.run")
+    def test_clone_raises_if_repo_exists(self, mock_run, repo_manager):
+        """Verify FileExistsError when repo directory already exists."""
+        # Create the repo directory to simulate existing repo
+        repo_path = repo_manager._repo_path("test-project")
+        repo_path.mkdir(parents=True)
+
+        with pytest.raises(FileExistsError, match="already exists"):
+            repo_manager.clone_from_url(
+                project="test-project",
+                url="git@github.com:test/repo.git",
+            )
+
+
+class TestGetRepoStatusLinked:
+    """Test get_repo_status reports is_linked from git config."""
+
+    @patch("git.repo_manager.subprocess.run")
+    def test_status_reports_is_linked_true(self, mock_run, repo_manager):
+        """Verify is_linked is True when claudevn.isLinked is set."""
+        repo_path = repo_manager._repo_path("test-project")
+        repo_path.mkdir(parents=True)
+        (repo_path / "HEAD").write_text("ref: refs/heads/main\n")
+
+        def side_effect(cmd, **kwargs):
+            result = MagicMock(returncode=0, stdout="", stderr="")
+            cmd_str = " ".join(cmd)
+            if "remote" in cmd and "get-url" in cmd:
+                result.stdout = "git@github.com:test/repo.git\n"
+            elif "branch" in cmd and "--list" in cmd:
+                result.stdout = "main\n"
+            elif "symbolic-ref" in cmd:
+                result.stdout = "refs/heads/main\n"
+            elif "remote.origin.mirror" in cmd:
+                result.returncode = 1  # not a mirror
+            elif "claudevn.isLinked" in cmd:
+                result.stdout = "true\n"
+            return result
+
+        mock_run.side_effect = side_effect
+
+        status = repo_manager.get_repo_status("test-project")
+
+        assert status is not None
+        assert status["is_linked"] is True
+        assert status["is_mirror"] is False
+
+    @patch("git.repo_manager.subprocess.run")
+    def test_status_reports_is_linked_false_for_internal_repos(self, mock_run, repo_manager):
+        """Verify is_linked is False for repos without claudevn.isLinked."""
+        repo_path = repo_manager._repo_path("internal-project")
+        repo_path.mkdir(parents=True)
+        (repo_path / "HEAD").write_text("ref: refs/heads/main\n")
+
+        def side_effect(cmd, **kwargs):
+            result = MagicMock(returncode=0, stdout="", stderr="")
+            if "remote" in cmd and "get-url" in cmd:
+                result.stdout = "\n"
+            elif "branch" in cmd and "--list" in cmd:
+                result.stdout = "main\n"
+            elif "symbolic-ref" in cmd:
+                result.stdout = "refs/heads/main\n"
+            elif "config" in cmd and "--get" in cmd:
+                result.returncode = 1  # no config value
+            return result
+
+        mock_run.side_effect = side_effect
+
+        status = repo_manager.get_repo_status("internal-project")
+
+        assert status is not None
+        assert status["is_linked"] is False
+        assert status["is_mirror"] is False

--- a/serving/tests/unit/test_repo_sync.py
+++ b/serving/tests/unit/test_repo_sync.py
@@ -25,7 +25,8 @@ def mock_repo_manager():
         "default_branch": "main",
         "branches": ["main", "develop"],
         "branch_count": 2,
-        "is_mirror": True
+        "is_mirror": False,
+        "is_linked": True
     }
     return manager
 
@@ -196,7 +197,8 @@ class TestRepoSyncService:
             assert result is not None
             assert result.clone_status == RepoCloneStatus.CLONED
             assert result.branch_count == 2
-            assert result.is_mirror is True
+            assert result.is_mirror is False
+            assert result.is_linked is True
 
 
 class TestLocalNameGeneration:


### PR DESCRIPTION
## Summary
- Replace `git clone --bare --mirror` with `git clone --bare` in `clone_from_url()` to prevent compute feature branches from being destroyed on fetch
- Configure restricted fetch refspec (default branch + tags only) instead of the dangerous catch-all `+refs/*:refs/*`
- Store `claudevn.isLinked` and `claudevn.sshKeyId` in bare repo git config for downstream services (e.g. PR service)
- Add `is_linked` field to `RepoStatusResponse` model and `get_repo_status()` output

## Changes
- `serving/git/repo_manager.py` — `clone_from_url()`: safe bare clone + metadata; `get_repo_status()`: report `is_linked`
- `serving/models/project.py` — Added `is_linked` field to `RepoStatusResponse`
- `serving/services/repo_sync_service.py` — Pass `ssh_key_id` through to `clone_from_url()`; include `is_linked` in status response
- `serving/tests/unit/test_repo_manager_clone.py` — 9 new unit tests covering clone behavior and status reporting
- `serving/tests/unit/test_repo_sync.py` — Updated fixture and assertions for `is_linked`

## Testing
- [x] 9 new unit tests added (`test_repo_manager_clone.py`)
- [x] All 19 tests passing (9 new + 10 existing `test_repo_sync.py`)

## Issue
Closes #23