### PR TITLE
fix: re-trigger merge after conflict resolution completes (#55)

### DIFF
--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -526,10 +526,15 @@ async def _handle_work_status_update(event: ComputeEventRequest) -> None:
 
     work = await work_map.get_work(event.task_id)
     if not work:
-        logger.debug(
-            f"No work item found for task_id={event.task_id}, "
-            "skipping work/issue transition"
-        )
+        # Conflict resolution tasks have synthetic IDs: conflict-{work_id}-{random}
+        # Extract the original work_id and handle post-conflict re-merge (#55)
+        if event.task_id.startswith("conflict-"):
+            await _handle_conflict_resolution_completed(event, work_map)
+        else:
+            logger.debug(
+                f"No work item found for task_id={event.task_id}, "
+                "skipping work/issue transition"
+            )
         return
 
     # Handle started event
@@ -898,6 +903,68 @@ async def _dispatch_conflict_resolution_work(
 
     except Exception as e:
         logger.error(f"Error dispatching conflict resolution work: {e}")
+
+
+async def _handle_conflict_resolution_completed(event, work_map) -> None:
+    """Handle completion of a conflict resolution task by re-triggering merge.
+
+    Conflict resolution tasks have synthetic IDs: conflict-{work_id}-{random}.
+    After the compute rebases and pushes, we need to look up the original work
+    item and call _auto_create_and_merge_pr so the PR gets re-approved and
+    merged. Without this, resolved PRs stay stuck in 'conflict' status (#55).
+    """
+    from models.work_map import WorkStatus
+
+    task_id = event.task_id
+    is_success = (
+        event.event.value == "claude_code_completed"
+        and event.exit_code is not None
+        and event.exit_code == 0
+    )
+
+    # Extract original work_id: "conflict-{work_id}-{random_hex}"
+    parts = task_id.split("-", 1)  # ["conflict", "{work_id}-{random}"]
+    if len(parts) < 2:
+        logger.warning(f"Malformed conflict task_id: {task_id}")
+        return
+
+    # work_id format is "work_{hex}" — rejoin everything except the last segment
+    remainder = parts[1]  # e.g. "work_abc123-7d65ee98"
+    # Split from the right to separate the random suffix
+    segments = remainder.rsplit("-", 1)
+    if len(segments) == 2:
+        original_work_id = segments[0]  # "work_abc123"
+    else:
+        original_work_id = remainder
+
+    work = await work_map.get_work(original_work_id)
+    if not work:
+        logger.warning(
+            f"Conflict resolution completed ({task_id}) but original work "
+            f"{original_work_id} not found"
+        )
+        return
+
+    if not is_success:
+        logger.warning(
+            f"Conflict resolution failed for {task_id} "
+            f"(exit_code={event.exit_code}), work {original_work_id} unchanged"
+        )
+        return
+
+    logger.info(
+        f"Conflict resolution succeeded ({task_id}), "
+        f"re-triggering merge for work {original_work_id}"
+    )
+
+    # Re-trigger the PR merge pipeline with the original work item
+    branch_name = event.branch_name or work.branch_name
+    if branch_name and work.project_id:
+        await _auto_create_and_merge_pr(work, branch_name, event.compute_id)
+
+        # Cascade dependents now that the merge can proceed
+        if work.status == WorkStatus.COMPLETED:
+            await work_map.cascade_dependents(work.work_id)
 
 
 async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> None:

--- a/serving/tests/unit/test_conflict_resolution_dispatch.py
+++ b/serving/tests/unit/test_conflict_resolution_dispatch.py
@@ -273,3 +273,141 @@ class TestDispatchConflictResolutionWork:
             )
 
 
+# =============================================================================
+# Issue #55: Conflict resolution completed re-triggers merge
+# =============================================================================
+
+
+def _make_conflict_event(task_id, exit_code=0, branch_name="feat/my-branch"):
+    """Build a mock ComputeEventRequest for conflict resolution completion."""
+    event = MagicMock()
+    event.task_id = task_id
+    event.compute_id = "compute-001"
+    event.event.value = "claude_code_completed"
+    event.exit_code = exit_code
+    event.branch_name = branch_name
+    event.error = None
+    event.duration_seconds = 30
+    return event
+
+
+class TestConflictResolutionRemerge:
+    """Issue #55: After conflict resolution, re-trigger merge pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_extracts_work_id_and_retriggers_merge(self):
+        """Successful conflict resolution extracts work_id and calls _auto_create_and_merge_pr."""
+        from api.compute import _handle_conflict_resolution_completed
+
+        event = _make_conflict_event("conflict-work_abc123-7d65ee98")
+        work = MagicMock()
+        work.work_id = "work_abc123"
+        work.branch_name = "feat/my-branch"
+        work.project_id = "proj-1"
+        work.status = MagicMock(value="completed")
+
+        mock_work_map = MagicMock()
+        mock_work_map.get_work = AsyncMock(return_value=work)
+        mock_work_map.cascade_dependents = AsyncMock()
+
+        with patch("api.compute._auto_create_and_merge_pr", new_callable=AsyncMock) as mock_merge:
+            await _handle_conflict_resolution_completed(event, mock_work_map)
+
+        mock_work_map.get_work.assert_awaited_once_with("work_abc123")
+        mock_merge.assert_awaited_once_with(work, "feat/my-branch", "compute-001")
+
+    @pytest.mark.asyncio
+    async def test_failed_conflict_resolution_does_not_retrigger(self):
+        """Failed conflict resolution (nonzero exit) does not re-trigger merge."""
+        from api.compute import _handle_conflict_resolution_completed
+
+        event = _make_conflict_event("conflict-work_abc123-7d65ee98", exit_code=1)
+        work = MagicMock()
+        work.work_id = "work_abc123"
+
+        mock_work_map = MagicMock()
+        mock_work_map.get_work = AsyncMock(return_value=work)
+
+        with patch("api.compute._auto_create_and_merge_pr", new_callable=AsyncMock) as mock_merge:
+            await _handle_conflict_resolution_completed(event, mock_work_map)
+
+        mock_merge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_original_work_is_handled(self):
+        """If original work item is not found, log warning and return gracefully."""
+        from api.compute import _handle_conflict_resolution_completed
+
+        event = _make_conflict_event("conflict-work_gone999-aabbccdd")
+
+        mock_work_map = MagicMock()
+        mock_work_map.get_work = AsyncMock(return_value=None)
+
+        with patch("api.compute._auto_create_and_merge_pr", new_callable=AsyncMock) as mock_merge:
+            await _handle_conflict_resolution_completed(event, mock_work_map)
+
+        mock_merge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_uses_event_branch_name_over_work_branch(self):
+        """Event branch_name takes precedence over work.branch_name."""
+        from api.compute import _handle_conflict_resolution_completed
+
+        event = _make_conflict_event(
+            "conflict-work_abc123-7d65ee98",
+            branch_name="f/issue_123/compute-001",
+        )
+        work = MagicMock()
+        work.work_id = "work_abc123"
+        work.branch_name = "old-branch"
+        work.project_id = "proj-1"
+        work.status = MagicMock(value="completed")
+
+        mock_work_map = MagicMock()
+        mock_work_map.get_work = AsyncMock(return_value=work)
+        mock_work_map.cascade_dependents = AsyncMock()
+
+        with patch("api.compute._auto_create_and_merge_pr", new_callable=AsyncMock) as mock_merge:
+            await _handle_conflict_resolution_completed(event, mock_work_map)
+
+        mock_merge.assert_awaited_once_with(work, "f/issue_123/compute-001", "compute-001")
+
+    @pytest.mark.asyncio
+    async def test_cascades_dependents_when_work_already_completed(self):
+        """After re-merge, cascade dependents if work was already in COMPLETED status."""
+        from api.compute import _handle_conflict_resolution_completed
+        from models.work_map import WorkStatus
+
+        event = _make_conflict_event("conflict-work_abc123-7d65ee98")
+        work = MagicMock()
+        work.work_id = "work_abc123"
+        work.branch_name = "feat/my-branch"
+        work.project_id = "proj-1"
+        work.status = WorkStatus.COMPLETED
+
+        mock_work_map = MagicMock()
+        mock_work_map.get_work = AsyncMock(return_value=work)
+        mock_work_map.cascade_dependents = AsyncMock()
+
+        with patch("api.compute._auto_create_and_merge_pr", new_callable=AsyncMock):
+            await _handle_conflict_resolution_completed(event, mock_work_map)
+
+        mock_work_map.cascade_dependents.assert_awaited_once_with("work_abc123")
+
+    @pytest.mark.asyncio
+    async def test_handle_work_status_routes_conflict_tasks(self):
+        """_handle_work_status_update routes conflict-* tasks to the new handler."""
+        from api.compute import _handle_work_status_update
+
+        event = _make_conflict_event("conflict-work_abc123-7d65ee98")
+
+        mock_work_map = MagicMock()
+        mock_work_map.get_work = AsyncMock(return_value=None)
+
+        with patch("services.work_map_service.get_work_map_service", return_value=mock_work_map), \
+             patch("api.compute._handle_conflict_resolution_completed", new_callable=AsyncMock, create=True) as mock_handler:
+            await _handle_work_status_update(event)
+
+        mock_handler.assert_awaited_once_with(event, mock_work_map)
+
+


### PR DESCRIPTION
## Summary
Fixes #55

After conflict resolution tasks complete, the merge pipeline was never re-triggered, leaving resolved PRs permanently stuck in `conflict` status.

## Root Cause

`_handle_work_status_update` looks up work items by `event.task_id`, but conflict resolution tasks have synthetic IDs (`conflict-{work_id}-{random}`) that don't match any work item. `get_work()` returned `None`, the handler exited early, and `_auto_create_and_merge_pr` was never called.

## Changes

- **`serving/api/compute.py`**: Added `_handle_conflict_resolution_completed()` that extracts the original `work_id` from the synthetic task ID, looks up the work item, and re-triggers `_auto_create_and_merge_pr`. The routing check (`event.task_id.startswith("conflict-")`) is added at the existing early-return point in `_handle_work_status_update`.
- **`serving/tests/unit/test_conflict_resolution_dispatch.py`**: Added 6 tests covering: successful re-merge, failed resolution, missing work item, branch name precedence, dependency cascade, and routing integration.

## Testing
- [x] All 14 unit tests pass (8 existing + 6 new)
- [x] Existing conflict resolution tests unaffected

Generated with [Claude Code](https://claude.com/claude-code)