### PR TITLE
fix: Atomic repo creation during project creation (#61)

### DIFF
--- a/serving/frontend/src/components/projects/ProjectFormModal.jsx
+++ b/serving/frontend/src/components/projects/ProjectFormModal.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { X, FolderGit2, Code, Database, Server, Globe, Folder, Box, Layers, Cpu, Cloud, Shield, ChevronDown, ChevronRight, Plus, GitBranch, Trash2 } from 'lucide-react'
 import Modal from '../common/Modal'
 import { createProject, updateProject } from '../../api/projects'
+import { useSSHKeys } from '../../hooks/useSSHKeys'
 import '../common/Modal.css'
 import './Projects.css'
 
@@ -134,7 +135,10 @@ function InlineRepoForm({ onAdd }) {
   const [repoName, setRepoName] = useState('')
   const [repoUrl, setRepoUrl] = useState('')
   const [defaultBranch, setDefaultBranch] = useState('main')
+  const [sshKeyId, setSshKeyId] = useState('')
   const [formError, setFormError] = useState(null)
+
+  const { keys, loading: keysLoading } = useSSHKeys()
 
   const handleAdd = () => {
     if (!repoName.trim()) {
@@ -151,11 +155,13 @@ function InlineRepoForm({ onAdd }) {
       name: repoName.trim(),
       url: mode === 'link' ? repoUrl.trim() : null,
       default_branch: defaultBranch.trim() || 'main',
+      ssh_key_id: mode === 'link' && sshKeyId ? sshKeyId : null,
     })
 
     setRepoName('')
     setRepoUrl('')
     setDefaultBranch('main')
+    setSshKeyId('')
     setFormError(null)
   }
 
@@ -225,6 +231,22 @@ function InlineRepoForm({ onAdd }) {
           onKeyDown={handleKeyDown}
           placeholder="Default branch (main)"
         />
+
+        {mode === 'link' && (
+          <select
+            className="form-input"
+            value={sshKeyId}
+            onChange={(e) => setSshKeyId(e.target.value)}
+          >
+            <option value="">SSH Key: None (no authentication)</option>
+            {keysLoading && <option disabled>Loading keys...</option>}
+            {keys.map((key) => (
+              <option key={key.key_id} value={key.key_id}>
+                {key.key_id}{key.description ? ` - ${key.description}` : ''}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
 
       {formError && (
@@ -341,6 +363,7 @@ function ProjectFormModal({ isOpen, onClose, onSuccess, project = null }) {
             name: repo.name,
             url: repo.url,
             default_branch: repo.default_branch,
+            ssh_key_id: repo.ssh_key_id,
           })),
         }
 

--- a/serving/frontend/src/components/projects/ProjectFormModal.test.jsx
+++ b/serving/frontend/src/components/projects/ProjectFormModal.test.jsx
@@ -8,6 +8,19 @@ vi.mock('../../api/projects', () => ({
   updateProject: vi.fn(),
 }))
 
+// Mock useSSHKeys hook
+vi.mock('../../hooks/useSSHKeys', () => ({
+  useSSHKeys: () => ({
+    keys: [
+      { key_id: 'key_abc123', description: 'GitHub deploy key' },
+      { key_id: 'key_def456', description: 'GitLab key' },
+    ],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}))
+
 import { createProject, updateProject } from '../../api/projects'
 
 describe('ProjectFormModal', () => {
@@ -244,6 +257,7 @@ describe('ProjectFormModal', () => {
             name: 'my-repo',
             url: null,
             default_branch: 'main',
+            ssh_key_id: null,
           },
         ],
       })
@@ -283,6 +297,51 @@ describe('ProjectFormModal', () => {
             name: 'ext-repo',
             url: 'https://github.com/test/repo.git',
             default_branch: 'main',
+            ssh_key_id: null,
+          },
+        ],
+      })
+    })
+  })
+
+  it('includes ssh_key_id when SSH key is selected for linked repo', async () => {
+    render(<ProjectFormModal {...defaultProps} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'Test Project' },
+    })
+
+    fireEvent.click(screen.getByText('Repositories'))
+    fireEvent.click(screen.getByText('Link External'))
+
+    fireEvent.change(screen.getByPlaceholderText('Repository name'), {
+      target: { value: 'private-repo' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('https://github.com/org/repo.git'), {
+      target: { value: 'git@github.com:org/private.git' },
+    })
+
+    // Select an SSH key
+    const sshSelect = screen.getByDisplayValue('SSH Key: None (no authentication)')
+    fireEvent.change(sshSelect, { target: { value: 'key_abc123' } })
+
+    fireEvent.click(screen.getByText('Add to list'))
+    fireEvent.click(screen.getByText('Create Project'))
+
+    await waitFor(() => {
+      expect(createProject).toHaveBeenCalledWith({
+        name: 'Test Project',
+        description: '',
+        icon: null,
+        icon_color: null,
+        labels: [],
+        repos: [
+          {
+            mode: 'link',
+            name: 'private-repo',
+            url: 'git@github.com:org/private.git',
+            default_branch: 'main',
+            ssh_key_id: 'key_abc123',
           },
         ],
       })

--- a/serving/models/project.py
+++ b/serving/models/project.py
@@ -115,6 +115,7 @@ class PendingRepoRequest(BaseModel):
     name: str = Field(..., description="Repository name")
     url: Optional[str] = Field(None, description="External URL (required for 'link' mode)")
     default_branch: str = Field(default="main", description="Default branch name")
+    ssh_key_id: Optional[str] = Field(None, description="SSH key for private repo authentication")
 
 
 class ProjectCreateRequest(BaseModel):

--- a/serving/services/project_service.py
+++ b/serving/services/project_service.py
@@ -183,6 +183,7 @@ class ProjectService:
                             name=pending_repo.name,
                             url=pending_repo.url,
                             default_branch=pending_repo.default_branch,
+                            ssh_key_id=pending_repo.ssh_key_id,
                         ),
                     )
                 else:

--- a/serving/tests/unit/test_create_project_with_repos.py
+++ b/serving/tests/unit/test_create_project_with_repos.py
@@ -156,6 +156,31 @@ class TestCreateProjectWithLinkedRepo:
         mock_sync.clone_repo.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_ssh_key_id_forwarded_to_add_repo(self, project_service):
+        """ssh_key_id from PendingRepoRequest should be forwarded to RepoAddRequest."""
+        mock_sync = _mock_sync_service(success=True)
+        mock_rm = _mock_repo_manager()
+
+        request = ProjectCreateRequest(
+            name="My Project",
+            repos=[
+                PendingRepoRequest(
+                    mode="link",
+                    name="private-repo",
+                    url="git@github.com:org/private.git",
+                    ssh_key_id="key_abc123",
+                ),
+            ],
+        )
+
+        with patch(PATCH_GET_SYNC, return_value=mock_sync), \
+             patch(PATCH_GET_RM, return_value=mock_rm):
+            project = await project_service.create_project(request)
+
+        assert len(project.repos) == 1
+        assert project.repos[0].ssh_key_id == "key_abc123"
+
+    @pytest.mark.asyncio
     async def test_clone_error_recorded_in_metadata(self, project_service):
         """Clone failure should be recorded in repo metadata, not raise."""
         mock_sync = _mock_sync_service(
@@ -338,6 +363,7 @@ class TestPendingRepoRequestModel:
         assert req.mode == "create"
         assert req.url is None
         assert req.default_branch == "main"
+        assert req.ssh_key_id is None
 
     def test_link_mode(self):
         """Link mode with URL should work."""
@@ -350,6 +376,16 @@ class TestPendingRepoRequestModel:
         assert req.mode == "link"
         assert req.url == "https://github.com/org/repo.git"
         assert req.default_branch == "develop"
+
+    def test_link_mode_with_ssh_key(self):
+        """Link mode should accept ssh_key_id."""
+        req = PendingRepoRequest(
+            mode="link",
+            name="private-repo",
+            url="git@github.com:org/private.git",
+            ssh_key_id="key_abc123",
+        )
+        assert req.ssh_key_id == "key_abc123"
 
     def test_project_create_request_with_repos(self):
         """ProjectCreateRequest should accept repos field."""


### PR DESCRIPTION
## Summary
- Repos linked during project creation are now processed atomically in the backend instead of via sequential frontend API calls
- Clone errors are recorded in repo metadata and surfaced to the user
- Fixes the root cause: the two-step create-then-add-repos flow was fragile due to timing/persistence issues

## Changes
- **`serving/models/project.py`**: Added `PendingRepoRequest` model and `repos` field to `ProjectCreateRequest`
- **`serving/services/project_service.py`**: Updated `create_project()` to process repos atomically using existing `add_repo()`/`create_internal_repo()` methods; errors are caught per-repo without failing the whole operation
- **`serving/frontend/.../ProjectFormModal.jsx`**: Sends repos in creation payload instead of sequential post-creation API calls; checks response repos for clone errors and displays them
- **`serving/frontend/.../ProjectFormModal.test.jsx`**: Updated tests for atomic creation flow; added clone error surfacing test
- **`serving/tests/unit/test_create_project_with_repos.py`**: 16 new unit tests covering internal repos, linked repos, mixed repos, clone failures, edge cases, and model validation

## Testing
- [x] Tier 1 unit tests added (16 new tests)
- [x] All 167 related tests passing (0 regressions)
- [ ] Frontend tests need `node_modules` to run (CI will verify)

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issue
Closes #61