### PR TITLE
fix: Invalid effort level and swallowed stderr in SDK executor (#67)

### DIFF
--- a/compute/services/claude_code_spawner.py
+++ b/compute/services/claude_code_spawner.py
@@ -862,10 +862,10 @@ fi
             complexity: One of 'simple', 'standard', 'complex'
 
         Returns:
-            SDK effort value: 'medium', 'high', or 'max'
+            SDK effort value: 'low', 'medium', or 'high'
         """
-        return {"simple": "medium", "standard": "high", "complex": "max"}.get(
-            complexity, "high"
+        return {"simple": "low", "standard": "medium", "complex": "high"}.get(
+            complexity, "medium"
         )
 
     @staticmethod

--- a/compute/services/claude_sdk_executor.py
+++ b/compute/services/claude_sdk_executor.py
@@ -135,7 +135,7 @@ async def execute_task(
         model: Claude model identifier (e.g. 'claude-opus-4-20250514').
             If None, uses the SDK/CLI default model.
         effort: Controls response depth — 'low'/'medium' for simple tasks,
-            'high'/'max' for complex ones. If None, uses SDK default.
+            'high' for complex ones. If None, uses SDK default.
 
     Returns:
         ExecutionResult with output, status, and metadata
@@ -148,6 +148,12 @@ async def execute_task(
             error="Demo mode enabled - real compute execution is disabled",
         )
 
+    stderr_lines: List[str] = []
+
+    def _capture_stderr(line: str) -> None:
+        stderr_lines.append(line)
+        logger.warning(f"[sdk-stderr] {line}")
+
     options_kwargs: Dict[str, Any] = {
         "cwd": str(cwd),
         "system_prompt": system_prompt,
@@ -157,6 +163,7 @@ async def execute_task(
         "env": env_vars or {},
         "max_turns": max_turns,
         "allowed_tools": allowed_tools or [],
+        "stderr": _capture_stderr,
     }
     if model:
         options_kwargs["model"] = model
@@ -213,11 +220,14 @@ async def execute_task(
         )
 
     except Exception as e:
-        logger.error(f"SDK execution failed: {e}")
+        stderr_output = "\n".join(stderr_lines)
+        error_msg = stderr_output if stderr_output else str(e)
+        exc_exit_code = getattr(e, "exit_code", None) or -1
+        logger.error(f"SDK execution failed (exit_code={exc_exit_code}): {error_msg}")
         return ExecutionResult(
             success=False,
-            exit_code=-1,
+            exit_code=exc_exit_code,
             output="\n".join(output_parts),
-            error=str(e),
+            error=error_msg,
             tool_calls=tool_calls,
         )

--- a/compute/tests/unit/test_claude_code_spawner.py
+++ b/compute/tests/unit/test_claude_code_spawner.py
@@ -3816,16 +3816,16 @@ class TestEffortAndMaxTurnsMapping:
     """Tests for _get_effort_for_complexity and _get_max_turns_for_complexity (#60)."""
 
     def test_simple_effort(self):
-        assert ClaudeCodeSpawner._get_effort_for_complexity("simple") == "medium"
+        assert ClaudeCodeSpawner._get_effort_for_complexity("simple") == "low"
 
     def test_standard_effort(self):
-        assert ClaudeCodeSpawner._get_effort_for_complexity("standard") == "high"
+        assert ClaudeCodeSpawner._get_effort_for_complexity("standard") == "medium"
 
     def test_complex_effort(self):
-        assert ClaudeCodeSpawner._get_effort_for_complexity("complex") == "max"
+        assert ClaudeCodeSpawner._get_effort_for_complexity("complex") == "high"
 
-    def test_unknown_effort_defaults_to_high(self):
-        assert ClaudeCodeSpawner._get_effort_for_complexity("unknown") == "high"
+    def test_unknown_effort_defaults_to_medium(self):
+        assert ClaudeCodeSpawner._get_effort_for_complexity("unknown") == "medium"
 
     def test_simple_max_turns(self):
         assert ClaudeCodeSpawner._get_max_turns_for_complexity("simple") == 30

--- a/compute/tests/unit/test_claude_sdk_executor.py
+++ b/compute/tests/unit/test_claude_sdk_executor.py
@@ -364,15 +364,15 @@ class TestEffortParameter:
         assert "effort" not in call_kwargs
 
     @pytest.mark.asyncio
-    async def test_effort_max_for_complex_tasks(self, tmp_path):
-        """Verify max effort can be passed through."""
+    async def test_effort_high_for_complex_tasks(self, tmp_path):
+        """Verify high effort can be passed through."""
         result_msg = ResultMessage(
             subtype="success",
             duration_ms=100,
             duration_api_ms=80,
             is_error=False,
             num_turns=1,
-            session_id="session-max",
+            session_id="session-high",
             total_cost_usd=0.01,
         )
 
@@ -388,11 +388,11 @@ class TestEffortParameter:
                 prompt="test",
                 cwd=tmp_path,
                 mcp_servers={},
-                effort="max",
+                effort="high",
             )
 
         call_kwargs = mock_opts.call_args[1]
-        assert call_kwargs["effort"] == "max"
+        assert call_kwargs["effort"] == "high"
 
 
 class TestSystemPromptParameter:


### PR DESCRIPTION
## Summary
- Fixes compute crash when executing complex tasks due to invalid `"max"` effort level
- Fixes generic error messages by capturing actual stderr from Claude CLI subprocess

## Changes
- **`compute/services/claude_code_spawner.py`**: Change effort mapping from `simple→medium, standard→high, complex→max` to `simple→low, standard→medium, complex→high` — `"max"` is not a valid effort level
- **`compute/services/claude_sdk_executor.py`**: Add `stderr` callback to `ClaudeAgentOptions` to capture CLI errors; use captured stderr in error messages; extract real `exit_code` from `ProcessError` instead of hardcoding `-1`
- **Tests updated**: 210 tests passing in container (0 regressions)

## Testing
- [x] All 210 compute unit tests passing in Docker
- [x] Containers rebuilt and running

## Issue
Closes #67