### PR TITLE
feat: Improve Compute Timing dashboard styling and add issue context (#69)

### DIFF
--- a/serving/frontend/src/pages/TimingPage.css
+++ b/serving/frontend/src/pages/TimingPage.css
@@ -55,10 +55,36 @@
   font-size: 0.82rem;
 }
 
-.phase-badge {
-  border-left: 3px solid;
-  padding-left: 0.5rem;
-  font-weight: 500;
+/* Phase Pill - bold color treatment */
+.phase-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.phase-pill .phase-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* Stat bar in aggregate table */
+.stat-bar-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.stat-bar {
+  height: 6px;
+  border-radius: 3px;
+  min-width: 2px;
 }
 
 /* Work Items List */
@@ -78,7 +104,7 @@
 
 .work-item-header {
   display: grid;
-  grid-template-columns: 20px 1fr 1fr auto auto auto;
+  grid-template-columns: 20px 1fr auto auto auto;
   align-items: center;
   gap: 0.75rem;
   padding: 0.6rem 0.75rem;
@@ -96,6 +122,19 @@
   align-items: center;
 }
 
+.work-item-primary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  overflow: hidden;
+}
+
+.work-item-primary-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .work-item-id {
   font-weight: 600;
   font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
@@ -105,10 +144,34 @@
   white-space: nowrap;
 }
 
-.work-item-instance {
-  color: var(--color-text-secondary, #64748b);
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+.work-item-issue-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 600;
+  font-size: 0.82rem;
+  color: var(--color-primary, #3b82f6);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.work-item-issue-link:hover {
+  text-decoration: underline;
+  color: var(--color-primary-hover, #2563eb);
+}
+
+.work-item-issue-title {
   font-size: 0.8rem;
+  color: var(--color-text-secondary, #64748b);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.work-item-instance {
+  color: var(--color-text-tertiary, #94a3b8);
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+  font-size: 0.75rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -146,49 +209,101 @@
   margin-bottom: 0.75rem;
 }
 
+/* Waterfall legend */
+.waterfall-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-border-light, #f1f5f9);
+}
+
+.waterfall-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  color: var(--color-text-secondary, #64748b);
+}
+
+.waterfall-legend-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+}
+
+/* Waterfall time axis */
+.waterfall-time-axis {
+  display: grid;
+  grid-template-columns: 140px 1fr 60px;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.waterfall-time-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  color: var(--color-text-tertiary, #94a3b8);
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+}
+
 .waterfall-row {
   display: grid;
-  grid-template-columns: 120px 1fr 60px;
+  grid-template-columns: 140px 1fr 60px;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.2rem 0;
+  padding: 0.25rem 0;
 }
 
 .waterfall-label {
-  font-size: 0.78rem;
-  color: var(--color-text-secondary, #64748b);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  font-weight: 500;
   text-align: right;
   white-space: nowrap;
+  justify-content: flex-end;
+}
+
+.waterfall-label-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .waterfall-track {
   position: relative;
-  height: 16px;
+  height: 20px;
   background: var(--color-bg, #fff);
   border-radius: 3px;
   overflow: hidden;
+  border: 1px solid var(--color-border-light, #f1f5f9);
 }
 
 .waterfall-bar {
   position: absolute;
-  top: 1px;
-  height: 14px;
-  border-radius: 2px;
-  min-width: 2px;
-  opacity: 0.85;
+  top: 2px;
+  height: 16px;
+  border-radius: 3px;
+  min-width: 3px;
   transition: opacity 0.15s;
 }
 
 .waterfall-bar:hover {
-  opacity: 1;
+  opacity: 0.8;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
 }
 
 .waterfall-duration {
-  font-size: 0.78rem;
+  font-size: 0.8rem;
+  font-weight: 500;
   font-variant-numeric: tabular-nums;
   font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
   text-align: right;
-  color: var(--color-text-secondary, #64748b);
 }
 
 /* Entry Rows */
@@ -200,7 +315,7 @@
 
 .entry-row {
   display: grid;
-  grid-template-columns: 140px 80px 70px 1fr;
+  grid-template-columns: 160px 80px 70px 1fr;
   align-items: center;
   gap: 0.5rem;
   padding: 0.25rem 0;
@@ -208,10 +323,18 @@
 }
 
 .entry-phase {
-  border-left: 3px solid;
-  padding-left: 0.4rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
   font-weight: 500;
-  font-size: 0.78rem;
+  font-size: 0.8rem;
+}
+
+.entry-phase-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .entry-start {

--- a/serving/frontend/src/pages/TimingPage.jsx
+++ b/serving/frontend/src/pages/TimingPage.jsx
@@ -24,6 +24,16 @@ const PHASE_COLORS = {
   total_wall_time: '#64748b'
 }
 
+const PHASE_BG_COLORS = {
+  workspace_setup: 'rgba(59, 130, 246, 0.1)',
+  repo_clone: 'rgba(139, 92, 246, 0.1)',
+  sdk_launch: 'rgba(245, 158, 11, 0.1)',
+  mcp_tool_call: 'rgba(16, 185, 129, 0.1)',
+  api_inference: 'rgba(239, 68, 68, 0.1)',
+  git_push: 'rgba(99, 102, 241, 0.1)',
+  total_wall_time: 'rgba(100, 116, 139, 0.1)'
+}
+
 function formatDuration(ms) {
   if (ms == null) return '-'
   if (ms < 1000) return `${Math.round(ms)}ms`
@@ -37,10 +47,24 @@ function formatTimestamp(ts) {
   return d.toLocaleTimeString()
 }
 
+function PhasePill({ phase }) {
+  const color = PHASE_COLORS[phase] || '#94a3b8'
+  const bgColor = PHASE_BG_COLORS[phase] || 'rgba(148, 163, 184, 0.1)'
+
+  return (
+    <span className="phase-pill" style={{ backgroundColor: bgColor, color }}>
+      <span className="phase-dot" style={{ backgroundColor: color }} />
+      {PHASE_LABELS[phase] || phase}
+    </span>
+  )
+}
+
 function AggregateStatsTable({ aggregates }) {
   if (!aggregates.length) {
     return <p className="timing-empty">No aggregate data yet</p>
   }
+
+  const maxAvg = Math.max(...aggregates.map(s => s.avg_ms))
 
   return (
     <div className="timing-table-container">
@@ -60,13 +84,21 @@ function AggregateStatsTable({ aggregates }) {
         <tbody>
           {aggregates.map(stat => (
             <tr key={stat.phase}>
-              <td>
-                <span className="phase-badge" style={{ borderLeftColor: PHASE_COLORS[stat.phase] || '#94a3b8' }}>
-                  {PHASE_LABELS[stat.phase] || stat.phase}
-                </span>
-              </td>
+              <td><PhasePill phase={stat.phase} /></td>
               <td className="timing-num">{stat.count}</td>
-              <td className="timing-num">{formatDuration(stat.avg_ms)}</td>
+              <td className="timing-num">
+                <div className="stat-bar-container">
+                  <span>{formatDuration(stat.avg_ms)}</span>
+                  <span
+                    className="stat-bar"
+                    style={{
+                      width: `${Math.max((stat.avg_ms / maxAvg) * 60, 3)}px`,
+                      backgroundColor: PHASE_COLORS[stat.phase] || '#94a3b8',
+                      opacity: 0.5
+                    }}
+                  />
+                </div>
+              </td>
               <td className="timing-num">{formatDuration(stat.p50_ms)}</td>
               <td className="timing-num">{formatDuration(stat.p95_ms)}</td>
               <td className="timing-num">{formatDuration(stat.p99_ms)}</td>
@@ -80,31 +112,63 @@ function AggregateStatsTable({ aggregates }) {
   )
 }
 
+function WaterfallLegend({ entries }) {
+  const phases = [...new Set(entries.map(e => e.phase))]
+
+  return (
+    <div className="waterfall-legend">
+      {phases.map(phase => (
+        <span key={phase} className="waterfall-legend-item">
+          <span className="waterfall-legend-swatch" style={{ backgroundColor: PHASE_COLORS[phase] || '#94a3b8' }} />
+          {PHASE_LABELS[phase] || phase}
+        </span>
+      ))}
+    </div>
+  )
+}
+
 function WaterfallBar({ entries, maxDuration }) {
   if (!entries.length || !maxDuration) return null
 
-  // Find the earliest start time among all entries
   const starts = entries.map(e => new Date(e.start).getTime())
   const minStart = Math.min(...starts)
 
+  const timeMarkers = [0, maxDuration * 0.25, maxDuration * 0.5, maxDuration * 0.75, maxDuration]
+
   return (
     <div className="waterfall-chart">
+      <WaterfallLegend entries={entries} />
+
+      <div className="waterfall-time-axis">
+        <span />
+        <div className="waterfall-time-labels">
+          {timeMarkers.map((ms, idx) => (
+            <span key={idx}>{formatDuration(ms)}</span>
+          ))}
+        </div>
+        <span />
+      </div>
+
       {entries.map((entry, idx) => {
         const start = new Date(entry.start).getTime()
         const duration = entry.duration_ms || 0
         const offset = ((start - minStart) / maxDuration) * 100
         const width = (duration / maxDuration) * 100
+        const color = PHASE_COLORS[entry.phase] || '#94a3b8'
 
         return (
           <div key={idx} className="waterfall-row">
-            <span className="waterfall-label">{PHASE_LABELS[entry.phase] || entry.phase}</span>
+            <span className="waterfall-label">
+              <span className="waterfall-label-dot" style={{ backgroundColor: color }} />
+              {PHASE_LABELS[entry.phase] || entry.phase}
+            </span>
             <div className="waterfall-track">
               <div
                 className="waterfall-bar"
                 style={{
                   left: `${Math.min(offset, 98)}%`,
                   width: `${Math.max(width, 0.5)}%`,
-                  backgroundColor: PHASE_COLORS[entry.phase] || '#94a3b8'
+                  backgroundColor: color
                 }}
                 title={`${PHASE_LABELS[entry.phase] || entry.phase}: ${formatDuration(duration)}`}
               />
@@ -117,13 +181,33 @@ function WaterfallBar({ entries, maxDuration }) {
   )
 }
 
+function IssueLink({ issueId, issueTitle }) {
+  if (!issueId) return null
+
+  // Extract issue number from issue ID (e.g., "issue-42" -> 42)
+  const match = issueId.match(/(\d+)$/)
+  const displayId = match ? `#${match[1]}` : issueId
+
+  return (
+    <>
+      <span className="work-item-issue-link" title={issueTitle || issueId}>
+        {displayId}
+      </span>
+      {issueTitle && (
+        <span className="work-item-issue-title" title={issueTitle}>
+          {issueTitle}
+        </span>
+      )}
+    </>
+  )
+}
+
 function WorkItemRow({ item }) {
   const [expanded, setExpanded] = useState(false)
 
   const completedEntries = item.entries.filter(e => e.duration_ms != null)
   const totalDuration = completedEntries.reduce((sum, e) => sum + (e.duration_ms || 0), 0)
 
-  // Max duration for waterfall scaling (use total_wall_time if available, else sum)
   const wallTime = completedEntries.find(e => e.phase === 'total_wall_time')
   const maxDuration = wallTime?.duration_ms || totalDuration || 1
 
@@ -133,8 +217,13 @@ function WorkItemRow({ item }) {
         <span className="work-item-expand">
           {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         </span>
-        <span className="work-item-id">{item.work_id}</span>
-        <span className="work-item-instance">{item.instance_id}</span>
+        <div className="work-item-primary">
+          <div className="work-item-primary-row">
+            <span className="work-item-id">{item.work_id}</span>
+            <IssueLink issueId={item.issue_id} issueTitle={item.issue_title} />
+          </div>
+          <span className="work-item-instance">{item.instance_id}</span>
+        </div>
         <span className="work-item-phases">{completedEntries.length} phases</span>
         <span className="work-item-total">{formatDuration(totalDuration)}</span>
         <span className="work-item-time">{formatTimestamp(item.created_at)}</span>
@@ -145,7 +234,11 @@ function WorkItemRow({ item }) {
           <div className="work-item-entries">
             {item.entries.map((entry, idx) => (
               <div key={idx} className="entry-row">
-                <span className="entry-phase" style={{ borderLeftColor: PHASE_COLORS[entry.phase] || '#94a3b8' }}>
+                <span className="entry-phase">
+                  <span
+                    className="entry-phase-dot"
+                    style={{ backgroundColor: PHASE_COLORS[entry.phase] || '#94a3b8' }}
+                  />
                   {PHASE_LABELS[entry.phase] || entry.phase}
                 </span>
                 <span className="entry-start">{formatTimestamp(entry.start)}</span>

--- a/serving/models/timing.py
+++ b/serving/models/timing.py
@@ -35,6 +35,8 @@ class WorkItemTiming(BaseModel):
         default_factory=lambda: datetime.now(timezone.utc),
         description="When timing collection started"
     )
+    issue_id: Optional[str] = Field(None, description="Associated issue identifier")
+    issue_title: Optional[str] = Field(None, description="Associated issue title")
 
 
 class AggregateStats(BaseModel):

--- a/serving/services/timing_service.py
+++ b/serving/services/timing_service.py
@@ -247,6 +247,9 @@ class TimingService:
     async def get_dashboard(self, limit: int = 20) -> TimingDashboardResponse:
         """Get dashboard data combining recent timings and aggregates.
 
+        Enriches work items with issue context from the work map service
+        when available.
+
         Args:
             limit: Number of recent work items to show
 
@@ -255,6 +258,9 @@ class TimingService:
         """
         work_items = await self.get_recent_timings(limit)
         aggregates = await self.get_aggregate_stats(100)
+
+        # Enrich work items with issue context
+        await self._enrich_issue_context(work_items)
 
         # Count total work items
         if self._redis:
@@ -267,6 +273,32 @@ class TimingService:
             aggregates=aggregates,
             total_work_items=total,
         )
+
+    async def _enrich_issue_context(
+        self, work_items: List[WorkItemTiming]
+    ) -> None:
+        """Enrich work items with issue context from the work map service.
+
+        Looks up each work_id in the work map service to find the associated
+        issue ID and title. Modifies work items in place.
+        """
+        try:
+            from services.work_map_service import get_work_map_service
+            wm_service = get_work_map_service()
+        except (RuntimeError, ImportError):
+            logger.debug("Work map service not available for issue enrichment")
+            return
+
+        for item in work_items:
+            if item.issue_id:
+                continue  # Already has issue context
+            try:
+                work = await wm_service.get_work(item.work_id)
+                if work and work.issue_id:
+                    item.issue_id = work.issue_id
+                    item.issue_title = work.title
+            except Exception:
+                logger.debug(f"Could not look up issue for work_id={item.work_id}")
 
     # =========================================================================
     # Private helpers

--- a/serving/tests/unit/test_timing_service.py
+++ b/serving/tests/unit/test_timing_service.py
@@ -216,6 +216,68 @@ class TestDashboard:
         assert result.total_work_items == 1
 
 
+class TestIssueContext:
+    """Test issue context fields on WorkItemTiming."""
+
+    @pytest.mark.asyncio
+    async def test_work_item_timing_has_issue_fields(self, service):
+        """WorkItemTiming should have optional issue_id and issue_title."""
+        base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        await service.record_phase(
+            "work-1", "compute-1", TimingPhase.SDK_LAUNCH,
+            base, base + timedelta(seconds=2)
+        )
+
+        timing = await service.get_work_item_timing("work-1", "compute-1")
+        assert timing.issue_id is None
+        assert timing.issue_title is None
+
+    @pytest.mark.asyncio
+    async def test_dashboard_without_work_map_service(self, service):
+        """Dashboard should work when work map service is not available."""
+        base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        await service.record_phase(
+            "work-1", "compute-1", TimingPhase.SDK_LAUNCH,
+            base, base + timedelta(seconds=2)
+        )
+
+        result = await service.get_dashboard()
+        assert len(result.work_items) == 1
+        # issue_id should be None when work map service isn't available
+        assert result.work_items[0].issue_id is None
+
+    @pytest.mark.asyncio
+    async def test_dashboard_enriches_issue_context(self, service, monkeypatch):
+        """Dashboard should enrich work items with issue context from work map."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        await service.record_phase(
+            "work-1", "compute-1", TimingPhase.SDK_LAUNCH,
+            base, base + timedelta(seconds=2)
+        )
+
+        # Mock work map service
+        mock_work = MagicMock()
+        mock_work.issue_id = "issue-42"
+        mock_work.title = "Fix auth bug"
+
+        mock_wm_service = MagicMock()
+        mock_wm_service.get_work = AsyncMock(return_value=mock_work)
+
+        import services.timing_service as ts_module
+        monkeypatch.setattr(
+            "services.work_map_service.get_work_map_service",
+            lambda: mock_wm_service
+        )
+
+        result = await service.get_dashboard()
+        assert result.work_items[0].issue_id == "issue-42"
+        assert result.work_items[0].issue_title == "Fix auth bug"
+
+
 class TestMemoryEviction:
     """Test in-memory storage limits."""
 


### PR DESCRIPTION
## Summary
- Redesign phase badges as colored pills with dot indicators and background tinting for immediate scannability
- Add waterfall chart legend, time axis markers, better bar contrast (full opacity, borders on hover)
- Display associated issue ID and title in work item rows with the issue number extracted from the work item's linked issue
- Backend enriches timing dashboard data with issue context from the work map service

## Changes
- **`serving/models/timing.py`**: Add optional `issue_id` and `issue_title` fields to `WorkItemTiming`
- **`serving/services/timing_service.py`**: Add `_enrich_issue_context()` method called during `get_dashboard()` to look up work items in the work map service and populate issue fields
- **`serving/frontend/src/pages/TimingPage.jsx`**: Replace `phase-badge` with `PhasePill` component, add `WaterfallLegend` and time axis, add `IssueLink` component, restructure `WorkItemRow` layout to show issue context
- **`serving/frontend/src/pages/TimingPage.css`**: New styles for phase pills, stat bars, waterfall legend/axis, issue link, and updated grid layouts
- **`serving/tests/unit/test_timing_service.py`**: Add `TestIssueContext` class with 3 tests for issue field defaults, graceful fallback, and enrichment via mocked work map service

## Testing
- [x] Tier 1 unit tests added/updated (3 new tests in TestIssueContext)
- [x] All Tier 1 unit tests passing (`./scripts/run_unit_tests.sh`)
- [x] Frontend builds successfully (`npx vite build`)

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issues
Closes #69