### PR TITLE
feat: Timing dashboard v3 - dark theme fix and issue-based restructure (#105)

### DIFF
--- a/serving/frontend/src/pages/TimingPage.css
+++ b/serving/frontend/src/pages/TimingPage.css
@@ -1,8 +1,52 @@
 /* Timing Page Styles */
 
+/* Project Summary Banner */
+.timing-project-summary {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1rem 1.25rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  margin-bottom: 1.5rem;
+}
+
+.timing-project-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.timing-project-stat-label {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.timing-project-stat-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+
+.timing-project-stat-value.accent {
+  color: var(--primary);
+}
+
+.timing-project-divider {
+  width: 1px;
+  height: 32px;
+  background: var(--border);
+}
+
 .timing-total-count {
   font-size: 0.85rem;
-  color: var(--color-text-secondary, #64748b);
+  color: var(--text-secondary);
   margin-left: 0.75rem;
 }
 
@@ -11,7 +55,7 @@
 }
 
 .timing-empty {
-  color: var(--color-text-secondary, #64748b);
+  color: var(--text-muted);
   font-size: 0.9rem;
   padding: 1.5rem;
   text-align: center;
@@ -31,8 +75,8 @@
 .timing-table th {
   text-align: left;
   padding: 0.5rem 0.75rem;
-  border-bottom: 2px solid var(--color-border, #e2e8f0);
-  color: var(--color-text-secondary, #64748b);
+  border-bottom: 2px solid var(--border);
+  color: var(--text-muted);
   font-weight: 600;
   font-size: 0.8rem;
   text-transform: uppercase;
@@ -41,18 +85,20 @@
 
 .timing-table td {
   padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid var(--color-border-light, #f1f5f9);
+  border-bottom: 1px solid var(--border-light);
+  color: var(--text);
 }
 
 .timing-table tbody tr:hover {
-  background: var(--color-bg-hover, #f8fafc);
+  background: var(--bg-hover);
 }
 
 .timing-num {
   text-align: right;
   font-variant-numeric: tabular-nums;
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.82rem;
+  color: var(--text);
 }
 
 /* Phase Pill - bold color treatment */
@@ -87,273 +133,292 @@
   min-width: 2px;
 }
 
-/* Work Items List */
-.work-items-list {
+/* Issue Groups */
+.issue-groups-list {
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  background: var(--color-border-light, #f1f5f9);
-  border: 1px solid var(--color-border, #e2e8f0);
-  border-radius: 6px;
+  gap: 0.5rem;
+}
+
+.issue-group {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
   overflow: hidden;
 }
 
-.work-item-row {
-  background: var(--color-bg, #fff);
-}
-
-.work-item-header {
-  display: grid;
-  grid-template-columns: 20px 1fr auto auto auto;
+.issue-group-header {
+  display: flex;
   align-items: center;
   gap: 0.75rem;
   padding: 0.6rem 0.75rem;
   cursor: pointer;
   font-size: 0.85rem;
+  transition: background 150ms ease;
 }
 
-.work-item-header:hover {
-  background: var(--color-bg-hover, #f8fafc);
+.issue-group-header:hover {
+  background: var(--bg-hover);
 }
 
-.work-item-expand {
-  color: var(--color-text-secondary, #64748b);
+.issue-group-expand {
+  color: var(--text-muted);
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
-.work-item-primary {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  overflow: hidden;
-}
-
-.work-item-primary-row {
+.issue-group-primary {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
 }
 
-.work-item-id {
-  font-weight: 600;
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+.issue-group-id {
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--primary);
+  white-space: nowrap;
+}
+
+.issue-group-title {
   font-size: 0.82rem;
+  color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.work-item-issue-link {
+.issue-group-no-issue {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.issue-group-stats {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-shrink: 0;
+}
+
+.issue-group-calls {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.issue-group-duration {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  white-space: nowrap;
+  color: var(--text);
+}
+
+.issue-group-time {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+/* Issue Group Detail (Expanded) */
+.issue-group-detail {
+  border-top: 1px solid var(--border-light);
+}
+
+/* Tool Call Rows */
+.tool-call-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.tool-call-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.45rem 0.75rem 0.45rem 2.25rem;
+  font-size: 0.82rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.tool-call-row:last-child {
+  border-bottom: none;
+}
+
+.tool-call-row:hover {
+  background: var(--bg-hover);
+}
+
+.tool-call-name {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.tool-call-label {
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tool-call-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.65rem;
   font-weight: 600;
-  font-size: 0.82rem;
-  color: var(--color-primary, #3b82f6);
-  text-decoration: none;
-  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
 }
 
-.work-item-issue-link:hover {
-  text-decoration: underline;
-  color: var(--color-primary-hover, #2563eb);
+.tool-call-badge.mcp {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10b981;
 }
 
-.work-item-issue-title {
-  font-size: 0.8rem;
-  color: var(--color-text-secondary, #64748b);
+.tool-call-badge.phase {
+  background: rgba(99, 102, 241, 0.15);
+  color: #818cf8;
+}
+
+.tool-call-duration-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 140px;
+}
+
+.duration-bar-track {
+  flex: 1;
+  height: 4px;
+  background: var(--border-light);
+  border-radius: 2px;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.work-item-instance {
-  color: var(--color-text-tertiary, #94a3b8);
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
-  font-size: 0.75rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.duration-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  min-width: 2px;
 }
 
-.work-item-phases {
-  color: var(--color-text-secondary, #64748b);
-  font-size: 0.8rem;
-  white-space: nowrap;
-}
-
-.work-item-total {
+.tool-call-duration {
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
-  font-size: 0.82rem;
-  white-space: nowrap;
-}
-
-.work-item-time {
-  color: var(--color-text-secondary, #64748b);
+  font-family: var(--font-mono);
   font-size: 0.8rem;
   white-space: nowrap;
+  color: var(--text);
+  min-width: 50px;
+  text-align: right;
 }
 
-/* Work Item Detail (Expanded) */
-.work-item-detail {
-  padding: 0.75rem 1rem 1rem;
-  background: var(--color-bg-subtle, #f8fafc);
-  border-top: 1px solid var(--color-border-light, #f1f5f9);
+.tool-call-duration.long-running {
+  color: var(--status-offline);
 }
 
-/* Waterfall Chart */
-.waterfall-chart {
+.tool-call-time {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.tool-call-meta {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  grid-column: 1 / -1;
+  padding-left: 0;
+}
+
+/* Section header */
+.section-header {
   margin-bottom: 0.75rem;
 }
 
-/* Waterfall legend */
-.waterfall-legend {
+.section-title {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-bottom: 0.5rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--color-border-light, #f1f5f9);
-}
-
-.waterfall-legend-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  font-size: 0.72rem;
-  color: var(--color-text-secondary, #64748b);
-}
-
-.waterfall-legend-swatch {
-  width: 10px;
-  height: 10px;
-  border-radius: 2px;
-}
-
-/* Waterfall time axis */
-.waterfall-time-axis {
-  display: grid;
-  grid-template-columns: 140px 1fr 60px;
-  gap: 0.5rem;
-  margin-bottom: 0.25rem;
-}
-
-.waterfall-time-labels {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.7rem;
-  color: var(--color-text-tertiary, #94a3b8);
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
-}
-
-.waterfall-row {
-  display: grid;
-  grid-template-columns: 140px 1fr 60px;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.25rem 0;
-}
-
-.waterfall-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  font-size: 0.8rem;
-  font-weight: 500;
-  text-align: right;
-  white-space: nowrap;
-  justify-content: flex-end;
-}
-
-.waterfall-label-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.waterfall-track {
-  position: relative;
-  height: 20px;
-  background: var(--color-bg, #fff);
-  border-radius: 3px;
-  overflow: hidden;
-  border: 1px solid var(--color-border-light, #f1f5f9);
-}
-
-.waterfall-bar {
-  position: absolute;
-  top: 2px;
-  height: 16px;
-  border-radius: 3px;
-  min-width: 3px;
-  transition: opacity 0.15s;
-}
-
-.waterfall-bar:hover {
-  opacity: 0.8;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
-}
-
-.waterfall-duration {
-  font-size: 0.8rem;
-  font-weight: 500;
-  font-variant-numeric: tabular-nums;
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
-  text-align: right;
-}
-
-/* Entry Rows */
-.work-item-entries {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.entry-row {
-  display: grid;
-  grid-template-columns: 160px 80px 70px 1fr;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem 0;
-  font-size: 0.8rem;
-}
-
-.entry-phase {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  font-weight: 500;
-  font-size: 0.8rem;
-}
-
-.entry-phase-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.entry-start {
-  color: var(--color-text-secondary, #64748b);
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
-  font-size: 0.78rem;
-}
-
-.entry-duration {
+  font-size: var(--font-size-lg);
   font-weight: 600;
-  font-variant-numeric: tabular-nums;
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
-  font-size: 0.78rem;
+  color: var(--text);
 }
 
-.entry-meta {
-  color: var(--color-text-tertiary, #94a3b8);
-  font-size: 0.75rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+/* Page header content */
+.page-header-content {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.page-header-content .page-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Refresh button */
+.refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  transition: all 150ms ease;
+}
+
+.refresh-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.refresh-btn .spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* Error banner */
+.error-banner {
+  padding: 0.75rem 1rem;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-md);
+  color: #fca5a5;
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
+}
+
+/* Loading container */
+.loading-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
 }

--- a/serving/frontend/src/pages/TimingPage.jsx
+++ b/serving/frontend/src/pages/TimingPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { RefreshCw, Clock, BarChart3, Timer, ChevronDown, ChevronRight } from 'lucide-react'
 import Spinner from '../components/common/Spinner'
 import useTiming from '../hooks/useTiming'
@@ -25,14 +25,16 @@ const PHASE_COLORS = {
 }
 
 const PHASE_BG_COLORS = {
-  workspace_setup: 'rgba(59, 130, 246, 0.1)',
-  repo_clone: 'rgba(139, 92, 246, 0.1)',
-  sdk_launch: 'rgba(245, 158, 11, 0.1)',
-  mcp_tool_call: 'rgba(16, 185, 129, 0.1)',
-  api_inference: 'rgba(239, 68, 68, 0.1)',
-  git_push: 'rgba(99, 102, 241, 0.1)',
-  total_wall_time: 'rgba(100, 116, 139, 0.1)'
+  workspace_setup: 'rgba(59, 130, 246, 0.15)',
+  repo_clone: 'rgba(139, 92, 246, 0.15)',
+  sdk_launch: 'rgba(245, 158, 11, 0.15)',
+  mcp_tool_call: 'rgba(16, 185, 129, 0.15)',
+  api_inference: 'rgba(239, 68, 68, 0.15)',
+  git_push: 'rgba(99, 102, 241, 0.15)',
+  total_wall_time: 'rgba(100, 116, 139, 0.15)'
 }
+
+const LONG_RUNNING_THRESHOLD_MS = 90000
 
 function formatDuration(ms) {
   if (ms == null) return '-'
@@ -47,9 +49,29 @@ function formatTimestamp(ts) {
   return d.toLocaleTimeString()
 }
 
+/** Strip common prefixes from MCP tool names (e.g. "claudevn_get_context" -> "get_context") */
+function cleanToolName(name) {
+  if (!name) return name
+  return name.replace(/^claudevn_/, '')
+}
+
+/** Check if an entry's metadata indicates it's an MCP tool call */
+function isMcpEntry(entry) {
+  if (entry.phase === 'mcp_tool_call') return true
+  const meta = entry.metadata || {}
+  return meta.tool_name?.startsWith('claudevn_') || false
+}
+
+/** Get display name for an entry */
+function getEntryDisplayName(entry) {
+  const meta = entry.metadata || {}
+  if (meta.tool_name) return cleanToolName(meta.tool_name)
+  return PHASE_LABELS[entry.phase] || entry.phase
+}
+
 function PhasePill({ phase }) {
   const color = PHASE_COLORS[phase] || '#94a3b8'
-  const bgColor = PHASE_BG_COLORS[phase] || 'rgba(148, 163, 184, 0.1)'
+  const bgColor = PHASE_BG_COLORS[phase] || 'rgba(148, 163, 184, 0.15)'
 
   return (
     <span className="phase-pill" style={{ backgroundColor: bgColor, color }}>
@@ -94,7 +116,7 @@ function AggregateStatsTable({ aggregates }) {
                     style={{
                       width: `${Math.max((stat.avg_ms / maxAvg) * 60, 3)}px`,
                       backgroundColor: PHASE_COLORS[stat.phase] || '#94a3b8',
-                      opacity: 0.5
+                      opacity: 0.6
                     }}
                   />
                 </div>
@@ -112,143 +134,140 @@ function AggregateStatsTable({ aggregates }) {
   )
 }
 
-function WaterfallLegend({ entries }) {
-  const phases = [...new Set(entries.map(e => e.phase))]
+function ProjectSummary({ workItems, totalWorkItems }) {
+  const totalDuration = workItems.reduce((sum, item) => {
+    const wall = item.entries.find(e => e.phase === 'total_wall_time')
+    return sum + (wall?.duration_ms || 0)
+  }, 0)
+
+  const issueCount = new Set(
+    workItems.filter(i => i.issue_id).map(i => i.issue_id)
+  ).size
 
   return (
-    <div className="waterfall-legend">
-      {phases.map(phase => (
-        <span key={phase} className="waterfall-legend-item">
-          <span className="waterfall-legend-swatch" style={{ backgroundColor: PHASE_COLORS[phase] || '#94a3b8' }} />
-          {PHASE_LABELS[phase] || phase}
-        </span>
-      ))}
-    </div>
-  )
-}
-
-function WaterfallBar({ entries, maxDuration }) {
-  if (!entries.length || !maxDuration) return null
-
-  const starts = entries.map(e => new Date(e.start).getTime())
-  const minStart = Math.min(...starts)
-
-  const timeMarkers = [0, maxDuration * 0.25, maxDuration * 0.5, maxDuration * 0.75, maxDuration]
-
-  return (
-    <div className="waterfall-chart">
-      <WaterfallLegend entries={entries} />
-
-      <div className="waterfall-time-axis">
-        <span />
-        <div className="waterfall-time-labels">
-          {timeMarkers.map((ms, idx) => (
-            <span key={idx}>{formatDuration(ms)}</span>
-          ))}
-        </div>
-        <span />
+    <div className="timing-project-summary">
+      <div className="timing-project-stat">
+        <span className="timing-project-stat-label">Total Time</span>
+        <span className="timing-project-stat-value accent">{formatDuration(totalDuration)}</span>
       </div>
-
-      {entries.map((entry, idx) => {
-        const start = new Date(entry.start).getTime()
-        const duration = entry.duration_ms || 0
-        const offset = ((start - minStart) / maxDuration) * 100
-        const width = (duration / maxDuration) * 100
-        const color = PHASE_COLORS[entry.phase] || '#94a3b8'
-
-        return (
-          <div key={idx} className="waterfall-row">
-            <span className="waterfall-label">
-              <span className="waterfall-label-dot" style={{ backgroundColor: color }} />
-              {PHASE_LABELS[entry.phase] || entry.phase}
-            </span>
-            <div className="waterfall-track">
-              <div
-                className="waterfall-bar"
-                style={{
-                  left: `${Math.min(offset, 98)}%`,
-                  width: `${Math.max(width, 0.5)}%`,
-                  backgroundColor: color
-                }}
-                title={`${PHASE_LABELS[entry.phase] || entry.phase}: ${formatDuration(duration)}`}
-              />
-            </div>
-            <span className="waterfall-duration">{formatDuration(duration)}</span>
-          </div>
-        )
-      })}
+      <div className="timing-project-divider" />
+      <div className="timing-project-stat">
+        <span className="timing-project-stat-label">Issues</span>
+        <span className="timing-project-stat-value">{issueCount}</span>
+      </div>
+      <div className="timing-project-divider" />
+      <div className="timing-project-stat">
+        <span className="timing-project-stat-label">Work Items</span>
+        <span className="timing-project-stat-value">{totalWorkItems}</span>
+      </div>
     </div>
   )
 }
 
-function IssueLink({ issueId, issueTitle }) {
-  if (!issueId) return null
+function ToolCallRow({ entry, maxDuration }) {
+  const displayName = getEntryDisplayName(entry)
+  const mcp = isMcpEntry(entry)
+  const duration = entry.duration_ms || 0
+  const isLong = duration >= LONG_RUNNING_THRESHOLD_MS
+  const barPercent = maxDuration > 0 ? Math.min((duration / maxDuration) * 100, 100) : 0
+  const color = isLong ? '#ef4444' : (PHASE_COLORS[entry.phase] || '#94a3b8')
 
-  // Extract issue number from issue ID (e.g., "issue-42" -> 42)
-  const match = issueId.match(/(\d+)$/)
-  const displayId = match ? `#${match[1]}` : issueId
+  const meta = entry.metadata || {}
+  const metaEntries = Object.entries(meta).filter(([k]) => k !== 'tool_name')
 
   return (
     <>
-      <span className="work-item-issue-link" title={issueTitle || issueId}>
-        {displayId}
-      </span>
-      {issueTitle && (
-        <span className="work-item-issue-title" title={issueTitle}>
-          {issueTitle}
+      <div className="tool-call-row">
+        <div className="tool-call-name">
+          <span className="tool-call-label">{displayName}</span>
+          {mcp && <span className="tool-call-badge mcp">MCP</span>}
+          {!mcp && entry.phase !== 'total_wall_time' && (
+            <span className="tool-call-badge phase">{PHASE_LABELS[entry.phase] || entry.phase}</span>
+          )}
+        </div>
+        <div className="tool-call-duration-bar">
+          <div className="duration-bar-track">
+            <div
+              className="duration-bar-fill"
+              style={{
+                width: `${Math.max(barPercent, 1)}%`,
+                backgroundColor: color
+              }}
+            />
+          </div>
+        </div>
+        <span className={`tool-call-duration${isLong ? ' long-running' : ''}`}>
+          {formatDuration(duration)}
         </span>
+      </div>
+      {metaEntries.length > 0 && (
+        <div className="tool-call-row" style={{ paddingTop: 0 }}>
+          <span className="tool-call-meta">
+            {metaEntries.map(([k, v]) => `${k}=${v}`).join(', ')}
+          </span>
+        </div>
       )}
     </>
   )
 }
 
-function WorkItemRow({ item }) {
+function IssueGroup({ issueKey, issueId, issueTitle, items }) {
   const [expanded, setExpanded] = useState(false)
 
-  const completedEntries = item.entries.filter(e => e.duration_ms != null)
-  const totalDuration = completedEntries.reduce((sum, e) => sum + (e.duration_ms || 0), 0)
+  // Collect all entries across work items for this issue (excluding total_wall_time)
+  const allEntries = items.flatMap(item =>
+    item.entries.filter(e => e.duration_ms != null && e.phase !== 'total_wall_time')
+  )
 
-  const wallTime = completedEntries.find(e => e.phase === 'total_wall_time')
-  const maxDuration = wallTime?.duration_ms || totalDuration || 1
+  const totalDuration = allEntries.reduce((sum, e) => sum + (e.duration_ms || 0), 0)
+  const maxEntryDuration = allEntries.length > 0
+    ? Math.max(...allEntries.map(e => e.duration_ms || 0))
+    : 1
+
+  // Extract issue display ID
+  const displayId = issueId
+    ? (() => {
+        const match = issueId.match(/(\d+)$/)
+        return match ? `#${match[1]}` : issueId
+      })()
+    : null
+
+  const latestTime = items.length > 0
+    ? items.reduce((latest, item) => {
+        const t = new Date(item.created_at).getTime()
+        return t > latest ? t : latest
+      }, 0)
+    : null
 
   return (
-    <div className="work-item-row">
-      <div className="work-item-header" onClick={() => setExpanded(!expanded)}>
-        <span className="work-item-expand">
+    <div className="issue-group">
+      <div className="issue-group-header" onClick={() => setExpanded(!expanded)}>
+        <span className="issue-group-expand">
           {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         </span>
-        <div className="work-item-primary">
-          <div className="work-item-primary-row">
-            <span className="work-item-id">{item.work_id}</span>
-            <IssueLink issueId={item.issue_id} issueTitle={item.issue_title} />
-          </div>
-          <span className="work-item-instance">{item.instance_id}</span>
+        <div className="issue-group-primary">
+          {displayId ? (
+            <>
+              <span className="issue-group-id">{displayId}</span>
+              {issueTitle && <span className="issue-group-title">{issueTitle}</span>}
+            </>
+          ) : (
+            <span className="issue-group-no-issue">No associated issue</span>
+          )}
         </div>
-        <span className="work-item-phases">{completedEntries.length} phases</span>
-        <span className="work-item-total">{formatDuration(totalDuration)}</span>
-        <span className="work-item-time">{formatTimestamp(item.created_at)}</span>
+        <div className="issue-group-stats">
+          <span className="issue-group-calls">{allEntries.length} calls</span>
+          <span className="issue-group-duration">{formatDuration(totalDuration)}</span>
+          {latestTime && (
+            <span className="issue-group-time">{formatTimestamp(new Date(latestTime).toISOString())}</span>
+          )}
+        </div>
       </div>
       {expanded && (
-        <div className="work-item-detail">
-          <WaterfallBar entries={completedEntries} maxDuration={maxDuration} />
-          <div className="work-item-entries">
-            {item.entries.map((entry, idx) => (
-              <div key={idx} className="entry-row">
-                <span className="entry-phase">
-                  <span
-                    className="entry-phase-dot"
-                    style={{ backgroundColor: PHASE_COLORS[entry.phase] || '#94a3b8' }}
-                  />
-                  {PHASE_LABELS[entry.phase] || entry.phase}
-                </span>
-                <span className="entry-start">{formatTimestamp(entry.start)}</span>
-                <span className="entry-duration">{formatDuration(entry.duration_ms)}</span>
-                {entry.metadata && Object.keys(entry.metadata).length > 0 && (
-                  <span className="entry-meta">
-                    {Object.entries(entry.metadata).map(([k, v]) => `${k}=${v}`).join(', ')}
-                  </span>
-                )}
-              </div>
+        <div className="issue-group-detail">
+          <div className="tool-call-list">
+            {allEntries.map((entry, idx) => (
+              <ToolCallRow key={idx} entry={entry} maxDuration={maxEntryDuration} />
             ))}
           </div>
         </div>
@@ -257,17 +276,52 @@ function WorkItemRow({ item }) {
   )
 }
 
+/** Group work items by issue, returning sorted groups */
+function groupByIssue(workItems) {
+  const groups = new Map()
+
+  for (const item of workItems) {
+    const key = item.issue_id || `_no_issue_${item.work_id}`
+    if (!groups.has(key)) {
+      groups.set(key, {
+        issueKey: key,
+        issueId: item.issue_id,
+        issueTitle: item.issue_title,
+        items: []
+      })
+    }
+    const group = groups.get(key)
+    // Update title if we get a better one
+    if (item.issue_title && !group.issueTitle) {
+      group.issueTitle = item.issue_title
+    }
+    group.items.push(item)
+  }
+
+  // Sort: issues with IDs first (by most recent), then no-issue items
+  return [...groups.values()].sort((a, b) => {
+    if (a.issueId && !b.issueId) return -1
+    if (!a.issueId && b.issueId) return 1
+    // Sort by most recent work item
+    const aTime = Math.max(...a.items.map(i => new Date(i.created_at).getTime()))
+    const bTime = Math.max(...b.items.map(i => new Date(i.created_at).getTime()))
+    return bTime - aTime
+  })
+}
+
 function TimingPage() {
   const { workItems, aggregates, totalWorkItems, loading, error, refresh } = useTiming({
     pollInterval: 10000,
     limit: 20
   })
 
+  const issueGroups = useMemo(() => groupByIssue(workItems), [workItems])
+
   if (loading && !workItems.length) {
     return (
       <div className="page">
         <header className="page-header">
-          <h1 className="page-title">Compute Timing</h1>
+          <h1 className="page-title">Timing</h1>
         </header>
         <div className="loading-container">
           <Spinner />
@@ -282,9 +336,8 @@ function TimingPage() {
         <div className="page-header-content">
           <h1 className="page-title">
             <Timer size={20} />
-            Compute Timing
+            Timing
           </h1>
-          <span className="timing-total-count">{totalWorkItems} work items tracked</span>
         </div>
         <button onClick={refresh} className="refresh-btn" disabled={loading}>
           <RefreshCw size={16} className={loading ? 'spinning' : ''} />
@@ -298,6 +351,9 @@ function TimingPage() {
         </div>
       )}
 
+      {/* Project Summary */}
+      <ProjectSummary workItems={workItems} totalWorkItems={totalWorkItems} />
+
       {/* Aggregate Stats Section */}
       <section className="timing-section">
         <header className="section-header">
@@ -309,20 +365,26 @@ function TimingPage() {
         <AggregateStatsTable aggregates={aggregates} />
       </section>
 
-      {/* Per-Work-Item Timing Section */}
+      {/* Issues Section */}
       <section className="timing-section">
         <header className="section-header">
           <h2 className="section-title">
             <Clock size={16} />
-            Recent Work Items
+            Issues
           </h2>
         </header>
-        {workItems.length === 0 ? (
+        {issueGroups.length === 0 ? (
           <p className="timing-empty">No timing data yet. Timing data will appear when compute instances process work items.</p>
         ) : (
-          <div className="work-items-list">
-            {workItems.map((item, idx) => (
-              <WorkItemRow key={`${item.work_id}-${item.instance_id}-${idx}`} item={item} />
+          <div className="issue-groups-list">
+            {issueGroups.map(group => (
+              <IssueGroup
+                key={group.issueKey}
+                issueKey={group.issueKey}
+                issueId={group.issueId}
+                issueTitle={group.issueTitle}
+                items={group.items}
+              />
             ))}
           </div>
         )}
@@ -332,3 +394,4 @@ function TimingPage() {
 }
 
 export default TimingPage
+export { formatDuration, cleanToolName, groupByIssue, LONG_RUNNING_THRESHOLD_MS }

--- a/serving/frontend/src/pages/TimingPage.test.jsx
+++ b/serving/frontend/src/pages/TimingPage.test.jsx
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { formatDuration, cleanToolName, groupByIssue, LONG_RUNNING_THRESHOLD_MS } from './TimingPage'
+
+describe('formatDuration', () => {
+  it('returns dash for null/undefined', () => {
+    expect(formatDuration(null)).toBe('-')
+    expect(formatDuration(undefined)).toBe('-')
+  })
+
+  it('formats milliseconds', () => {
+    expect(formatDuration(0)).toBe('0ms')
+    expect(formatDuration(500)).toBe('500ms')
+    expect(formatDuration(999)).toBe('999ms')
+  })
+
+  it('formats seconds', () => {
+    expect(formatDuration(1000)).toBe('1.0s')
+    expect(formatDuration(5300)).toBe('5.3s')
+    expect(formatDuration(59999)).toBe('60.0s')
+  })
+
+  it('formats minutes', () => {
+    expect(formatDuration(60000)).toBe('1.0m')
+    expect(formatDuration(90000)).toBe('1.5m')
+    expect(formatDuration(1862000)).toBe('31.0m')
+  })
+})
+
+describe('cleanToolName', () => {
+  it('strips claudevn_ prefix', () => {
+    expect(cleanToolName('claudevn_get_context')).toBe('get_context')
+    expect(cleanToolName('claudevn_request_review')).toBe('request_review')
+  })
+
+  it('leaves names without prefix unchanged', () => {
+    expect(cleanToolName('get_context')).toBe('get_context')
+    expect(cleanToolName('some_tool')).toBe('some_tool')
+  })
+
+  it('handles null/undefined', () => {
+    expect(cleanToolName(null)).toBe(null)
+    expect(cleanToolName(undefined)).toBe(undefined)
+  })
+
+  it('handles empty string', () => {
+    expect(cleanToolName('')).toBe('')
+  })
+})
+
+describe('LONG_RUNNING_THRESHOLD_MS', () => {
+  it('is 90 seconds', () => {
+    expect(LONG_RUNNING_THRESHOLD_MS).toBe(90000)
+  })
+})
+
+describe('groupByIssue', () => {
+  const makeItem = (workId, issueId, issueTitle, createdAt) => ({
+    work_id: workId,
+    instance_id: 'compute-1',
+    issue_id: issueId,
+    issue_title: issueTitle,
+    created_at: createdAt || '2024-01-01T00:00:00Z',
+    entries: [
+      { phase: 'mcp_tool_call', duration_ms: 100, start: '2024-01-01T00:00:00Z', metadata: {} }
+    ]
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(groupByIssue([])).toEqual([])
+  })
+
+  it('groups work items by issue_id', () => {
+    const items = [
+      makeItem('w1', 'issue-42', 'Fix bug', '2024-01-01T01:00:00Z'),
+      makeItem('w2', 'issue-42', 'Fix bug', '2024-01-01T02:00:00Z'),
+      makeItem('w3', 'issue-43', 'Add feature', '2024-01-01T03:00:00Z'),
+    ]
+
+    const groups = groupByIssue(items)
+    expect(groups).toHaveLength(2)
+
+    const issue42 = groups.find(g => g.issueId === 'issue-42')
+    expect(issue42.items).toHaveLength(2)
+    expect(issue42.issueTitle).toBe('Fix bug')
+
+    const issue43 = groups.find(g => g.issueId === 'issue-43')
+    expect(issue43.items).toHaveLength(1)
+  })
+
+  it('creates separate groups for items without issue_id', () => {
+    const items = [
+      makeItem('w1', null, null, '2024-01-01T01:00:00Z'),
+      makeItem('w2', null, null, '2024-01-01T02:00:00Z'),
+    ]
+
+    const groups = groupByIssue(items)
+    expect(groups).toHaveLength(2)
+  })
+
+  it('sorts issues before no-issue items', () => {
+    const items = [
+      makeItem('w1', null, null, '2024-01-01T03:00:00Z'),
+      makeItem('w2', 'issue-42', 'Fix bug', '2024-01-01T01:00:00Z'),
+    ]
+
+    const groups = groupByIssue(items)
+    expect(groups[0].issueId).toBe('issue-42')
+    expect(groups[1].issueId).toBeNull()
+  })
+
+  it('sorts issues by most recent work item', () => {
+    const items = [
+      makeItem('w1', 'issue-42', 'Old issue', '2024-01-01T01:00:00Z'),
+      makeItem('w2', 'issue-43', 'New issue', '2024-01-01T03:00:00Z'),
+    ]
+
+    const groups = groupByIssue(items)
+    expect(groups[0].issueId).toBe('issue-43')
+    expect(groups[1].issueId).toBe('issue-42')
+  })
+
+  it('fills in issue title from any item in the group', () => {
+    const items = [
+      makeItem('w1', 'issue-42', null, '2024-01-01T01:00:00Z'),
+      makeItem('w2', 'issue-42', 'Fix the bug', '2024-01-01T02:00:00Z'),
+    ]
+
+    const groups = groupByIssue(items)
+    expect(groups[0].issueTitle).toBe('Fix the bug')
+  })
+})


### PR DESCRIPTION
## Summary
- Fix broken dark-theme styling caused by CSS variable name mismatch (`--color-*` fallbacks were light-theme colors; now uses correct `--bg`, `--text`, `--border` vars from App.css)
- Restructure data hierarchy from compute-instance-based to **Project → Issue → Tool Calls**
- Clean MCP tool names by stripping `claudevn_` prefix, with small MCP/phase badges
- Replace waterfall/bubble chart with simple duration bar indicators per tool call
- Highlight long-running calls (>90s) in red

## Changes
- `TimingPage.css` — Rewrote all CSS variables to match App.css dark-theme tokens; added styles for project summary banner, issue groups, tool call rows with duration bars
- `TimingPage.jsx` — Added `ProjectSummary` component (total time, issue count, work item count); `IssueGroup` component that groups work items by issue; `ToolCallRow` with clean names, MCP badges, duration bars, and long-running highlighting; exported `groupByIssue`, `cleanToolName`, `formatDuration` for testing
- `TimingPage.test.jsx` — 15 unit tests covering `formatDuration`, `cleanToolName`, `groupByIssue` logic (grouping, sorting, edge cases)

## Testing
- [x] Tier 1 unit tests added (15 tests, all passing)
- [x] All text readable on dark theme
- [x] Data organized by issue, not compute instance
- [x] Tool names cleaned (no `claudevn_` prefix)
- [x] Duration bars replace bubble chart
- [x] Long-running calls (>90s) flagged in red

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issues
Closes #105