### PR TITLE
feat: Remove HTTP server and port exposure from compute containers (#110)

### DIFF
--- a/.env.compute.example
+++ b/.env.compute.example
@@ -48,10 +48,8 @@ CLAUDEVN_COMPUTE_ID=compute-remote-001
 # Shown in the Serving UI and logs
 CLAUDEVN_COMPUTE_NAME=Remote-Compute
 
-# Public URL where this instance can be reached
-# Used for callbacks and status checks from Serving
-# If not set, defaults to http://compute:<COMPUTE_PORT>
-#CLAUDEVN_COMPUTE_PUBLIC_URL=http://your-host-ip:8010
+# Public URL where this instance can be reached (optional, informational only)
+#CLAUDEVN_COMPUTE_PUBLIC_URL=http://your-host-ip
 
 # ============================================
 # Registration Authentication
@@ -95,9 +93,8 @@ CLAUDEVN_RESOURCES_MEMORY=16gb
 # ============================================
 # Network Configuration
 # ============================================
-# Port to bind the compute HTTP API
-# Change this if running multiple compute instances on the same host
-COMPUTE_PORT=8010
+# No port needed — compute has no HTTP server.
+# It connects outbound to Serving via SSE.
 
 # Heartbeat interval (seconds)
 # How often to send health status to Serving
@@ -135,21 +132,19 @@ LOG_LEVEL=INFO
 # Network Requirements:
 #   - Outbound HTTP(S) access to CLAUDEVN_SERVING_URL
 #   - Outbound SSH access to Serving Git server (port 2222)
-#   - No inbound connections required (unless callbacks are configured)
+#   - No inbound connections required
 #
 # Multiple Instances:
 #   To run multiple compute instances on the same host:
 #   1. Create separate .env.compute files (.env.compute.1, .env.compute.2, etc.)
 #   2. Change CLAUDEVN_COMPUTE_ID for each instance
-#   3. Change COMPUTE_PORT for each instance
-#   4. Copy and modify docker-compose.compute.yml with unique service/container names
-#   5. Start each with: docker compose -f docker-compose.compute.yml up -d
+#   3. Copy and modify docker-compose.compute.yml with unique service/container names
+#   4. Start each with: docker compose -f docker-compose.compute.yml up -d
 #
 # Security:
 #   - Never commit .env.compute with real Serving URLs or credentials
 #   - Use TLS (HTTPS) for production — see deploy/cloud/ for Caddy setup
 #   - Consider VPN or private network for Serving access
-#   - Restrict host binding if needed (change COMPUTE_HOST in compose file)
 #
 # Troubleshooting:
 #   - Check network connectivity: curl $CLAUDEVN_SERVING_URL/api/v1/health

--- a/compute/Dockerfile
+++ b/compute/Dockerfile
@@ -1,5 +1,6 @@
 # ClaudeVN Compute Engine Dockerfile
-# v1.0: Supports MCP-based communication with Serving
+# v1.0: Standalone asyncio process — connects outbound to Serving via SSE.
+# No HTTP server, no exposed ports. Docker healthcheck uses heartbeat file.
 # Authentication: Uses host's Claude OAuth credentials via entrypoint copy from staging mount
 FROM python:3.11-slim-bookworm
 
@@ -21,6 +22,7 @@ RUN apt-get update && \
     procps \
     iputils-ping \
     netcat-openbsd \
+    findutils \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for Claude CLI (required for bypassPermissions mode)
@@ -53,12 +55,10 @@ RUN chmod +x /app/entrypoint.sh
 RUN mkdir -p data/compute logs workspace data/workspace && \
     chown -R compute:compute /app
 
-# Expose port (each instance gets a different port via docker-compose)
-EXPOSE 8003
+# No port exposed — compute connects outbound to Serving via SSE.
+# Serving never makes inbound connections to compute.
 
 # Default environment variables (overridden per instance in docker-compose)
-ENV COMPUTE_HOST=0.0.0.0
-ENV COMPUTE_PORT=8003
 ENV COMPUTE_INSTANCE_ID=compute-default
 ENV COMPUTE_INSTANCE_NAME=Compute-Instance
 ENV COMPUTE_STORAGE_PATH=/app/data/compute
@@ -84,13 +84,16 @@ ENV CLAUDEVN_SERVING_AUTH_URL=http://serving:8002/api/v1/auth
 # The entire service runs as 'compute' user (uid 1000) via gosu in entrypoint.
 # Git authentication uses HTTP tokens provisioned by Serving via SSE.
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost:${COMPUTE_PORT}/api/v1/health || exit 1
+# Heartbeat file for Docker healthcheck (updated on each SSE keepalive)
+ENV COMPUTE_HEARTBEAT_FILE=/tmp/compute-heartbeat
+
+# Health check: verify heartbeat file was updated within the last 60 seconds.
+# SSE keepalive events touch this file every 15s, so 60s allows for network hiccups.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+    CMD find /tmp/compute-heartbeat -newermt '-60 seconds' 2>/dev/null | grep -q . || exit 1
 
 # Entrypoint copies credentials from staging mount and fixes ownership
 ENTRYPOINT ["/app/entrypoint.sh"]
 
-# Run the application using shell form to expand environment variable
-CMD ["sh", "-c", "python -m uvicorn app:app --host 0.0.0.0 --port ${COMPUTE_PORT:-8003}"]
-
+# Run the compute engine as a standalone asyncio process (no HTTP server)
+CMD ["python", "app.py"]

--- a/compute/README.md
+++ b/compute/README.md
@@ -23,7 +23,7 @@ cd compute
 ./start.sh
 ```
 
-The engine will start on port 8003 (configurable) and operate in standalone mode.
+The engine will start and connect outbound to Serving via SSE.
 
 ### Integrated Mode
 
@@ -34,7 +34,7 @@ Start as part of the complete ClaudeVN platform:
 ./start_all.sh
 ```
 
-This starts Marketplace (8001), Serving (8002), and Compute (8003) together.
+This starts Marketplace (8003), Serving (8002), and Compute together.
 
 ### Stop the Engine
 
@@ -51,51 +51,45 @@ cd ..
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│           ClaudeVN Compute Engine (8003)             │
+│           ClaudeVN Compute Engine                    │
+│           (no HTTP server, no ports)                 │
 ├─────────────────────────────────────────────────────┤
 │                                                      │
-│  ┌──────────────┐         ┌────────────────┐       │
-│  │   Agents     │         │     Tools      │       │
-│  │   Registry   │         │    Registry    │       │
-│  └──────────────┘         └────────────────┘       │
-│                                                      │
 │  ┌──────────────────────────────────────────┐      │
-│  │       Registration Client                 │      │
-│  │  - Register with Serving                 │      │
-│  │  - Send heartbeats                       │      │
-│  │  - Report capabilities                   │      │
+│  │       SSE Event Client (outbound)         │      │
+│  │  - Connects to Serving SSE endpoint      │      │
+│  │  - Receives work_assigned events         │      │
+│  │  - Receives keepalive (heartbeat file)   │      │
 │  └──────────────────────────────────────────┘      │
 │                                                      │
 │  ┌──────────────────────────────────────────┐      │
-│  │          LLM Integration                  │      │
-│  │  - OpenAI, Anthropic providers           │      │
-│  │  - Fallback support                      │      │
-│  │  - Token tracking                        │      │
+│  │       Claude Code Spawner                 │      │
+│  │  - Spawns Claude Code CLI instances      │      │
+│  │  - Manages work execution lifecycle      │      │
+│  └──────────────────────────────────────────┘      │
+│                                                      │
+│  ┌──────────────────────────────────────────┐      │
+│  │       Credential Monitor                  │      │
+│  │  - Fetches credentials from Serving      │      │
+│  │  - Monitors expiry and refreshes         │      │
 │  └──────────────────────────────────────────┘      │
 │                                                      │
 └─────────────────────────────────────────────────────┘
-         │                               │
-         │ Registration                  │ Heartbeats
-         │ /api/v1/compute/register      │ /api/v1/compute/{id}/health
-         ▼                               ▼
+         │
+         │ Outbound SSE connection
+         │ GET /api/v1/compute/connect
+         ▼
 ┌─────────────────────────────────────────────────────┐
 │        Serving Component (Port 8002)                │
 │         - Compute Registry                          │
-│         - Marketplace Proxy                         │
-│         - Session Management                        │
+│         - SSE Connection Manager                    │
+│         - Work Orchestrator                         │
 └─────────────────────────────────────────────────────┘
 ```
 
 ## Configuration
 
 The compute engine is configured through environment variables:
-
-### Server Settings
-
-```bash
-COMPUTE_HOST=0.0.0.0              # Bind address
-COMPUTE_PORT=8003                  # Service port
-```
 
 ### Instance Identity
 
@@ -139,39 +133,22 @@ COMPUTE_ENABLE_GPU=false             # Enable GPU support
 LOG_LEVEL=INFO                       # Logging level
 ```
 
-## API Endpoints
+## Health Check
 
-### Health and Status
+Compute has no HTTP server. Docker healthcheck uses a **heartbeat file** mechanism:
 
-- `GET /health` - Health check with basic stats
-- `GET /stats` - Detailed statistics
-- `GET /` - Root endpoint with service info
-- `GET /version` - Version information
+1. SSE keepalive events from Serving touch `/tmp/compute-heartbeat` every ~15 seconds
+2. Docker healthcheck verifies the file was updated within the last 60 seconds
+3. If the file is stale or missing, the container is marked unhealthy
 
-### Instance Information
+For manual health checking:
+```bash
+# Check heartbeat file freshness
+docker exec claudevn-compute-1 find /tmp/compute-heartbeat -newermt '-60 seconds'
 
-- `GET /info` - Complete instance information
-- `GET /info/capabilities` - Capabilities (agents, tools, resources)
-- `GET /info/resources` - Hardware resources (CPU, memory, GPU)
-
-### Agent Management
-
-- `GET /agents` - List all agents
-- `GET /agents/{agent_id}` - Get specific agent
-- `POST /agents` - Register new agent
-- `DELETE /agents/{agent_id}` - Unregister agent
-
-### Tool Management
-
-- `GET /tools` - List all tools
-- `GET /tools/{tool_id}` - Get specific tool
-- `POST /tools` - Register new tool
-- `DELETE /tools/{tool_id}` - Unregister tool
-
-### Documentation
-
-- `GET /docs` - Interactive API documentation (Swagger UI)
-- `GET /redoc` - Alternative API documentation (ReDoc)
+# Check logs
+docker logs claudevn-compute-1
+```
 
 ## Agent Definitions
 
@@ -283,7 +260,7 @@ compute/
 │   ├── agent_registry.py    # Agent registry
 │   ├── tool_registry.py     # Tool registry
 │   └── registration_client.py  # Serving registration
-├── app.py                    # FastAPI application
+├── app.py                    # Standalone asyncio application (no HTTP server)
 ├── main.py                   # Entry point
 ├── config.py                 # Configuration
 ├── requirements.txt          # Python dependencies
@@ -336,22 +313,16 @@ See `compute/tests/integration/test_compute_serving_integration.py` for details.
 
 #### Manual Testing
 
-Test the health endpoint:
+Check the heartbeat file (inside container):
 
 ```bash
-curl http://localhost:8003/health
+docker exec claudevn-compute-1 ls -la /tmp/compute-heartbeat
 ```
 
-Test agent listing:
+Check logs:
 
 ```bash
-curl http://localhost:8003/agents
-```
-
-Get instance info:
-
-```bash
-curl http://localhost:8003/info
+docker logs claudevn-compute-1
 ```
 
 ## Integration with Serving
@@ -390,14 +361,11 @@ tail -f ../logs/compute.log
 ### Check Status
 
 ```bash
-# Health check
-curl http://localhost:8003/health
+# Check heartbeat
+docker exec claudevn-compute-1 find /tmp/compute-heartbeat -newermt '-60 seconds'
 
-# Detailed stats
-curl http://localhost:8003/stats
-
-# Instance info
-curl http://localhost:8003/info
+# Check container health
+docker inspect --format='{{.State.Health.Status}}' claudevn-compute-1
 ```
 
 ### Registration Status
@@ -409,19 +377,6 @@ curl http://localhost:8002/api/v1/compute
 ```
 
 ## Troubleshooting
-
-### Port Already in Use
-
-```bash
-# Find process using port 8003
-lsof -i :8003
-
-# Kill it
-kill -9 <PID>
-
-# Or use stop script
-./stop.sh
-```
 
 ### Registration Fails
 

--- a/compute/api/health.py
+++ b/compute/api/health.py
@@ -1,15 +1,15 @@
-"""Health check endpoints for Compute Infrastructure (v1.0)."""
+"""Health check utilities for Compute Infrastructure (v1.0).
+
+Provides health status logic used by the heartbeat file mechanism.
+No HTTP endpoints — compute has no HTTP server.
+"""
 
 import logging
-from datetime import datetime, timezone
-from fastapi import APIRouter
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v1", tags=["health"])
 
-
-def _compute_health_status(sse_connected: bool, credentials_usable: bool) -> str:
+def compute_health_status(sse_connected: bool, credentials_usable: bool) -> str:
     """Determine overall health status.
 
     Args:
@@ -24,73 +24,3 @@ def _compute_health_status(sse_connected: bool, credentials_usable: bool) -> str
     if not sse_connected and not credentials_usable:
         return "unhealthy"
     return "degraded"
-
-
-@router.get("/health")
-async def health_check():
-    """Health check endpoint.
-
-    Returns status of the compute infrastructure including credential health.
-    Used by Docker health checks.
-    """
-    from services.claude_code_spawner import get_claude_code_spawner
-    from services.sse_event_client import get_sse_event_client
-    from services.credential_monitor import get_credential_monitor
-
-    spawner = get_claude_code_spawner()
-    sse_client = get_sse_event_client()
-    cred_monitor = get_credential_monitor()
-
-    # Check if SSE client is connected
-    sse_connected = sse_client.is_connected if sse_client else False
-
-    # Check credential health
-    credentials_usable = cred_monitor.is_usable if cred_monitor else True
-    cred_status = cred_monitor.get_status() if cred_monitor else None
-
-    # Determine auth_status for serving's compute registry
-    if cred_monitor and cred_monitor.is_usable:
-        auth_status = "authorized"
-    elif cred_monitor and cred_monitor.status.value == "expired":
-        auth_status = "expired"
-    else:
-        auth_status = "unauthorized"
-
-    response = {
-        "status": _compute_health_status(sse_connected, credentials_usable),
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "architecture": "v1.0",
-        "sse_connected": sse_connected,
-        "running_instances": spawner.get_status()["running_instances"] if spawner else 0,
-        "auth_status": auth_status,
-    }
-
-    if cred_status:
-        response["credentials"] = {
-            "status": cred_status["status"],
-            "valid": cred_status["credentials_valid"],
-            "expires_at": cred_status["expires_at"],
-            "last_check": cred_status["last_check"],
-        }
-
-    return response
-
-
-@router.get("/stats")
-async def get_stats():
-    """Get detailed statistics."""
-    from services.claude_code_spawner import get_claude_code_spawner
-    from services.sse_event_client import get_sse_event_client
-    from services.credential_monitor import get_credential_monitor
-
-    spawner = get_claude_code_spawner()
-    sse_client = get_sse_event_client()
-    cred_monitor = get_credential_monitor()
-
-    return {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "spawner": spawner.get_status() if spawner else None,
-        "sse_client": sse_client.get_status() if sse_client else None,
-        "credentials": cred_monitor.get_status() if cred_monitor else None,
-    }
-

--- a/compute/app.py
+++ b/compute/app.py
@@ -1,8 +1,9 @@
 """
-FastAPI application for ClaudeVN Compute Infrastructure (v1.0).
+ClaudeVN Compute Infrastructure (v1.0) — standalone asyncio application.
 
-This is the v1.0 architecture where compute is lightweight infrastructure
-that spawns Claude Code CLI instances for work execution.
+No HTTP server. Compute connects outbound to Serving via SSE and receives
+work assignments. Docker healthcheck uses a heartbeat file updated on each
+SSE keepalive.
 """
 
 import asyncio
@@ -10,16 +11,12 @@ import os
 import signal
 import logging
 from pathlib import Path
-from contextlib import asynccontextmanager
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 
 from config import load_config, get_version
 from services.sse_event_client import initialize_sse_event_client
 from services.conflict_handler import initialize_conflict_handler
 from services.claude_code_spawner import initialize_claude_code_spawner, get_claude_code_spawner
 from services.credential_monitor import initialize_credential_monitor, get_credential_monitor
-from api import health
 
 
 # Configure logging
@@ -40,17 +37,30 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# Heartbeat file path for Docker healthcheck
+HEARTBEAT_FILE = Path(os.getenv("COMPUTE_HEARTBEAT_FILE", "/tmp/compute-heartbeat"))
+
 # Global state
 config = None
 sse_event_client = None
 conflict_handler = None
 claude_code_spawner = None
 credential_monitor = None
+_shutdown_event: asyncio.Event = None
+
+
+def _touch_heartbeat() -> None:
+    """Update heartbeat file timestamp for Docker healthcheck."""
+    try:
+        HEARTBEAT_FILE.touch()
+    except OSError:
+        pass
 
 
 async def _handle_keepalive(event_type: str, data: dict) -> None:
     """Handle keepalive events from Serving."""
     logger.debug(f"Received keepalive: {data.get('timestamp')}")
+    _touch_heartbeat()
 
 
 async def _handle_credentials_refresh(event_type: str, data: dict) -> None:
@@ -148,12 +158,10 @@ async def _async_sighup_reload() -> None:
         logger.info(f"SIGHUP credential reload complete: status={new_status.value}")
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    """Lifespan context manager for startup and shutdown events."""
+async def startup() -> None:
+    """Initialize all services."""
     global config, sse_event_client, conflict_handler, claude_code_spawner, credential_monitor
 
-    # Startup
     logger.info("Starting ClaudeVN Compute Infrastructure (v1.0)...")
 
     # Load configuration
@@ -244,11 +252,14 @@ async def lifespan(app: FastAPI):
         logger.error("Compute infrastructure cannot function without SSE connection")
         raise
 
+    # Touch heartbeat on successful startup
+    _touch_heartbeat()
+
     logger.info("Compute infrastructure started successfully")
 
-    yield
 
-    # Shutdown
+async def shutdown() -> None:
+    """Shut down all services cleanly."""
     logger.info("Shutting down Compute infrastructure...")
 
     # Stop credential monitor
@@ -282,87 +293,34 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.error(f"Error stopping SSE client: {e}")
 
+    # Remove heartbeat file on clean shutdown
+    try:
+        HEARTBEAT_FILE.unlink(missing_ok=True)
+    except OSError:
+        pass
+
     logger.info("Compute infrastructure shutdown complete")
 
 
-# Create FastAPI application
-app = FastAPI(
-    title="ClaudeVN Compute Infrastructure",
-    description="Lightweight compute infrastructure that spawns Claude Code instances (v1.0)",
-    version=get_version(),
-    lifespan=lifespan
-)
+async def main() -> None:
+    """Run the compute infrastructure as a standalone asyncio application."""
+    global _shutdown_event
+    _shutdown_event = asyncio.Event()
 
-# Add CORS middleware
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],  # In production, specify exact origins
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+    loop = asyncio.get_event_loop()
 
-# Include routers (only health endpoint needed for v1.0)
-app.include_router(health.router)
+    # Register signal handlers for graceful shutdown
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, _shutdown_event.set)
 
+    await startup()
 
-@app.get("/")
-async def root():
-    """Root endpoint."""
-    from services.claude_code_spawner import get_claude_code_spawner
-
-    spawner = get_claude_code_spawner()
-    spawner_status = spawner.get_status() if spawner else {"error": "spawner not initialized"}
-
-    return {
-        "service": "ClaudeVN Compute Infrastructure",
-        "version": get_version(),
-        "architecture": "v1.0",
-        "status": "running",
-        "compute_id": config.instance_id if config else "unknown",
-        "spawner": spawner_status,
-        "docs": "/docs",
-        "health": "/health",
-    }
-
-
-@app.get("/version")
-async def version():
-    """Get version information."""
-    return {
-        "version": get_version(),
-        "service": "compute",
-        "architecture": "v1.0"
-    }
-
-
-@app.get("/status")
-async def status():
-    """Get detailed status."""
-    from services.claude_code_spawner import get_claude_code_spawner
-    from services.sse_event_client import get_sse_event_client
-
-    spawner = get_claude_code_spawner()
-    sse_client = get_sse_event_client()
-
-    return {
-        "compute_id": config.instance_id if config else "unknown",
-        "serving_url": config.serving_url if config else "unknown",
-        "spawner": spawner.get_status() if spawner else None,
-        "sse_client": sse_client.get_status() if sse_client else None,
-    }
+    try:
+        # Wait until shutdown is signaled
+        await _shutdown_event.wait()
+    finally:
+        await shutdown()
 
 
 if __name__ == "__main__":
-    import uvicorn
-
-    # Load config for port
-    cfg = load_config()
-
-    uvicorn.run(
-        "app:app",
-        host=cfg.host,
-        port=cfg.port,
-        reload=False,
-        log_level=cfg.log_level.lower()
-    )
+    asyncio.run(main())

--- a/compute/config.py
+++ b/compute/config.py
@@ -18,10 +18,6 @@ logger = logging.getLogger(__name__)
 class ComputeConfig(BaseModel):
     """Configuration for compute infrastructure (v1.0)."""
 
-    # Server settings
-    host: str = Field(default="0.0.0.0", description="Bind host")
-    port: int = Field(default=8003, description="Bind port")
-
     # Instance identity
     instance_id: Optional[str] = Field(default=None, description="Unique compute infrastructure ID")
     instance_name: Optional[str] = Field(default=None, description="Human-readable instance name")
@@ -96,8 +92,6 @@ def load_config() -> ComputeConfig:
     """
     # Load from environment
     config = ComputeConfig(
-        host=os.getenv("CLAUDEVN_HOST", os.getenv("COMPUTE_HOST", "0.0.0.0")),
-        port=int(os.getenv("CLAUDEVN_PORT", os.getenv("COMPUTE_PORT", "8003"))),
         instance_id=os.getenv("CLAUDEVN_COMPUTE_ID", os.getenv("COMPUTE_INSTANCE_ID")),
         instance_name=os.getenv("CLAUDEVN_COMPUTE_NAME", os.getenv("COMPUTE_INSTANCE_NAME")),
         serving_url=os.getenv("CLAUDEVN_SERVING_URL", os.getenv("SERVING_URL", "http://localhost:8002")),
@@ -127,7 +121,7 @@ def load_config() -> ComputeConfig:
     # Generate instance ID if not provided
     if not config.instance_id:
         hostname = socket.gethostname()
-        config.instance_id = f"compute-{hostname}-{config.port}"
+        config.instance_id = f"compute-{hostname}"
 
     # Generate instance name if not provided
     if not config.instance_name:

--- a/compute/entrypoint.sh
+++ b/compute/entrypoint.sh
@@ -104,6 +104,6 @@ chown -R compute:compute /app/logs /app/data 2>/dev/null || true
 
 # Drop privileges and execute the main command as 'compute' user.
 # The entrypoint runs as root for credential setup (chown), then gosu drops to
-# compute for the actual service. This ensures uvicorn, the spawner, git, SSH keys,
+# compute for the actual service. This ensures the SSE client, spawner, git,
 # and Claude CLI all run as the same user — eliminating ownership mismatches.
 exec gosu compute "$@"

--- a/compute/main.py
+++ b/compute/main.py
@@ -1,73 +1,43 @@
 """
 Main entry point for ClaudeVN Compute Engine.
 
-This script starts the compute engine with proper configuration and logging.
+Runs the compute infrastructure as a standalone asyncio process.
+No HTTP server — connects outbound to Serving via SSE.
 """
 
 import sys
+import asyncio
 import logging
-from pathlib import Path
-import uvicorn
 
 from config import load_config
 
 
-def setup_logging(config):
-    """Set up logging configuration."""
+def main():
+    """Main entry point."""
+    # Load configuration for startup banner
+    config = load_config()
+
+    # Setup logging
     log_level = getattr(logging, config.log_level.upper(), logging.INFO)
-    
-    # Create log directory if specified
-    if config.log_file:
-        log_path = Path(config.log_file)
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-    
-    # Configure root logger
     logging.basicConfig(
         level=log_level,
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        handlers=[
-            logging.StreamHandler(sys.stdout),
-            logging.FileHandler(config.log_file) if config.log_file else logging.NullHandler()
-        ]
+        handlers=[logging.StreamHandler(sys.stdout)]
     )
-    
-    return logging.getLogger(__name__)
+    logger = logging.getLogger(__name__)
 
-
-def main():
-    """Main entry point."""
-    # Load configuration
-    config = load_config()
-    
-    # Setup logging
-    logger = setup_logging(config)
-    
-    logger.info("="*60)
+    logger.info("=" * 60)
     logger.info("ClaudeVN Compute Engine")
-    logger.info("="*60)
+    logger.info("=" * 60)
     logger.info(f"Instance ID: {config.instance_id}")
     logger.info(f"Instance Name: {config.instance_name}")
-    logger.info(f"Host: {config.host}")
-    logger.info(f"Port: {config.port}")
     logger.info(f"Serving URL: {config.serving_url}")
-    logger.info(f"Storage: {config.storage_path}")
-    logger.info(f"Register on startup: {config.register_on_startup}")
-    if config.agents_dir:
-        logger.info(f"Agents directory: {config.agents_dir}")
-    if config.tools_dir:
-        logger.info(f"Tools directory: {config.tools_dir}")
-    logger.info("="*60)
-    
-    # Start server
+    logger.info(f"Storage: {config.storage_path if hasattr(config, 'storage_path') else 'N/A'}")
+    logger.info("=" * 60)
+
     try:
-        uvicorn.run(
-            "app:app",
-            host=config.host,
-            port=config.port,
-            reload=False,
-            log_level=config.log_level.lower(),
-            access_log=True
-        )
+        from app import main as async_main
+        asyncio.run(async_main())
     except KeyboardInterrupt:
         logger.info("Shutting down due to keyboard interrupt...")
     except Exception as e:
@@ -77,4 +47,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/compute/requirements.txt
+++ b/compute/requirements.txt
@@ -1,8 +1,6 @@
 # ClaudeVN Compute Engine Requirements
 
 # Core dependencies
-fastapi>=0.104.0
-uvicorn[standard]>=0.24.0
 pydantic>=2.0.0
 python-dotenv>=1.0.0
 

--- a/compute/start.sh
+++ b/compute/start.sh
@@ -15,6 +15,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}========================================${NC}"
@@ -23,7 +24,6 @@ echo -e "${BLUE}========================================${NC}"
 echo ""
 
 # Configuration
-COMPUTE_PORT=${COMPUTE_PORT:-8003}
 LOG_DIR="../logs"
 PID_FILE=".compute.pid"
 
@@ -41,14 +41,6 @@ if [ -f "$PID_FILE" ]; then
         echo -e "${YELLOW}→${NC} Removing stale PID file"
         rm -f "$PID_FILE"
     fi
-fi
-
-# Check if port is in use
-if lsof -Pi :$COMPUTE_PORT -sTCP:LISTEN -t >/dev/null 2>&1 ; then
-    echo -e "${RED}✗${NC} Port ${COMPUTE_PORT} is already in use"
-    echo -e "${YELLOW}→${NC} Process using port:"
-    lsof -Pi :$COMPUTE_PORT -sTCP:LISTEN
-    exit 1
 fi
 
 # Check Python
@@ -69,7 +61,7 @@ if [ -f "../.env" ]; then
 fi
 
 # Check dependencies
-if ! python3 -c "import fastapi" 2>/dev/null; then
+if ! python3 -c "import pydantic" 2>/dev/null; then
     echo -e "${YELLOW}→${NC} Installing dependencies..."
     pip install -q -r requirements.txt
     echo -e "${GREEN}✓${NC} Dependencies installed"
@@ -93,8 +85,6 @@ echo ""
 echo -e "${CYAN}→ Starting Compute Engine...${NC}"
 
 # Set environment variables
-export COMPUTE_PORT=$COMPUTE_PORT
-export COMPUTE_HOST=0.0.0.0
 export PYTHONPATH="${PYTHONPATH}:$(pwd)"
 
 # Start the service
@@ -118,14 +108,15 @@ else
     exit 1
 fi
 
-# Wait for health check
-echo -e "${YELLOW}→${NC} Waiting for service to be ready..."
-sleep 3
+# Wait for heartbeat file (indicates SSE connection is alive)
+echo -e "${YELLOW}→${NC} Waiting for SSE connection..."
+sleep 5
 
-if curl -s -f --connect-timeout 3 --max-time 5 "http://localhost:${COMPUTE_PORT}/health" > /dev/null 2>&1; then
-    echo -e "${GREEN}✓${NC} Compute engine is healthy"
+HEARTBEAT_FILE="${COMPUTE_HEARTBEAT_FILE:-/tmp/compute-heartbeat}"
+if [ -f "$HEARTBEAT_FILE" ]; then
+    echo -e "${GREEN}✓${NC} Compute engine is healthy (SSE connected)"
 else
-    echo -e "${YELLOW}⚠${NC}  Health check pending (service may still be initializing)"
+    echo -e "${YELLOW}⚠${NC}  Heartbeat file not yet created (SSE may still be connecting)"
 fi
 
 echo ""
@@ -134,10 +125,8 @@ echo -e "${GREEN}✓ Compute Engine Running${NC}"
 echo -e "${BLUE}========================================${NC}"
 echo ""
 echo -e "${CYAN}Service Information:${NC}"
-echo -e "  API:    http://localhost:${COMPUTE_PORT}"
-echo -e "  Health: http://localhost:${COMPUTE_PORT}/health"
-echo -e "  Docs:   http://localhost:${COMPUTE_PORT}/docs"
-echo -e "  PID:    ${PID}"
+echo -e "  PID:       ${PID}"
+echo -e "  Heartbeat: ${HEARTBEAT_FILE}"
 echo ""
 echo -e "${CYAN}Logs:${NC}"
 echo -e "  ${LOG_DIR}/compute.log"
@@ -146,4 +135,3 @@ echo -e "${CYAN}Management:${NC}"
 echo -e "  Stop:      ${YELLOW}./stop.sh${NC}"
 echo -e "  View logs: ${YELLOW}tail -f ${LOG_DIR}/compute.log${NC}"
 echo ""
-

--- a/compute/stop.sh
+++ b/compute/stop.sh
@@ -15,23 +15,22 @@ echo -e "${BLUE}========================================${NC}"
 echo ""
 
 PID_FILE=".compute.pid"
-COMPUTE_PORT=${COMPUTE_PORT:-8003}
 
 # Function to kill process safely
 kill_process() {
     local pid=$1
-    
+
     if ps -p $pid > /dev/null 2>&1; then
         echo -e "${YELLOW}→${NC} Stopping compute engine (PID: ${pid})..."
         kill -15 $pid 2>/dev/null || true
         sleep 2
-        
+
         # Force kill if still running
         if ps -p $pid > /dev/null 2>&1; then
             echo -e "${YELLOW}→${NC} Force stopping..."
             kill -9 $pid 2>/dev/null || true
         fi
-        
+
         if ! ps -p $pid > /dev/null 2>&1; then
             echo -e "${GREEN}✓${NC} Compute engine stopped"
             return 0
@@ -54,18 +53,12 @@ else
     echo -e "${YELLOW}⚠${NC}  No PID file found"
 fi
 
-# Also check port for any remaining processes
-if lsof -Pi :$COMPUTE_PORT -sTCP:LISTEN -t >/dev/null 2>&1 ; then
-    echo -e "${YELLOW}→${NC} Found process on port ${COMPUTE_PORT}"
-    PIDS=$(lsof -Pi :$COMPUTE_PORT -sTCP:LISTEN -t)
-    for PID in $PIDS; do
-        kill_process $PID
-    done
-fi
+# Clean up heartbeat file
+HEARTBEAT_FILE="${COMPUTE_HEARTBEAT_FILE:-/tmp/compute-heartbeat}"
+rm -f "$HEARTBEAT_FILE" 2>/dev/null
 
 echo ""
 echo -e "${BLUE}========================================${NC}"
 echo -e "${GREEN}✓ Compute Engine Stopped${NC}"
 echo -e "${BLUE}========================================${NC}"
 echo ""
-

--- a/compute/tests/test_heartbeat_healthcheck.py
+++ b/compute/tests/test_heartbeat_healthcheck.py
@@ -1,0 +1,115 @@
+"""Tests for heartbeat-based Docker healthcheck mechanism (#110)."""
+
+import asyncio
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+
+class TestHeartbeatFile:
+    """Verify the heartbeat file mechanism for Docker healthcheck."""
+
+    def test_touch_heartbeat_creates_file(self, tmp_path):
+        """_touch_heartbeat should create the heartbeat file."""
+        heartbeat_file = tmp_path / "heartbeat"
+        with patch("app.HEARTBEAT_FILE", heartbeat_file):
+            from app import _touch_heartbeat
+            _touch_heartbeat()
+            assert heartbeat_file.exists()
+
+    def test_touch_heartbeat_updates_mtime(self, tmp_path):
+        """_touch_heartbeat should update the file's modification time."""
+        heartbeat_file = tmp_path / "heartbeat"
+        heartbeat_file.touch()
+        old_mtime = heartbeat_file.stat().st_mtime
+
+        # Small delay to ensure mtime changes
+        time.sleep(0.05)
+
+        with patch("app.HEARTBEAT_FILE", heartbeat_file):
+            from app import _touch_heartbeat
+            _touch_heartbeat()
+            new_mtime = heartbeat_file.stat().st_mtime
+            assert new_mtime >= old_mtime
+
+    def test_touch_heartbeat_handles_permission_error(self, tmp_path):
+        """_touch_heartbeat should not raise on OSError."""
+        # Use a path that can't be written
+        heartbeat_file = Path("/nonexistent/dir/heartbeat")
+        with patch("app.HEARTBEAT_FILE", heartbeat_file):
+            from app import _touch_heartbeat
+            # Should not raise
+            _touch_heartbeat()
+
+
+class TestKeepaliveHandler:
+    """Verify keepalive handler touches heartbeat file."""
+
+    @pytest.mark.asyncio
+    async def test_keepalive_touches_heartbeat(self, tmp_path):
+        """Keepalive events should update the heartbeat file."""
+        heartbeat_file = tmp_path / "heartbeat"
+        with patch("app.HEARTBEAT_FILE", heartbeat_file):
+            from app import _handle_keepalive
+            await _handle_keepalive("keepalive", {"timestamp": "2026-03-02T00:00:00Z"})
+            assert heartbeat_file.exists()
+
+
+class TestHealthStatusFunction:
+    """Test the compute_health_status utility."""
+
+    def test_healthy_when_connected_and_credentials_valid(self):
+        from api.health import compute_health_status
+        assert compute_health_status(True, True) == "healthy"
+
+    def test_unhealthy_when_disconnected_and_no_credentials(self):
+        from api.health import compute_health_status
+        assert compute_health_status(False, False) == "unhealthy"
+
+    def test_degraded_when_only_sse_connected(self):
+        from api.health import compute_health_status
+        assert compute_health_status(True, False) == "degraded"
+
+    def test_degraded_when_only_credentials_valid(self):
+        from api.health import compute_health_status
+        assert compute_health_status(False, True) == "degraded"
+
+
+class TestAppHasNoFastAPI:
+    """Verify FastAPI has been removed from compute."""
+
+    def test_no_fastapi_import(self):
+        """app.py should not import FastAPI."""
+        import importlib
+        source_path = Path(__file__).parent.parent / "app.py"
+        source = source_path.read_text()
+        assert "from fastapi" not in source
+        assert "import fastapi" not in source
+
+    def test_no_uvicorn_import(self):
+        """app.py should not import uvicorn."""
+        source_path = Path(__file__).parent.parent / "app.py"
+        source = source_path.read_text()
+        assert "import uvicorn" not in source
+
+    def test_no_fastapi_in_requirements(self):
+        """requirements.txt should not contain fastapi."""
+        req_path = Path(__file__).parent.parent / "requirements.txt"
+        source = req_path.read_text()
+        assert "fastapi" not in source
+        assert "uvicorn" not in source
+
+
+class TestConfigNoPort:
+    """Verify port/host fields removed from config."""
+
+    def test_config_has_no_port_field(self):
+        from config import ComputeConfig
+        assert not hasattr(ComputeConfig.model_fields, "port") or "port" not in ComputeConfig.model_fields
+
+    def test_config_has_no_host_field(self):
+        from config import ComputeConfig
+        assert not hasattr(ComputeConfig.model_fields, "host") or "host" not in ComputeConfig.model_fields

--- a/docker-compose.compute.yml
+++ b/docker-compose.compute.yml
@@ -12,7 +12,7 @@
 #
 # Prerequisites:
 #   - Accessible Serving instance (configure CLAUDEVN_SERVING_URL in .env.compute)
-#   - Network connectivity to Serving (HTTP + SSH Git port 2222)
+#   - Network connectivity to Serving (HTTPS outbound only)
 #   - Full repository checkout (for build context)
 #
 # Authentication Modes:
@@ -21,7 +21,7 @@
 #
 # Scaling:
 #   To run multiple compute instances, edit .env.compute and duplicate this file
-#   with unique CLAUDEVN_COMPUTE_ID, COMPUTE_PORT, and container_name values.
+#   with unique CLAUDEVN_COMPUTE_ID and container_name values.
 #
 # Note on env_file vs environment:
 #   env_file injects vars into the container runtime only - NOT into compose ${} interpolation.
@@ -31,11 +31,8 @@
 
 services:
   # Remote Compute Instance
-  # NOTE: No host port mapping. In the SSE architecture, Serving never makes
-  # inbound connections to Compute. Compute connects outbound to Serving via SSE.
-  # The internal port is used only for container healthchecks (docker network).
-  # To access the Compute health API for debugging, use:
-  #   docker exec claudevn-compute-remote curl http://localhost:8010/api/v1/health
+  # No HTTP server, no ports. Connects outbound to Serving via SSE.
+  # Healthcheck uses heartbeat file updated on each SSE keepalive.
   compute:
     build:
       context: .
@@ -44,8 +41,7 @@ services:
     env_file:
       - .env.compute
     environment:
-      # Hardcoded server binding defaults (not user-configurable via .env.compute)
-      - COMPUTE_HOST=0.0.0.0
+      # Hardcoded defaults (not user-configurable via .env.compute)
       - COMPUTE_STORAGE_PATH=/app/data/compute
       - COMPUTE_LOG_FILE=/app/logs/compute.log
 
@@ -53,7 +49,7 @@ services:
       - COMPUTE_REGISTER_ON_STARTUP=true
       - MCP_ENABLED=true
 
-      # All other vars (COMPUTE_PORT, COMPUTE_INSTANCE_ID, COMPUTE_INSTANCE_NAME,
+      # All other vars (COMPUTE_INSTANCE_ID, COMPUTE_INSTANCE_NAME,
       # SERVING_URL, CLAUDEVN_SERVING_URL, CLAUDEVN_SERVING_AUTH_URL,
       # COMPUTE_HEARTBEAT_INTERVAL, COMPUTE_SKILLS, COMPUTE_CAPABILITIES,
       # CLAUDEVN_RESOURCES_CPU, CLAUDEVN_RESOURCES_MEMORY, COMPUTE_AUTH_MODE,
@@ -67,13 +63,6 @@ services:
     volumes:
       - compute_data:/app/data
       - compute_logs:/app/logs
-
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8010/api/v1/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
 
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,19 +151,14 @@ services:
     restart: unless-stopped
 
   # Compute Instance 1 - Code Writer specialist
-  # NOTE: No host port mapping. In the SSE architecture, Serving never makes
-  # inbound connections to Compute. Compute connects outbound to Serving via SSE.
-  # The internal port is used only for container healthchecks (docker network).
-  # To access the Compute health API for debugging, use:
-  #   docker exec claudevn-compute-1 curl http://localhost:8010/api/v1/health
+  # No HTTP server, no ports. Connects outbound to Serving via SSE.
+  # Healthcheck uses heartbeat file updated on each SSE keepalive.
   compute-1:
     build:
       context: .
       dockerfile: compute/Dockerfile
     container_name: claudevn-compute-1
     environment:
-      - COMPUTE_HOST=0.0.0.0
-      - COMPUTE_PORT=8010
       - COMPUTE_INSTANCE_ID=compute-001
       - COMPUTE_INSTANCE_NAME=Compute-CodeWriter
       - COMPUTE_STORAGE_PATH=/app/data/compute
@@ -191,24 +186,15 @@ services:
     depends_on:
       serving:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8010/api/v1/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
     restart: unless-stopped
 
   # Compute Instance 2 - Debugger specialist (TEMPORARILY DISABLED)
-  # NOTE: No host port mapping — see compute-1 comment above.
   compute-2:
     build:
       context: .
       dockerfile: compute/Dockerfile
     container_name: claudevn-compute-2
     environment:
-      - COMPUTE_HOST=0.0.0.0
-      - COMPUTE_PORT=8011
       - COMPUTE_INSTANCE_ID=compute-002
       - COMPUTE_INSTANCE_NAME=Compute-Debugger
       - COMPUTE_STORAGE_PATH=/app/data/compute
@@ -234,24 +220,15 @@ services:
     depends_on:
       serving:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8011/api/v1/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
     restart: unless-stopped
 
   # Compute Instance 3 - Documentation specialist (TEMPORARILY DISABLED)
-  # NOTE: No host port mapping — see compute-1 comment above.
   # compute-3:
   #   build:
   #     context: .
   #     dockerfile: compute/Dockerfile
   #   container_name: claudevn-compute-3
   #   environment:
-  #     - COMPUTE_HOST=0.0.0.0
-  #     - COMPUTE_PORT=8012
   #     - COMPUTE_INSTANCE_ID=compute-003
   #     - COMPUTE_INSTANCE_NAME=Compute-DocWriter
   #     - COMPUTE_STORAGE_PATH=/app/data/compute
@@ -277,12 +254,6 @@ services:
   #   depends_on:
   #     serving:
   #       condition: service_healthy
-  #   healthcheck:
-  #     test: ["CMD", "curl", "-f", "http://localhost:8012/api/v1/health"]
-  #     interval: 30s
-  #     timeout: 10s
-  #     retries: 3
-  #     start_period: 30s
   #   restart: unless-stopped
 
 # Named volumes for data persistence


### PR DESCRIPTION
## Summary
- Remove unnecessary FastAPI/uvicorn HTTP server from compute containers
- Compute now runs as a standalone asyncio process with SSE-only outbound communication
- Docker healthcheck uses heartbeat file mechanism instead of HTTP endpoint

## Changes
- **compute/app.py**: Rewritten as standalone asyncio application (no FastAPI)
- **compute/Dockerfile**: Removed `EXPOSE`, `COMPUTE_HOST`, `COMPUTE_PORT`; heartbeat-file healthcheck
- **compute/requirements.txt**: Removed `fastapi` and `uvicorn` dependencies
- **compute/config.py**: Removed `host` and `port` fields from `ComputeConfig`
- **compute/api/health.py**: Converted from FastAPI router to utility function
- **compute/main.py**: Removed uvicorn, runs asyncio directly
- **compute/entrypoint.sh**: Updated comments
- **compute/start.sh, stop.sh**: Removed port references, added heartbeat file support
- **docker-compose.yml**: Removed all compute port mappings and `COMPUTE_HOST`/`COMPUTE_PORT` env vars
- **docker-compose.compute.yml**: Same cleanup for remote compute template
- **.env.compute.example**: Removed `COMPUTE_PORT`, updated notes
- **compute/README.md**: Updated architecture diagram, removed HTTP API docs, added heartbeat healthcheck docs

## Healthcheck Mechanism
SSE keepalive events (every 15s) touch `/tmp/compute-heartbeat`. Docker healthcheck verifies the file was updated within 60 seconds using `find -newermt`. This validates the SSE connection is alive, not just that a process exists.

## Testing
- [x] 13 new unit tests for heartbeat mechanism, health status function, and FastAPI removal verification
- [x] All 11 existing compute config tests passing
- [x] All Tier 1 unit tests passing

## Issues
Closes #110