### PR TITLE
feat: Timing dashboard v4 with full lineage tracing (#122)

### DIFF
--- a/serving/frontend/src/hooks/useTiming.js
+++ b/serving/frontend/src/hooks/useTiming.js
@@ -38,6 +38,7 @@ function useTiming(options = {}) {
     workItems: dashboard?.work_items || [],
     aggregates: dashboard?.aggregates || [],
     totalWorkItems: dashboard?.total_work_items || 0,
+    projectSummary: dashboard?.project_summary || null,
     loading,
     error,
     refresh

--- a/serving/frontend/src/pages/TimingPage.css
+++ b/serving/frontend/src/pages/TimingPage.css
@@ -344,8 +344,100 @@
   padding-left: 0;
 }
 
+/* Source Badges (Directive / Issue / Untracked) */
+.source-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+
+.source-badge-directive {
+  background: rgba(139, 92, 246, 0.15);
+  color: #a78bfa;
+}
+
+.source-badge-issue {
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+}
+
+.source-badge-untracked {
+  background: rgba(148, 163, 184, 0.15);
+  color: #94a3b8;
+}
+
+/* Directive Group (nested) */
+.directive-group > .issue-group-header .issue-group-title {
+  font-weight: 500;
+}
+
+.directive-children {
+  padding: 0;
+}
+
+.directive-children .issue-group {
+  border-radius: 0;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+}
+
+.directive-children .issue-group:last-child {
+  border-bottom: none;
+}
+
+.directive-children .issue-group-header {
+  padding-left: 2rem;
+}
+
+.directive-children .tool-call-row {
+  padding-left: 3.5rem;
+}
+
+/* Section count badge */
+.section-count {
+  font-size: 0.72rem;
+  font-weight: 600;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.05rem 0.5rem;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Untracked toggle */
+.untracked-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 150ms ease;
+  margin-left: auto;
+}
+
+.untracked-toggle:hover {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
 /* Section header */
 .section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
   margin-bottom: 0.75rem;
 }
 

--- a/serving/frontend/src/pages/TimingPage.jsx
+++ b/serving/frontend/src/pages/TimingPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { RefreshCw, Clock, BarChart3, Timer, ChevronDown, ChevronRight } from 'lucide-react'
+import { RefreshCw, Clock, BarChart3, Timer, ChevronDown, ChevronRight, Eye, EyeOff } from 'lucide-react'
 import Spinner from '../components/common/Spinner'
 import useTiming from '../hooks/useTiming'
 import './TimingPage.css'
@@ -69,6 +69,16 @@ function getEntryDisplayName(entry) {
   return PHASE_LABELS[entry.phase] || entry.phase
 }
 
+function SourceBadge({ type }) {
+  const config = {
+    directive: { label: 'DIRECTIVE', className: 'source-badge-directive' },
+    issue: { label: 'ISSUE', className: 'source-badge-issue' },
+    untracked: { label: 'UNTRACKED', className: 'source-badge-untracked' },
+  }
+  const { label, className } = config[type] || config.untracked
+  return <span className={`source-badge ${className}`}>{label}</span>
+}
+
 function PhasePill({ phase }) {
   const color = PHASE_COLORS[phase] || '#94a3b8'
   const bgColor = PHASE_BG_COLORS[phase] || 'rgba(148, 163, 184, 0.15)'
@@ -134,31 +144,29 @@ function AggregateStatsTable({ aggregates }) {
   )
 }
 
-function ProjectSummary({ workItems, totalWorkItems }) {
-  const totalDuration = workItems.reduce((sum, item) => {
-    const wall = item.entries.find(e => e.phase === 'total_wall_time')
-    return sum + (wall?.duration_ms || 0)
-  }, 0)
-
-  const issueCount = new Set(
-    workItems.filter(i => i.issue_id).map(i => i.issue_id)
-  ).size
+function ProjectSummary({ projectSummary }) {
+  if (!projectSummary) return null
 
   return (
     <div className="timing-project-summary">
       <div className="timing-project-stat">
         <span className="timing-project-stat-label">Total Time</span>
-        <span className="timing-project-stat-value accent">{formatDuration(totalDuration)}</span>
+        <span className="timing-project-stat-value accent">{formatDuration(projectSummary.total_duration_ms)}</span>
+      </div>
+      <div className="timing-project-divider" />
+      <div className="timing-project-stat">
+        <span className="timing-project-stat-label">Directives</span>
+        <span className="timing-project-stat-value">{projectSummary.directive_count}</span>
       </div>
       <div className="timing-project-divider" />
       <div className="timing-project-stat">
         <span className="timing-project-stat-label">Issues</span>
-        <span className="timing-project-stat-value">{issueCount}</span>
+        <span className="timing-project-stat-value">{projectSummary.issue_count}</span>
       </div>
       <div className="timing-project-divider" />
       <div className="timing-project-stat">
-        <span className="timing-project-stat-label">Work Items</span>
-        <span className="timing-project-stat-value">{totalWorkItems}</span>
+        <span className="timing-project-stat-label">Events</span>
+        <span className="timing-project-stat-value">{projectSummary.timing_event_count}</span>
       </div>
     </div>
   )
@@ -211,10 +219,9 @@ function ToolCallRow({ entry, maxDuration }) {
   )
 }
 
-function IssueGroup({ issueKey, issueId, issueTitle, items }) {
+function IssueGroup({ issueId, issueTitle, items, badge }) {
   const [expanded, setExpanded] = useState(false)
 
-  // Collect all entries across work items for this issue (excluding total_wall_time)
   const allEntries = items.flatMap(item =>
     item.entries.filter(e => e.duration_ms != null && e.phase !== 'total_wall_time')
   )
@@ -224,7 +231,6 @@ function IssueGroup({ issueKey, issueId, issueTitle, items }) {
     ? Math.max(...allEntries.map(e => e.duration_ms || 0))
     : 1
 
-  // Extract issue display ID
   const displayId = issueId
     ? (() => {
         const match = issueId.match(/(\d+)$/)
@@ -245,6 +251,7 @@ function IssueGroup({ issueKey, issueId, issueTitle, items }) {
         <span className="issue-group-expand">
           {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         </span>
+        {badge && <SourceBadge type={badge} />}
         <div className="issue-group-primary">
           {displayId ? (
             <>
@@ -276,46 +283,148 @@ function IssueGroup({ issueKey, issueId, issueTitle, items }) {
   )
 }
 
-/** Group work items by issue, returning sorted groups */
-function groupByIssue(workItems) {
-  const groups = new Map()
+function DirectiveGroup({ directiveId, directiveText, issueGroups }) {
+  const [expanded, setExpanded] = useState(false)
+
+  const totalDuration = issueGroups.reduce((sum, group) => {
+    return sum + group.items.reduce((s, item) => {
+      const wall = item.entries.find(e => e.phase === 'total_wall_time')
+      return s + (wall?.duration_ms || 0)
+    }, 0)
+  }, 0)
+
+  const issueCount = issueGroups.length
+
+  return (
+    <div className="issue-group directive-group">
+      <div className="issue-group-header" onClick={() => setExpanded(!expanded)}>
+        <span className="issue-group-expand">
+          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </span>
+        <SourceBadge type="directive" />
+        <div className="issue-group-primary">
+          <span className="issue-group-title">{directiveText || directiveId}</span>
+        </div>
+        <div className="issue-group-stats">
+          <span className="issue-group-calls">{issueCount} {issueCount === 1 ? 'issue' : 'issues'}</span>
+          <span className="issue-group-duration">{formatDuration(totalDuration)}</span>
+        </div>
+      </div>
+      {expanded && (
+        <div className="issue-group-detail directive-children">
+          {issueGroups.map(group => (
+            <IssueGroup
+              key={group.issueKey}
+              issueId={group.issueId}
+              issueTitle={group.issueTitle}
+              items={group.items}
+              badge="issue"
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Group work items into three tiers:
+ * 1. Directives - items with directive_id, grouped by directive then by issue
+ * 2. Issues - items with issue_id but no directive_id
+ * 3. Untracked - items with neither
+ */
+function groupByTier(workItems) {
+  const directiveMap = new Map()  // directive_id -> { directiveText, issueMap }
+  const issueOnly = new Map()     // issue_id -> { issueId, issueTitle, items }
+  const untracked = []            // items with no issue or directive
 
   for (const item of workItems) {
-    const key = item.issue_id || `_no_issue_${item.work_id}`
-    if (!groups.has(key)) {
-      groups.set(key, {
-        issueKey: key,
-        issueId: item.issue_id,
-        issueTitle: item.issue_title,
-        items: []
-      })
+    if (item.directive_id) {
+      // Tier 1: Directive
+      if (!directiveMap.has(item.directive_id)) {
+        directiveMap.set(item.directive_id, {
+          directiveId: item.directive_id,
+          directiveText: item.directive_text,
+          issueMap: new Map(),
+        })
+      }
+      const dGroup = directiveMap.get(item.directive_id)
+      if (item.directive_text && !dGroup.directiveText) {
+        dGroup.directiveText = item.directive_text
+      }
+      const issueKey = item.issue_id || `_no_issue_${item.work_id}`
+      if (!dGroup.issueMap.has(issueKey)) {
+        dGroup.issueMap.set(issueKey, {
+          issueKey,
+          issueId: item.issue_id,
+          issueTitle: item.issue_title,
+          items: [],
+        })
+      }
+      const iGroup = dGroup.issueMap.get(issueKey)
+      if (item.issue_title && !iGroup.issueTitle) iGroup.issueTitle = item.issue_title
+      iGroup.items.push(item)
+    } else if (item.issue_id) {
+      // Tier 2: Issue only
+      if (!issueOnly.has(item.issue_id)) {
+        issueOnly.set(item.issue_id, {
+          issueKey: item.issue_id,
+          issueId: item.issue_id,
+          issueTitle: item.issue_title,
+          items: [],
+        })
+      }
+      const group = issueOnly.get(item.issue_id)
+      if (item.issue_title && !group.issueTitle) group.issueTitle = item.issue_title
+      group.items.push(item)
+    } else {
+      // Tier 3: Untracked
+      untracked.push(item)
     }
-    const group = groups.get(key)
-    // Update title if we get a better one
-    if (item.issue_title && !group.issueTitle) {
-      group.issueTitle = item.issue_title
-    }
-    group.items.push(item)
   }
 
-  // Sort: issues with IDs first (by most recent), then no-issue items
-  return [...groups.values()].sort((a, b) => {
-    if (a.issueId && !b.issueId) return -1
-    if (!a.issueId && b.issueId) return 1
-    // Sort by most recent work item
+  // Convert directive issueMap to sorted arrays
+  const directives = [...directiveMap.values()].map(d => ({
+    ...d,
+    issueGroups: [...d.issueMap.values()].sort((a, b) => {
+      const aTime = Math.max(...a.items.map(i => new Date(i.created_at).getTime()))
+      const bTime = Math.max(...b.items.map(i => new Date(i.created_at).getTime()))
+      return bTime - aTime
+    }),
+  }))
+
+  // Sort directives by most recent activity
+  directives.sort((a, b) => {
+    const aTime = Math.max(...a.issueGroups.flatMap(g => g.items.map(i => new Date(i.created_at).getTime())))
+    const bTime = Math.max(...b.issueGroups.flatMap(g => g.items.map(i => new Date(i.created_at).getTime())))
+    return bTime - aTime
+  })
+
+  const issues = [...issueOnly.values()].sort((a, b) => {
     const aTime = Math.max(...a.items.map(i => new Date(i.created_at).getTime()))
     const bTime = Math.max(...b.items.map(i => new Date(i.created_at).getTime()))
     return bTime - aTime
   })
+
+  // Wrap untracked items as individual groups
+  const untrackedGroups = untracked.map(item => ({
+    issueKey: `_untracked_${item.work_id}`,
+    issueId: null,
+    issueTitle: null,
+    items: [item],
+  }))
+
+  return { directives, issues, untrackedGroups }
 }
 
 function TimingPage() {
-  const { workItems, aggregates, totalWorkItems, loading, error, refresh } = useTiming({
+  const { workItems, aggregates, totalWorkItems, projectSummary, loading, error, refresh } = useTiming({
     pollInterval: 10000,
     limit: 20
   })
 
-  const issueGroups = useMemo(() => groupByIssue(workItems), [workItems])
+  const [showUntracked, setShowUntracked] = useState(false)
+  const { directives, issues, untrackedGroups } = useMemo(() => groupByTier(workItems), [workItems])
 
   if (loading && !workItems.length) {
     return (
@@ -329,6 +438,8 @@ function TimingPage() {
       </div>
     )
   }
+
+  const hasData = directives.length > 0 || issues.length > 0 || untrackedGroups.length > 0
 
   return (
     <div className="page">
@@ -352,7 +463,7 @@ function TimingPage() {
       )}
 
       {/* Project Summary */}
-      <ProjectSummary workItems={workItems} totalWorkItems={totalWorkItems} />
+      <ProjectSummary projectSummary={projectSummary} />
 
       {/* Aggregate Stats Section */}
       <section className="timing-section">
@@ -365,33 +476,95 @@ function TimingPage() {
         <AggregateStatsTable aggregates={aggregates} />
       </section>
 
-      {/* Issues Section */}
-      <section className="timing-section">
-        <header className="section-header">
-          <h2 className="section-title">
-            <Clock size={16} />
-            Issues
-          </h2>
-        </header>
-        {issueGroups.length === 0 ? (
-          <p className="timing-empty">No timing data yet. Timing data will appear when compute instances process work items.</p>
-        ) : (
-          <div className="issue-groups-list">
-            {issueGroups.map(group => (
-              <IssueGroup
-                key={group.issueKey}
-                issueKey={group.issueKey}
-                issueId={group.issueId}
-                issueTitle={group.issueTitle}
-                items={group.items}
-              />
-            ))}
-          </div>
-        )}
-      </section>
+      {/* Three-Tier Timing Display */}
+      {!hasData ? (
+        <p className="timing-empty">No timing data yet. Timing data will appear when compute instances process work items.</p>
+      ) : (
+        <>
+          {/* Tier 1: Directives */}
+          {directives.length > 0 && (
+            <section className="timing-section">
+              <header className="section-header">
+                <h2 className="section-title">
+                  <Clock size={16} />
+                  Directives
+                  <span className="section-count">{directives.length}</span>
+                </h2>
+              </header>
+              <div className="issue-groups-list">
+                {directives.map(d => (
+                  <DirectiveGroup
+                    key={d.directiveId}
+                    directiveId={d.directiveId}
+                    directiveText={d.directiveText}
+                    issueGroups={d.issueGroups}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Tier 2: Issues (no directive parent) */}
+          {issues.length > 0 && (
+            <section className="timing-section">
+              <header className="section-header">
+                <h2 className="section-title">
+                  <Clock size={16} />
+                  Issues
+                  <span className="section-count">{issues.length}</span>
+                </h2>
+              </header>
+              <div className="issue-groups-list">
+                {issues.map(group => (
+                  <IssueGroup
+                    key={group.issueKey}
+                    issueId={group.issueId}
+                    issueTitle={group.issueTitle}
+                    items={group.items}
+                    badge="issue"
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Tier 3: Untracked */}
+          {untrackedGroups.length > 0 && (
+            <section className="timing-section">
+              <header className="section-header">
+                <h2 className="section-title">
+                  <Clock size={16} />
+                  Untracked
+                  <span className="section-count">{untrackedGroups.length}</span>
+                </h2>
+                <button
+                  className="untracked-toggle"
+                  onClick={() => setShowUntracked(!showUntracked)}
+                >
+                  {showUntracked ? <EyeOff size={14} /> : <Eye size={14} />}
+                  {showUntracked ? 'Hide' : 'Show'}
+                </button>
+              </header>
+              {showUntracked && (
+                <div className="issue-groups-list">
+                  {untrackedGroups.map(group => (
+                    <IssueGroup
+                      key={group.issueKey}
+                      issueId={group.issueId}
+                      issueTitle={group.issueTitle}
+                      items={group.items}
+                      badge="untracked"
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
+        </>
+      )}
     </div>
   )
 }
 
 export default TimingPage
-export { formatDuration, cleanToolName, groupByIssue, LONG_RUNNING_THRESHOLD_MS }
+export { formatDuration, cleanToolName, groupByTier, LONG_RUNNING_THRESHOLD_MS }

--- a/serving/frontend/src/pages/TimingPage.test.jsx
+++ b/serving/frontend/src/pages/TimingPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatDuration, cleanToolName, groupByIssue, LONG_RUNNING_THRESHOLD_MS } from './TimingPage'
+import { formatDuration, cleanToolName, groupByTier, LONG_RUNNING_THRESHOLD_MS } from './TimingPage'
 
 describe('formatDuration', () => {
   it('returns dash for null/undefined', () => {
@@ -53,79 +53,121 @@ describe('LONG_RUNNING_THRESHOLD_MS', () => {
   })
 })
 
-describe('groupByIssue', () => {
-  const makeItem = (workId, issueId, issueTitle, createdAt) => ({
+describe('groupByTier', () => {
+  const makeItem = (workId, opts = {}) => ({
     work_id: workId,
     instance_id: 'compute-1',
-    issue_id: issueId,
-    issue_title: issueTitle,
-    created_at: createdAt || '2024-01-01T00:00:00Z',
+    issue_id: opts.issueId || null,
+    issue_title: opts.issueTitle || null,
+    goal_id: opts.goalId || null,
+    directive_id: opts.directiveId || null,
+    directive_text: opts.directiveText || null,
+    created_at: opts.createdAt || '2024-01-01T00:00:00Z',
     entries: [
       { phase: 'mcp_tool_call', duration_ms: 100, start: '2024-01-01T00:00:00Z', metadata: {} }
     ]
   })
 
-  it('returns empty array for empty input', () => {
-    expect(groupByIssue([])).toEqual([])
+  it('returns empty tiers for empty input', () => {
+    const { directives, issues, untrackedGroups } = groupByTier([])
+    expect(directives).toEqual([])
+    expect(issues).toEqual([])
+    expect(untrackedGroups).toEqual([])
   })
 
-  it('groups work items by issue_id', () => {
+  it('groups items with directive_id into directives tier', () => {
     const items = [
-      makeItem('w1', 'issue-42', 'Fix bug', '2024-01-01T01:00:00Z'),
-      makeItem('w2', 'issue-42', 'Fix bug', '2024-01-01T02:00:00Z'),
-      makeItem('w3', 'issue-43', 'Add feature', '2024-01-01T03:00:00Z'),
+      makeItem('w1', { directiveId: 'd-1', directiveText: 'Build feature', issueId: 'i-1', issueTitle: 'Task 1' }),
+      makeItem('w2', { directiveId: 'd-1', directiveText: 'Build feature', issueId: 'i-2', issueTitle: 'Task 2' }),
     ]
 
-    const groups = groupByIssue(items)
-    expect(groups).toHaveLength(2)
-
-    const issue42 = groups.find(g => g.issueId === 'issue-42')
-    expect(issue42.items).toHaveLength(2)
-    expect(issue42.issueTitle).toBe('Fix bug')
-
-    const issue43 = groups.find(g => g.issueId === 'issue-43')
-    expect(issue43.items).toHaveLength(1)
+    const { directives, issues, untrackedGroups } = groupByTier(items)
+    expect(directives).toHaveLength(1)
+    expect(directives[0].directiveId).toBe('d-1')
+    expect(directives[0].directiveText).toBe('Build feature')
+    expect(directives[0].issueGroups).toHaveLength(2)
+    expect(issues).toHaveLength(0)
+    expect(untrackedGroups).toHaveLength(0)
   })
 
-  it('creates separate groups for items without issue_id', () => {
+  it('groups items with issue_id but no directive into issues tier', () => {
     const items = [
-      makeItem('w1', null, null, '2024-01-01T01:00:00Z'),
-      makeItem('w2', null, null, '2024-01-01T02:00:00Z'),
+      makeItem('w1', { issueId: 'i-1', issueTitle: 'Fix bug' }),
+      makeItem('w2', { issueId: 'i-1', issueTitle: 'Fix bug' }),
+      makeItem('w3', { issueId: 'i-2', issueTitle: 'Add test' }),
     ]
 
-    const groups = groupByIssue(items)
-    expect(groups).toHaveLength(2)
+    const { directives, issues, untrackedGroups } = groupByTier(items)
+    expect(directives).toHaveLength(0)
+    expect(issues).toHaveLength(2)
+    expect(issues.find(g => g.issueId === 'i-1').items).toHaveLength(2)
+    expect(untrackedGroups).toHaveLength(0)
   })
 
-  it('sorts issues before no-issue items', () => {
+  it('puts items with no issue or directive into untracked tier', () => {
     const items = [
-      makeItem('w1', null, null, '2024-01-01T03:00:00Z'),
-      makeItem('w2', 'issue-42', 'Fix bug', '2024-01-01T01:00:00Z'),
+      makeItem('w1'),
+      makeItem('w2'),
     ]
 
-    const groups = groupByIssue(items)
-    expect(groups[0].issueId).toBe('issue-42')
-    expect(groups[1].issueId).toBeNull()
+    const { directives, issues, untrackedGroups } = groupByTier(items)
+    expect(directives).toHaveLength(0)
+    expect(issues).toHaveLength(0)
+    expect(untrackedGroups).toHaveLength(2)
+  })
+
+  it('sorts directives by most recent activity', () => {
+    const items = [
+      makeItem('w1', { directiveId: 'd-old', issueId: 'i-1', createdAt: '2024-01-01T01:00:00Z' }),
+      makeItem('w2', { directiveId: 'd-new', issueId: 'i-2', createdAt: '2024-01-01T03:00:00Z' }),
+    ]
+
+    const { directives } = groupByTier(items)
+    expect(directives[0].directiveId).toBe('d-new')
+    expect(directives[1].directiveId).toBe('d-old')
   })
 
   it('sorts issues by most recent work item', () => {
     const items = [
-      makeItem('w1', 'issue-42', 'Old issue', '2024-01-01T01:00:00Z'),
-      makeItem('w2', 'issue-43', 'New issue', '2024-01-01T03:00:00Z'),
+      makeItem('w1', { issueId: 'i-old', createdAt: '2024-01-01T01:00:00Z' }),
+      makeItem('w2', { issueId: 'i-new', createdAt: '2024-01-01T03:00:00Z' }),
     ]
 
-    const groups = groupByIssue(items)
-    expect(groups[0].issueId).toBe('issue-43')
-    expect(groups[1].issueId).toBe('issue-42')
+    const { issues } = groupByTier(items)
+    expect(issues[0].issueId).toBe('i-new')
+    expect(issues[1].issueId).toBe('i-old')
+  })
+
+  it('fills in directive text from any item in the group', () => {
+    const items = [
+      makeItem('w1', { directiveId: 'd-1', issueId: 'i-1' }),
+      makeItem('w2', { directiveId: 'd-1', directiveText: 'Build feature', issueId: 'i-2' }),
+    ]
+
+    const { directives } = groupByTier(items)
+    expect(directives[0].directiveText).toBe('Build feature')
   })
 
   it('fills in issue title from any item in the group', () => {
     const items = [
-      makeItem('w1', 'issue-42', null, '2024-01-01T01:00:00Z'),
-      makeItem('w2', 'issue-42', 'Fix the bug', '2024-01-01T02:00:00Z'),
+      makeItem('w1', { issueId: 'i-1' }),
+      makeItem('w2', { issueId: 'i-1', issueTitle: 'Fix the bug' }),
     ]
 
-    const groups = groupByIssue(items)
-    expect(groups[0].issueTitle).toBe('Fix the bug')
+    const { issues } = groupByTier(items)
+    expect(issues[0].issueTitle).toBe('Fix the bug')
+  })
+
+  it('handles mixed tiers correctly', () => {
+    const items = [
+      makeItem('w1', { directiveId: 'd-1', issueId: 'i-1', issueTitle: 'Task 1' }),
+      makeItem('w2', { issueId: 'i-2', issueTitle: 'Standalone' }),
+      makeItem('w3'),
+    ]
+
+    const { directives, issues, untrackedGroups } = groupByTier(items)
+    expect(directives).toHaveLength(1)
+    expect(issues).toHaveLength(1)
+    expect(untrackedGroups).toHaveLength(1)
   })
 })

--- a/serving/models/timing.py
+++ b/serving/models/timing.py
@@ -37,6 +37,9 @@ class WorkItemTiming(BaseModel):
     )
     issue_id: Optional[str] = Field(None, description="Associated issue identifier")
     issue_title: Optional[str] = Field(None, description="Associated issue title")
+    goal_id: Optional[str] = Field(None, description="Parent goal identifier")
+    directive_id: Optional[str] = Field(None, description="Originating directive identifier")
+    directive_text: Optional[str] = Field(None, description="Directive summary text")
 
 
 class AggregateStats(BaseModel):
@@ -51,8 +54,18 @@ class AggregateStats(BaseModel):
     max_ms: float = Field(0.0, description="Maximum duration in milliseconds")
 
 
+class ProjectTimingSummary(BaseModel):
+    """Project-level timing summary for the dashboard."""
+    total_duration_ms: float = Field(0.0, description="Sum of all wall times")
+    directive_count: int = Field(0, description="Unique directives with timing data")
+    issue_count: int = Field(0, description="Unique issues with timing data")
+    timing_event_count: int = Field(0, description="Total timing entries")
+    work_item_count: int = Field(0, description="Total work items")
+
+
 class TimingDashboardResponse(BaseModel):
     """Response for the timing dashboard API."""
     work_items: List[WorkItemTiming] = Field(default_factory=list, description="Recent work item timings")
     aggregates: List[AggregateStats] = Field(default_factory=list, description="Aggregate stats by phase")
     total_work_items: int = Field(0, description="Total work items with timing data")
+    project_summary: Optional[ProjectTimingSummary] = Field(None, description="Project-level timing summary")

--- a/serving/models/work_map.py
+++ b/serving/models/work_map.py
@@ -458,6 +458,12 @@ class Goal(BaseModel):
     priority: IssuePriority = Field(default=IssuePriority.P1)
     status: GoalStatus = Field(default=GoalStatus.PLANNING)
 
+    # Lineage: originating directive
+    directive_id: Optional[str] = Field(
+        None,
+        description="Originating unified directive ID (back-reference for lineage tracing)"
+    )
+
     # Populated after planning
     issue_ids: List[str] = Field(default_factory=list, description="Issue IDs created for this goal")
 

--- a/serving/services/timing_service.py
+++ b/serving/services/timing_service.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional
 
 from models.timing import (
     AggregateStats,
+    ProjectTimingSummary,
     TimingDashboardResponse,
     TimingEntry,
     TimingPhase,
@@ -268,19 +269,23 @@ class TimingService:
         else:
             total = len(self._memory)
 
+        # Compute project summary
+        project_summary = self._compute_project_summary(work_items, total)
+
         return TimingDashboardResponse(
             work_items=work_items,
             aggregates=aggregates,
             total_work_items=total,
+            project_summary=project_summary,
         )
 
     async def _enrich_issue_context(
         self, work_items: List[WorkItemTiming]
     ) -> None:
-        """Enrich work items with issue context from the work map service.
+        """Enrich work items with full lineage context.
 
-        Looks up each work_id in the work map service to find the associated
-        issue ID and title. Modifies work items in place.
+        Resolves the chain: work_id → issue → goal → directive.
+        Modifies work items in place.
         """
         try:
             from services.work_map_service import get_work_map_service
@@ -289,16 +294,94 @@ class TimingService:
             logger.debug("Work map service not available for issue enrichment")
             return
 
+        # Cache lookups to avoid repeated queries
+        issue_cache = {}  # issue_id -> Issue
+        goal_cache = {}   # goal_id -> Goal
+        directive_cache = {}  # directive_id -> UnifiedDirective
+
         for item in work_items:
+            # Step 1: Resolve issue from work item
+            if not item.issue_id:
+                try:
+                    work = await wm_service.get_work(item.work_id)
+                    if work and work.issue_id:
+                        item.issue_id = work.issue_id
+                        item.issue_title = work.title
+                except Exception:
+                    logger.debug(f"Could not look up issue for work_id={item.work_id}")
+
+            # Step 2: Resolve goal from issue
+            if item.issue_id and not item.goal_id:
+                try:
+                    issue = issue_cache.get(item.issue_id)
+                    if issue is None:
+                        issue = await wm_service.get_issue(item.issue_id)
+                        issue_cache[item.issue_id] = issue
+                    if issue and issue.goal_id:
+                        item.goal_id = issue.goal_id
+                except Exception:
+                    logger.debug(f"Could not look up goal for issue_id={item.issue_id}")
+
+            # Step 3: Resolve directive from goal
+            if item.goal_id and not item.directive_id:
+                try:
+                    goal = goal_cache.get(item.goal_id)
+                    if goal is None:
+                        from services.goal_service import get_goal_service
+                        goal_service = get_goal_service()
+                        goal = await goal_service.get_goal(item.goal_id)
+                        goal_cache[item.goal_id] = goal
+                    if goal and goal.directive_id:
+                        item.directive_id = goal.directive_id
+                        # Resolve directive text
+                        if item.directive_id not in directive_cache:
+                            try:
+                                from services.unified_directive_service import get_unified_directive_service
+                                uds = get_unified_directive_service()
+                                directive = await uds.get_directive(
+                                    goal.project_id or "", item.directive_id
+                                )
+                                directive_cache[item.directive_id] = directive
+                            except Exception:
+                                directive_cache[item.directive_id] = None
+                        directive = directive_cache.get(item.directive_id)
+                        if directive:
+                            # Use first 120 chars of directive text as summary
+                            text = directive.text
+                            item.directive_text = text[:120] + ("..." if len(text) > 120 else "")
+                except Exception:
+                    logger.debug(f"Could not look up directive for goal_id={item.goal_id}")
+
+    @staticmethod
+    def _compute_project_summary(
+        work_items: List[WorkItemTiming], total_work_items: int
+    ) -> ProjectTimingSummary:
+        """Compute project-level timing summary from enriched work items."""
+        total_duration = 0.0
+        directive_ids = set()
+        issue_ids = set()
+        timing_event_count = 0
+
+        for item in work_items:
+            # Sum wall times
+            for entry in item.entries:
+                if entry.phase.value == "total_wall_time" and entry.duration_ms:
+                    total_duration += entry.duration_ms
+            # Count timing entries
+            timing_event_count += len(item.entries)
+            # Collect unique directives and issues
+            if item.directive_id:
+                directive_ids.add(item.directive_id)
             if item.issue_id:
-                continue  # Already has issue context
-            try:
-                work = await wm_service.get_work(item.work_id)
-                if work and work.issue_id:
-                    item.issue_id = work.issue_id
-                    item.issue_title = work.title
-            except Exception:
-                logger.debug(f"Could not look up issue for work_id={item.work_id}")
+                issue_ids.add(item.issue_id)
+
+        return ProjectTimingSummary(
+            total_duration_ms=round(total_duration, 1),
+            directive_count=len(directive_ids),
+            issue_count=len(issue_ids),
+            timing_event_count=timing_event_count,
+            work_item_count=total_work_items,
+        )
 
     # =========================================================================
     # Private helpers

--- a/serving/services/unified_directive_service.py
+++ b/serving/services/unified_directive_service.py
@@ -465,6 +465,10 @@ class UnifiedDirectiveService:
             )
             goal = await goal_service.create_goal(request)
 
+            # Propagate directive_id to goal for lineage tracing (#122)
+            goal.directive_id = directive.directive_id
+            await goal_service._save_goal_to_redis(goal)
+
             # Set outcome immediately so it's available even if
             # subsequent intent mapping fails (prevents frontend
             # fallback from creating a duplicate goal).
@@ -600,6 +604,10 @@ class UnifiedDirectiveService:
                 )
                 goal = await goal_service.create_goal(request)
                 outcome.goal_id_created = goal.goal_id
+
+                # Propagate directive_id to goal for lineage tracing (#122)
+                goal.directive_id = directive.directive_id
+                await goal_service._save_goal_to_redis(goal)
 
                 # Map directive intent to goal intent fields (best-effort)
                 try:

--- a/serving/tests/test_timing_lineage.py
+++ b/serving/tests/test_timing_lineage.py
@@ -1,0 +1,268 @@
+"""Unit tests for timing lineage enrichment and project summary (#122)."""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from models.timing import (
+    ProjectTimingSummary,
+    TimingEntry,
+    TimingPhase,
+    WorkItemTiming,
+)
+from services.timing_service import TimingService
+
+
+# =========================================================================
+# Fixtures
+# =========================================================================
+
+
+def _make_timing(work_id, issue_id=None, goal_id=None, directive_id=None, wall_ms=1000):
+    """Create a WorkItemTiming with optional lineage fields and a wall time entry."""
+    entries = [
+        TimingEntry(
+            phase=TimingPhase.TOTAL_WALL_TIME,
+            start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            duration_ms=wall_ms,
+        ),
+        TimingEntry(
+            phase=TimingPhase.MCP_TOOL_CALL,
+            start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            duration_ms=200,
+            metadata={"tool_name": "claudevn_get_context"},
+        ),
+    ]
+    return WorkItemTiming(
+        work_id=work_id,
+        instance_id="compute-1",
+        entries=entries,
+        issue_id=issue_id,
+        goal_id=goal_id,
+        directive_id=directive_id,
+    )
+
+
+# =========================================================================
+# ProjectTimingSummary tests
+# =========================================================================
+
+
+class TestComputeProjectSummary:
+    """Tests for TimingService._compute_project_summary."""
+
+    def test_empty_work_items(self):
+        summary = TimingService._compute_project_summary([], 0)
+        assert summary.total_duration_ms == 0.0
+        assert summary.directive_count == 0
+        assert summary.issue_count == 0
+        assert summary.timing_event_count == 0
+        assert summary.work_item_count == 0
+
+    def test_counts_unique_directives_and_issues(self):
+        items = [
+            _make_timing("w1", issue_id="i-1", directive_id="d-1"),
+            _make_timing("w2", issue_id="i-1", directive_id="d-1"),
+            _make_timing("w3", issue_id="i-2", directive_id="d-2"),
+            _make_timing("w4"),  # no issue or directive
+        ]
+        summary = TimingService._compute_project_summary(items, 10)
+        assert summary.directive_count == 2
+        assert summary.issue_count == 2
+        assert summary.work_item_count == 10
+
+    def test_sums_wall_time(self):
+        items = [
+            _make_timing("w1", wall_ms=5000),
+            _make_timing("w2", wall_ms=3000),
+        ]
+        summary = TimingService._compute_project_summary(items, 2)
+        assert summary.total_duration_ms == 8000.0
+
+    def test_counts_all_timing_entries(self):
+        items = [
+            _make_timing("w1"),  # 2 entries (wall + mcp_tool_call)
+            _make_timing("w2"),  # 2 entries
+        ]
+        summary = TimingService._compute_project_summary(items, 2)
+        assert summary.timing_event_count == 4
+
+
+# =========================================================================
+# Lineage enrichment tests
+# =========================================================================
+
+
+class TestEnrichIssueContext:
+    """Tests for TimingService._enrich_issue_context lineage chain."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_issue_from_work(self):
+        """work_id -> issue_id via work map service."""
+        service = TimingService()
+        item = _make_timing("w1")
+
+        mock_work = MagicMock()
+        mock_work.issue_id = "i-42"
+        mock_work.title = "Fix bug"
+
+        mock_wm = AsyncMock()
+        mock_wm.get_work = AsyncMock(return_value=mock_work)
+        mock_wm.get_issue = AsyncMock(return_value=None)
+
+        with patch("services.work_map_service.get_work_map_service", return_value=mock_wm):
+            await service._enrich_issue_context([item])
+
+        assert item.issue_id == "i-42"
+        assert item.issue_title == "Fix bug"
+
+    @pytest.mark.asyncio
+    async def test_resolves_goal_from_issue(self):
+        """issue_id -> goal_id via work map service."""
+        service = TimingService()
+        item = _make_timing("w1", issue_id="i-42")
+
+        mock_issue = MagicMock()
+        mock_issue.goal_id = "g-100"
+
+        mock_wm = AsyncMock()
+        mock_wm.get_issue = AsyncMock(return_value=mock_issue)
+
+        mock_goal = MagicMock()
+        mock_goal.directive_id = None
+        mock_goal_service = AsyncMock()
+        mock_goal_service.get_goal = AsyncMock(return_value=mock_goal)
+
+        with patch("services.work_map_service.get_work_map_service", return_value=mock_wm):
+            with patch("services.goal_service.get_goal_service", return_value=mock_goal_service):
+                await service._enrich_issue_context([item])
+
+        assert item.goal_id == "g-100"
+
+    @pytest.mark.asyncio
+    async def test_resolves_directive_from_goal(self):
+        """goal_id -> directive_id via goal service."""
+        service = TimingService()
+        item = _make_timing("w1", issue_id="i-42", goal_id="g-100")
+
+        mock_wm = AsyncMock()
+        mock_wm.get_issue = AsyncMock(return_value=None)
+
+        mock_goal = MagicMock()
+        mock_goal.directive_id = "d-50"
+        mock_goal.project_id = "proj-1"
+
+        mock_goal_service = AsyncMock()
+        mock_goal_service.get_goal = AsyncMock(return_value=mock_goal)
+
+        mock_directive = MagicMock()
+        mock_directive.text = "Build the authentication system"
+
+        mock_uds = AsyncMock()
+        mock_uds.get_directive = AsyncMock(return_value=mock_directive)
+
+        with patch("services.work_map_service.get_work_map_service", return_value=mock_wm):
+            with patch("services.goal_service.get_goal_service", return_value=mock_goal_service):
+                with patch(
+                    "services.unified_directive_service.get_unified_directive_service",
+                    return_value=mock_uds,
+                ):
+                    await service._enrich_issue_context([item])
+
+        assert item.directive_id == "d-50"
+        assert item.directive_text == "Build the authentication system"
+
+    @pytest.mark.asyncio
+    async def test_skips_already_enriched_items(self):
+        """Items with existing issue_id should not re-query work map."""
+        service = TimingService()
+        item = _make_timing("w1", issue_id="i-42", goal_id="g-100", directive_id="d-50")
+
+        mock_wm = AsyncMock()
+        mock_wm.get_work = AsyncMock()
+        mock_wm.get_issue = AsyncMock()
+
+        with patch("services.work_map_service.get_work_map_service", return_value=mock_wm):
+            await service._enrich_issue_context([item])
+
+        mock_wm.get_work.assert_not_called()
+        mock_wm.get_issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_work_map_service(self):
+        """Should not crash when work map service is unavailable."""
+        service = TimingService()
+        item = _make_timing("w1")
+
+        with patch(
+            "services.work_map_service.get_work_map_service",
+            side_effect=RuntimeError("not init"),
+        ):
+            await service._enrich_issue_context([item])
+
+        assert item.issue_id is None
+
+    @pytest.mark.asyncio
+    async def test_caches_issue_lookups(self):
+        """Multiple items with same issue_id should reuse cached issue."""
+        service = TimingService()
+        items = [
+            _make_timing("w1", issue_id="i-42"),
+            _make_timing("w2", issue_id="i-42"),
+        ]
+
+        mock_issue = MagicMock()
+        mock_issue.goal_id = "g-100"
+
+        mock_wm = AsyncMock()
+        mock_wm.get_issue = AsyncMock(return_value=mock_issue)
+
+        mock_goal = MagicMock()
+        mock_goal.directive_id = None
+        mock_goal_service = AsyncMock()
+        mock_goal_service.get_goal = AsyncMock(return_value=mock_goal)
+
+        with patch("services.work_map_service.get_work_map_service", return_value=mock_wm):
+            with patch("services.goal_service.get_goal_service", return_value=mock_goal_service):
+                await service._enrich_issue_context(items)
+
+        # get_issue should be called only once (cached)
+        assert mock_wm.get_issue.call_count == 1
+        assert items[0].goal_id == "g-100"
+        assert items[1].goal_id == "g-100"
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_directive_text(self):
+        """Directive text longer than 120 chars should be truncated."""
+        service = TimingService()
+        item = _make_timing("w1", issue_id="i-42", goal_id="g-100")
+
+        mock_wm = AsyncMock()
+        mock_wm.get_issue = AsyncMock(return_value=None)
+
+        mock_goal = MagicMock()
+        mock_goal.directive_id = "d-50"
+        mock_goal.project_id = "proj-1"
+
+        mock_goal_service = AsyncMock()
+        mock_goal_service.get_goal = AsyncMock(return_value=mock_goal)
+
+        long_text = "A" * 200
+        mock_directive = MagicMock()
+        mock_directive.text = long_text
+
+        mock_uds = AsyncMock()
+        mock_uds.get_directive = AsyncMock(return_value=mock_directive)
+
+        with patch("services.work_map_service.get_work_map_service", return_value=mock_wm):
+            with patch("services.goal_service.get_goal_service", return_value=mock_goal_service):
+                with patch(
+                    "services.unified_directive_service.get_unified_directive_service",
+                    return_value=mock_uds,
+                ):
+                    await service._enrich_issue_context([item])
+
+        assert len(item.directive_text) == 123  # 120 + "..."
+        assert item.directive_text.endswith("...")


### PR DESCRIPTION
## Summary
- Add full lineage tracing: directive -> goal -> issue -> work item -> timing entries
- Three-tier frontend display with Directives, Issues, and Untracked sections
- Project-level summary banner with directive count, issue count, total time, and event count

## Changes

### Backend
- **`serving/models/work_map.py`**: Add `directive_id` field to `Goal` model for back-reference to originating directive
- **`serving/models/timing.py`**: Extend `WorkItemTiming` with `goal_id`, `directive_id`, `directive_text`; add `ProjectTimingSummary` model; add `project_summary` to `TimingDashboardResponse`
- **`serving/services/timing_service.py`**: Extend `_enrich_issue_context()` to resolve full lineage chain (work -> issue -> goal -> directive) with caching; add `_compute_project_summary()` 
- **`serving/services/unified_directive_service.py`**: Propagate `directive_id` to Goal when created from directive (both `_handle_new_work` and `_handle_combined`)

### Frontend
- **`serving/frontend/src/pages/TimingPage.jsx`**: Replace flat issue grouping with three-tier display (Directives/Issues/Untracked); add `SourceBadge` component; add `DirectiveGroup` component; add show/hide toggle for untracked; use backend `project_summary` for banner
- **`serving/frontend/src/pages/TimingPage.css`**: Add styles for source badges, directive nesting, section counts, untracked toggle
- **`serving/frontend/src/hooks/useTiming.js`**: Expose `projectSummary` from hook

## Testing
- [x] Tier 1 unit tests added for lineage enrichment (11 tests): `serving/tests/test_timing_lineage.py`
- [x] Frontend unit tests updated for `groupByTier` (18 tests): `serving/frontend/src/pages/TimingPage.test.jsx`
- [x] All unit tests passing

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issues
Closes #122