### PR TITLE
feat: Detect externally-imported Redis credentials without restart (#32)

### DIFF
--- a/serving/api/auth.py
+++ b/serving/api/auth.py
@@ -5,7 +5,8 @@ Provides REST endpoints for token lifecycle management:
 - GET  /auth/token/{id}    - Get auth status for a component
 - DELETE /auth/token/{id}  - Revoke a token for a component
 - GET  /auth/tokens        - List all component auth statuses
-- GET  /auth/status        - System-level auth overview
+- GET  /auth/status        - System-level auth overview (auto-detects Redis imports)
+- POST /auth/refresh       - Force reload credentials from Redis
 - GET  /auth/credentials   - Raw credentials for compute (authenticated)
 """
 
@@ -44,8 +45,20 @@ async def get_auth_status():
 
     system_status = service.get_system_auth_status()
     # Also include legacy fields for backward compatibility
-    basic_status = service.get_status()
+    basic_status = await service.get_status()
     return {**basic_status, **system_status}
+
+
+@router.post("/refresh")
+async def refresh_from_redis():
+    """Force reload credentials from Redis.
+
+    Useful after importing credentials externally (e.g. via import-credentials.py)
+    or for manual recovery without restarting the service.
+    """
+    service = _get_service()
+    result = await service.refresh_from_redis()
+    return result
 
 
 @router.post("/token")
@@ -117,4 +130,5 @@ async def get_credentials():
     if not creds:
         raise HTTPException(status_code=503, detail="No credentials available")
 
-    return {"credentials": creds, "expires_at": service.get_status().get("expires_at")}
+    status = await service.get_status()
+    return {"credentials": creds, "expires_at": status.get("expires_at")}

--- a/serving/app.py
+++ b/serving/app.py
@@ -1141,7 +1141,7 @@ async def health_check():
     # Get Claude auth status
     try:
         auth_svc = get_claude_auth_service()
-        claude_auth_stats = auth_svc.get_status() if auth_svc else {"enabled": False}
+        claude_auth_stats = (await auth_svc.get_status()) if auth_svc else {"enabled": False}
     except Exception:
         claude_auth_stats = {"enabled": False}
 

--- a/serving/services/claude_auth_service.py
+++ b/serving/services/claude_auth_service.py
@@ -117,13 +117,60 @@ class ClaudeAuthService:
             self._status = AuthStatus.NOT_CONFIGURED
             self._expires_at = None
 
-    def get_status(self) -> dict[str, Any]:
-        """Get current authentication status."""
+    async def get_status(self) -> dict[str, Any]:
+        """Get current authentication status.
+
+        When status is NOT_CONFIGURED, performs a lightweight Redis check
+        to detect externally-imported credentials (e.g. via import-credentials.py)
+        without requiring a service restart.
+        """
+        if self._status == AuthStatus.NOT_CONFIGURED and self._redis:
+            await self._lazy_check_redis()
+
         return {
             "status": self._status.value,
             "authenticated": self._status == AuthStatus.AUTHENTICATED,
             "expires_at": self._expires_at,
             "message": self._error_message,
+        }
+
+    async def _lazy_check_redis(self) -> None:
+        """Check Redis for credentials when status is NOT_CONFIGURED.
+
+        Only called when no tokens are cached. Uses EXISTS for a cheap
+        check before doing a full reload.
+        """
+        try:
+            prefix = getattr(self._redis, '_prefix', 'claudevn:')
+            key = f"{prefix}auth:serving"
+            exists = await self._redis._redis.exists(key)
+            if exists:
+                await self.refresh_from_redis()
+        except Exception as e:
+            logger.warning(f"Lazy Redis check failed: {e}")
+
+    async def refresh_from_redis(self) -> dict[str, Any]:
+        """Force reload all tokens from Redis and update status.
+
+        Useful after external credential import or for manual recovery.
+
+        Returns:
+            Updated status dict.
+        """
+        await self._load_from_redis()
+        self._update_status()
+
+        # Apply serving token to env if found
+        serving_token = self._tokens.get("serving")
+        if serving_token and serving_token.get("status") == TokenStatus.ACTIVE.value:
+            self._apply_token_to_env(serving_token["token"])
+
+        logger.info(f"Refreshed from Redis: {len(self._tokens)} token(s), status={self._status.value}")
+
+        return {
+            "status": self._status.value,
+            "authenticated": self._status == AuthStatus.AUTHENTICATED,
+            "tokens_loaded": len(self._tokens),
         }
 
     async def store_token(

--- a/serving/tests/unit/test_auth_api.py
+++ b/serving/tests/unit/test_auth_api.py
@@ -32,12 +32,12 @@ class TestGetStatus:
 
     def test_status_authenticated(self, client):
         mock_service = MagicMock()
-        mock_service.get_status.return_value = {
+        mock_service.get_status = AsyncMock(return_value={
             "status": "authenticated",
             "authenticated": True,
             "expires_at": "2026-03-01T00:00:00Z",
             "message": None,
-        }
+        })
         mock_service.get_system_auth_status.return_value = {
             "serving_authorized": True,
             "compute_authorized": 2,
@@ -57,12 +57,12 @@ class TestGetStatus:
 
     def test_status_not_configured(self, client):
         mock_service = MagicMock()
-        mock_service.get_status.return_value = {
+        mock_service.get_status = AsyncMock(return_value={
             "status": "not_configured",
             "authenticated": False,
             "expires_at": None,
             "message": None,
-        }
+        })
         mock_service.get_system_auth_status.return_value = {
             "serving_authorized": False,
             "compute_authorized": 0,
@@ -75,6 +75,43 @@ class TestGetStatus:
             data = response.json()
             assert data["authenticated"] is False
             assert data["serving_authorized"] is False
+
+
+class TestRefreshFromRedis:
+    """Test POST /auth/refresh."""
+
+    def test_refresh_service_disabled(self, client):
+        with patch("api.auth.get_claude_auth_service", return_value=None):
+            response = client.post("/auth/refresh")
+            assert response.status_code == 503
+
+    def test_refresh_success(self, client):
+        mock_service = MagicMock()
+        mock_service.refresh_from_redis = AsyncMock(return_value={
+            "status": "authenticated",
+            "authenticated": True,
+            "tokens_loaded": 1,
+        })
+        with patch("api.auth.get_claude_auth_service", return_value=mock_service):
+            response = client.post("/auth/refresh")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "authenticated"
+            assert data["tokens_loaded"] == 1
+
+    def test_refresh_no_tokens(self, client):
+        mock_service = MagicMock()
+        mock_service.refresh_from_redis = AsyncMock(return_value={
+            "status": "not_configured",
+            "authenticated": False,
+            "tokens_loaded": 0,
+        })
+        with patch("api.auth.get_claude_auth_service", return_value=mock_service):
+            response = client.post("/auth/refresh")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["authenticated"] is False
+            assert data["tokens_loaded"] == 0
 
 
 class TestSubmitToken:
@@ -267,9 +304,9 @@ class TestGetCredentials:
         mock_service.get_credentials = AsyncMock(return_value={
             "token": "sk-ant-oat01-test",
         })
-        mock_service.get_status.return_value = {
+        mock_service.get_status = AsyncMock(return_value={
             "expires_at": "2026-03-01T00:00:00Z",
-        }
+        })
         with patch("api.auth.get_claude_auth_service", return_value=mock_service):
             response = client.get("/auth/credentials")
             assert response.status_code == 200

--- a/serving/tests/unit/test_claude_auth_service.py
+++ b/serving/tests/unit/test_claude_auth_service.py
@@ -37,8 +37,9 @@ def service_with_redis(redis_mock):
 class TestInit:
     """Test service initialization."""
 
-    def test_initial_status(self, service):
-        status = service.get_status()
+    @pytest.mark.asyncio
+    async def test_initial_status(self, service):
+        status = await service.get_status()
         assert status["status"] == AuthStatus.NOT_CONFIGURED.value
         assert status["authenticated"] is False
 
@@ -46,7 +47,7 @@ class TestInit:
     async def test_initialize_no_tokens(self, service):
         await service.initialize()
         try:
-            status = service.get_status()
+            status = await service.get_status()
             assert status["status"] == AuthStatus.NOT_CONFIGURED.value
             assert status["authenticated"] is False
         finally:
@@ -66,7 +67,7 @@ class TestInit:
 
         await service_with_redis.initialize()
         try:
-            status = service_with_redis.get_status()
+            status = await service_with_redis.get_status()
             assert status["status"] == AuthStatus.AUTHENTICATED.value
             assert status["authenticated"] is True
         finally:
@@ -83,7 +84,7 @@ class TestStoreToken:
         assert result["message"] == "Token stored successfully"
         assert result["expires_at"] is not None
 
-        status = service.get_status()
+        status = await service.get_status()
         assert status["authenticated"] is True
 
     @pytest.mark.asyncio
@@ -191,12 +192,12 @@ class TestClearCredentials:
     @pytest.mark.asyncio
     async def test_clear_existing_token(self, service):
         await service.store_token("sk-ant-oat01-clear-test")
-        assert service.get_status()["authenticated"] is True
+        assert (await service.get_status())["authenticated"] is True
 
         result = await service.clear_credentials()
         assert result is True
-        assert service.get_status()["authenticated"] is False
-        assert service.get_status()["status"] == AuthStatus.NOT_CONFIGURED.value
+        assert (await service.get_status())["authenticated"] is False
+        assert (await service.get_status())["status"] == AuthStatus.NOT_CONFIGURED.value
 
     @pytest.mark.asyncio
     async def test_clear_deletes_from_redis(self, service_with_redis, redis_mock):
@@ -217,21 +218,22 @@ class TestClearCredentials:
         # b should still be active
         token_b = await service.get_token("b")
         assert token_b == "sk-ant-oat01-b"
-        assert service.get_status()["authenticated"] is True
+        assert (await service.get_status())["authenticated"] is True
 
 
 class TestGetStatus:
     """Test status reporting."""
 
-    def test_status_not_configured(self, service):
-        status = service.get_status()
+    @pytest.mark.asyncio
+    async def test_status_not_configured(self, service):
+        status = await service.get_status()
         assert status["status"] == "not_configured"
         assert status["authenticated"] is False
 
     @pytest.mark.asyncio
     async def test_status_authenticated(self, service):
         await service.store_token("sk-ant-oat01-test")
-        status = service.get_status()
+        status = await service.get_status()
         assert status["status"] == "authenticated"
         assert status["authenticated"] is True
         assert status["expires_at"] is not None
@@ -242,7 +244,7 @@ class TestGetStatus:
         service._tokens["serving"]["status"] = TokenStatus.EXPIRED.value
         service._update_status()
 
-        status = service.get_status()
+        status = await service.get_status()
         assert status["status"] == "expired"
         assert status["authenticated"] is False
 
@@ -352,7 +354,7 @@ class TestExpiryCheck:
 
         await service._check_expiry()
         assert service._tokens["serving"]["status"] == TokenStatus.EXPIRED.value
-        assert service.get_status()["status"] == AuthStatus.EXPIRED.value
+        assert (await service.get_status())["status"] == AuthStatus.EXPIRED.value
 
     @pytest.mark.asyncio
     async def test_check_expiry_keeps_valid(self, service):
@@ -360,7 +362,7 @@ class TestExpiryCheck:
         # Expiry is ~365 days in the future by default
         await service._check_expiry()
         assert service._tokens["serving"]["status"] == TokenStatus.ACTIVE.value
-        assert service.get_status()["status"] == AuthStatus.AUTHENTICATED.value
+        assert (await service.get_status())["status"] == AuthStatus.AUTHENTICATED.value
 
     @pytest.mark.asyncio
     async def test_check_expiry_saves_to_redis(self, service_with_redis, redis_mock):
@@ -636,3 +638,120 @@ class TestRegistryAuthStatusSync:
                 assert call_args[0][1] == ComputeAuthStatus.UNAUTHORIZED
             finally:
                 await service_with_redis.shutdown()
+
+
+class TestLazyRedisCheck:
+    """Test lazy Redis check when status is NOT_CONFIGURED."""
+
+    @pytest.mark.asyncio
+    async def test_lazy_check_detects_imported_credentials(self, service_with_redis, redis_mock):
+        """get_status detects externally-imported credentials on first poll."""
+        # Service starts NOT_CONFIGURED with no cached tokens
+        assert service_with_redis._status == AuthStatus.NOT_CONFIGURED
+        assert len(service_with_redis._tokens) == 0
+
+        # Simulate external import: Redis now has a serving token
+        redis_mock._redis.exists = AsyncMock(return_value=1)
+        redis_mock._redis.scan = AsyncMock(return_value=(0, [b"claudevn:auth:serving"]))
+        redis_mock._redis.hgetall = AsyncMock(return_value={
+            b"token": b"sk-ant-oat01-imported",
+            b"component_type": b"serving",
+            b"authorized_at": b"2026-02-24T00:00:00+00:00",
+            b"expires_at": b"2027-02-24T00:00:00+00:00",
+            b"status": b"active",
+        })
+
+        # get_status should auto-detect the imported token
+        status = await service_with_redis.get_status()
+        assert status["status"] == AuthStatus.AUTHENTICATED.value
+        assert status["authenticated"] is True
+
+    @pytest.mark.asyncio
+    async def test_lazy_check_skips_when_already_authenticated(self, service_with_redis, redis_mock):
+        """No Redis check when already authenticated."""
+        await service_with_redis.store_token("sk-ant-oat01-existing")
+        redis_mock._redis.exists = AsyncMock()
+
+        status = await service_with_redis.get_status()
+        assert status["authenticated"] is True
+        # exists should NOT have been called (skipped because already authenticated)
+        redis_mock._redis.exists.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lazy_check_skips_without_redis(self, service):
+        """No lazy check when Redis is not configured."""
+        status = await service.get_status()
+        assert status["status"] == AuthStatus.NOT_CONFIGURED.value
+        # Should not raise - gracefully handles no Redis
+
+    @pytest.mark.asyncio
+    async def test_lazy_check_no_keys_in_redis(self, service_with_redis, redis_mock):
+        """Stays NOT_CONFIGURED when Redis has no auth keys."""
+        redis_mock._redis.exists = AsyncMock(return_value=0)
+
+        status = await service_with_redis.get_status()
+        assert status["status"] == AuthStatus.NOT_CONFIGURED.value
+        assert status["authenticated"] is False
+
+    @pytest.mark.asyncio
+    async def test_lazy_check_handles_redis_error(self, service_with_redis, redis_mock):
+        """Gracefully handles Redis errors during lazy check."""
+        redis_mock._redis.exists = AsyncMock(side_effect=ConnectionError("Redis down"))
+
+        # Should not raise
+        status = await service_with_redis.get_status()
+        assert status["status"] == AuthStatus.NOT_CONFIGURED.value
+
+
+class TestRefreshFromRedis:
+    """Test explicit refresh_from_redis method."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_loads_new_tokens(self, service_with_redis, redis_mock):
+        """refresh_from_redis picks up externally-imported credentials."""
+        redis_mock._redis.scan = AsyncMock(return_value=(0, [b"claudevn:auth:serving"]))
+        redis_mock._redis.hgetall = AsyncMock(return_value={
+            b"token": b"sk-ant-oat01-refreshed",
+            b"component_type": b"serving",
+            b"authorized_at": b"2026-02-24T00:00:00+00:00",
+            b"expires_at": b"2027-02-24T00:00:00+00:00",
+            b"status": b"active",
+        })
+
+        result = await service_with_redis.refresh_from_redis()
+        assert result["status"] == AuthStatus.AUTHENTICATED.value
+        assert result["authenticated"] is True
+        assert result["tokens_loaded"] == 1
+
+    @pytest.mark.asyncio
+    async def test_refresh_applies_serving_token_to_env(self, service_with_redis, redis_mock):
+        """refresh_from_redis applies serving token to process environment."""
+        redis_mock._redis.scan = AsyncMock(return_value=(0, [b"claudevn:auth:serving"]))
+        redis_mock._redis.hgetall = AsyncMock(return_value={
+            b"token": b"sk-ant-oat01-env-test",
+            b"component_type": b"serving",
+            b"authorized_at": b"2026-02-24T00:00:00+00:00",
+            b"expires_at": b"2027-02-24T00:00:00+00:00",
+            b"status": b"active",
+        })
+
+        with patch.object(service_with_redis, "_apply_token_to_env") as mock_apply:
+            await service_with_redis.refresh_from_redis()
+            mock_apply.assert_called_once_with("sk-ant-oat01-env-test")
+
+    @pytest.mark.asyncio
+    async def test_refresh_returns_not_configured_when_empty(self, service_with_redis, redis_mock):
+        """refresh_from_redis returns NOT_CONFIGURED when Redis is empty."""
+        redis_mock._redis.scan = AsyncMock(return_value=(0, []))
+
+        result = await service_with_redis.refresh_from_redis()
+        assert result["status"] == AuthStatus.NOT_CONFIGURED.value
+        assert result["authenticated"] is False
+        assert result["tokens_loaded"] == 0
+
+    @pytest.mark.asyncio
+    async def test_refresh_without_redis(self, service):
+        """refresh_from_redis works gracefully without Redis."""
+        result = await service.refresh_from_redis()
+        assert result["status"] == AuthStatus.NOT_CONFIGURED.value
+        assert result["tokens_loaded"] == 0

--- a/serving/tests/unit/test_serving_self_auth.py
+++ b/serving/tests/unit/test_serving_self_auth.py
@@ -218,7 +218,7 @@ class TestGracefulDegradation:
 
     @pytest.mark.asyncio
     async def test_status_not_configured_by_default(self, auth_service):
-        status = auth_service.get_status()
+        status = await auth_service.get_status()
         assert status["status"] == AuthStatus.NOT_CONFIGURED.value
         assert status["authenticated"] is False
 


### PR DESCRIPTION
## Summary
- Add lazy Redis check in `get_status()` when status is `NOT_CONFIGURED` — detects imported credentials without restart
- Add `POST /auth/refresh` endpoint for explicit forced reload from Redis
- No new background polling tasks added

## Changes
- `serving/services/claude_auth_service.py` — `get_status()` now async with lazy Redis check; new `_lazy_check_redis()` and `refresh_from_redis()` methods
- `serving/api/auth.py` — new `POST /auth/refresh` endpoint; updated `get_status` callers to await
- `serving/app.py` — updated health check to await `get_status()`
- `serving/tests/unit/test_claude_auth_service.py` — 9 new tests for lazy check and refresh
- `serving/tests/unit/test_auth_api.py` — 3 new tests for `/auth/refresh` endpoint
- `serving/tests/unit/test_serving_self_auth.py` — updated `get_status` call to await

## Testing
- [x] Tier 1 unit tests added (12 new tests)
- [x] All 99 auth-related unit tests passing
- [x] Full unit test suite: 3616 passed (3 pre-existing failures unrelated)

## Follow-up
- [ ] `.admin/import-credentials.py` can optionally call `POST /auth/refresh` after import

## Issues
Closes #32