### PR TITLE
fix: Remove duplicate directive title from GoalCreatedMessage (#40)

### DIFF
--- a/serving/frontend/src/components/directives/ConversationTimeline.jsx
+++ b/serving/frontend/src/components/directives/ConversationTimeline.jsx
@@ -49,10 +49,6 @@ function GoalCreatedMessage({ msg }) {
           <Sparkles size={14} className="conv-icon-goal" />
           <span className="conv-msg-label">New Work Created</span>
         </div>
-        <p className="conv-msg-text">{msg.goal?.title || msg.content}</p>
-        {msg.goal?.priority && (
-          <span className="conv-tag conv-tag-priority">{msg.goal.priority}</span>
-        )}
       </div>
     </div>
   )

--- a/serving/frontend/src/components/directives/ConversationTimeline.test.jsx
+++ b/serving/frontend/src/components/directives/ConversationTimeline.test.jsx
@@ -46,7 +46,7 @@ describe('ConversationTimeline', () => {
     expect(screen.getByText('Interpreting directive...')).toBeDefined()
   })
 
-  it('renders goal created message with title and priority', () => {
+  it('renders goal created message as brief confirmation without duplicating title', () => {
     const messages = [
       makeMsg(MSG_TYPES.GOAL_CREATED, 'Created: Test goal', {
         goal: { title: 'Test goal', priority: 'P1' },
@@ -54,9 +54,10 @@ describe('ConversationTimeline', () => {
     ]
     render(<ConversationTimeline {...defaultProps} messages={messages} />)
 
-    expect(screen.getByText('Test goal')).toBeDefined()
-    expect(screen.getByText('P1')).toBeDefined()
     expect(screen.getByText('New Work Created')).toBeDefined()
+    // Title and priority should NOT be rendered (they're shown in the goal header)
+    expect(screen.queryByText('Test goal')).toBeNull()
+    expect(screen.queryByText('P1')).toBeNull()
   })
 
   it('renders goal processing message with stage label and stepper', () => {
@@ -386,7 +387,7 @@ describe('ConversationTimeline', () => {
     render(<ConversationTimeline {...defaultProps} messages={messages} />)
 
     expect(screen.getByText('Build feature')).toBeDefined()
-    expect(screen.getByText('Feature')).toBeDefined()
+    expect(screen.getByText('New Work Created')).toBeDefined()
     expect(screen.getByText('Work Items Created')).toBeDefined()
   })
 })


### PR DESCRIPTION
## Summary
- Removed duplicate goal title and priority tag from `GoalCreatedMessage` in `ConversationTimeline.jsx`
- The directive title/priority is already displayed in the goal header (`GoalsPage.jsx:246-265`), so the timeline confirmation now shows only the "New Work Created" label

## Changes
- `ConversationTimeline.jsx`: Removed `<p>` displaying `msg.goal?.title` and the priority `<span>` from `GoalCreatedMessage`
- `ConversationTimeline.test.jsx`: Updated tests to verify title/priority are no longer rendered in `GoalCreatedMessage`

## Testing
- [x] Tier 1 unit tests updated and passing (25/25)
- [x] All existing tests still pass

## Follow-up
- No Tier 2 integration tests needed (UI-only change)

## Issues
Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)