### PR TITLE
feat: Timing dashboard v5 - fix display issues and improve aggregate stats (#125)

### DIFF
--- a/serving/frontend/src/pages/TimingPage.jsx
+++ b/serving/frontend/src/pages/TimingPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { RefreshCw, Clock, BarChart3, Timer, ChevronDown, ChevronRight, Eye, EyeOff } from 'lucide-react'
+import { RefreshCw, Clock, BarChart3, Timer, ChevronDown, ChevronRight, Layers, AlertCircle } from 'lucide-react'
 import Spinner from '../components/common/Spinner'
 import useTiming from '../hooks/useTiming'
 import './TimingPage.css'
@@ -69,24 +69,24 @@ function getEntryDisplayName(entry) {
   return PHASE_LABELS[entry.phase] || entry.phase
 }
 
-function SourceBadge({ type }) {
-  const config = {
-    directive: { label: 'DIRECTIVE', className: 'source-badge-directive' },
-    issue: { label: 'ISSUE', className: 'source-badge-issue' },
-    untracked: { label: 'UNTRACKED', className: 'source-badge-untracked' },
-  }
-  const { label, className } = config[type] || config.untracked
-  return <span className={`source-badge ${className}`}>{label}</span>
+/** Sum all entry durations for a list of work items (excluding total_wall_time) */
+function sumEntryDurations(items) {
+  return items.reduce((sum, item) => {
+    return sum + item.entries
+      .filter(e => e.duration_ms != null && e.phase !== 'total_wall_time')
+      .reduce((s, e) => s + (e.duration_ms || 0), 0)
+  }, 0)
 }
 
-function PhasePill({ phase }) {
+function PhasePill({ phase, toolName }) {
   const color = PHASE_COLORS[phase] || '#94a3b8'
   const bgColor = PHASE_BG_COLORS[phase] || 'rgba(148, 163, 184, 0.15)'
+  const label = toolName || PHASE_LABELS[phase] || phase
 
   return (
     <span className="phase-pill" style={{ backgroundColor: bgColor, color }}>
       <span className="phase-dot" style={{ backgroundColor: color }} />
-      {PHASE_LABELS[phase] || phase}
+      {label}
     </span>
   )
 }
@@ -114,59 +114,64 @@ function AggregateStatsTable({ aggregates }) {
           </tr>
         </thead>
         <tbody>
-          {aggregates.map(stat => (
-            <tr key={stat.phase}>
-              <td><PhasePill phase={stat.phase} /></td>
-              <td className="timing-num">{stat.count}</td>
-              <td className="timing-num">
-                <div className="stat-bar-container">
-                  <span>{formatDuration(stat.avg_ms)}</span>
-                  <span
-                    className="stat-bar"
-                    style={{
-                      width: `${Math.max((stat.avg_ms / maxAvg) * 60, 3)}px`,
-                      backgroundColor: PHASE_COLORS[stat.phase] || '#94a3b8',
-                      opacity: 0.6
-                    }}
-                  />
-                </div>
-              </td>
-              <td className="timing-num">{formatDuration(stat.p50_ms)}</td>
-              <td className="timing-num">{formatDuration(stat.p95_ms)}</td>
-              <td className="timing-num">{formatDuration(stat.p99_ms)}</td>
-              <td className="timing-num">{formatDuration(stat.min_ms)}</td>
-              <td className="timing-num">{formatDuration(stat.max_ms)}</td>
-            </tr>
-          ))}
+          {aggregates.map(stat => {
+            const key = stat.tool_name
+              ? `${stat.phase}:${stat.tool_name}`
+              : stat.phase
+            return (
+              <tr key={key}>
+                <td><PhasePill phase={stat.phase} toolName={stat.tool_name} /></td>
+                <td className="timing-num">{stat.count}</td>
+                <td className="timing-num">
+                  <div className="stat-bar-container">
+                    <span>{formatDuration(stat.avg_ms)}</span>
+                    <span
+                      className="stat-bar"
+                      style={{
+                        width: `${Math.max((stat.avg_ms / maxAvg) * 60, 3)}px`,
+                        backgroundColor: PHASE_COLORS[stat.phase] || '#94a3b8',
+                        opacity: 0.6
+                      }}
+                    />
+                  </div>
+                </td>
+                <td className="timing-num">{formatDuration(stat.p50_ms)}</td>
+                <td className="timing-num">{formatDuration(stat.p95_ms)}</td>
+                <td className="timing-num">{formatDuration(stat.p99_ms)}</td>
+                <td className="timing-num">{formatDuration(stat.min_ms)}</td>
+                <td className="timing-num">{formatDuration(stat.max_ms)}</td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>
   )
 }
 
-function ProjectSummary({ projectSummary }) {
-  if (!projectSummary) return null
+function ProjectSummary({ workItems, totalWorkItems }) {
+  // Sum all entry durations (excluding total_wall_time) across all work items
+  const totalDuration = sumEntryDurations(workItems)
+
+  const issueCount = new Set(
+    workItems.filter(i => i.issue_id).map(i => i.issue_id)
+  ).size
 
   return (
     <div className="timing-project-summary">
       <div className="timing-project-stat">
         <span className="timing-project-stat-label">Total Time</span>
-        <span className="timing-project-stat-value accent">{formatDuration(projectSummary.total_duration_ms)}</span>
-      </div>
-      <div className="timing-project-divider" />
-      <div className="timing-project-stat">
-        <span className="timing-project-stat-label">Directives</span>
-        <span className="timing-project-stat-value">{projectSummary.directive_count}</span>
+        <span className="timing-project-stat-value accent">{formatDuration(totalDuration)}</span>
       </div>
       <div className="timing-project-divider" />
       <div className="timing-project-stat">
         <span className="timing-project-stat-label">Issues</span>
-        <span className="timing-project-stat-value">{projectSummary.issue_count}</span>
+        <span className="timing-project-stat-value">{issueCount}</span>
       </div>
       <div className="timing-project-divider" />
       <div className="timing-project-stat">
-        <span className="timing-project-stat-label">Events</span>
-        <span className="timing-project-stat-value">{projectSummary.timing_event_count}</span>
+        <span className="timing-project-stat-label">Work Items</span>
+        <span className="timing-project-stat-value">{totalWorkItems}</span>
       </div>
     </div>
   )
@@ -219,7 +224,7 @@ function ToolCallRow({ entry, maxDuration }) {
   )
 }
 
-function IssueGroup({ issueId, issueTitle, items, badge }) {
+function WorkItemGroup({ groupKey, label, sublabel, items }) {
   const [expanded, setExpanded] = useState(false)
 
   const allEntries = items.flatMap(item =>
@@ -230,13 +235,6 @@ function IssueGroup({ issueId, issueTitle, items, badge }) {
   const maxEntryDuration = allEntries.length > 0
     ? Math.max(...allEntries.map(e => e.duration_ms || 0))
     : 1
-
-  const displayId = issueId
-    ? (() => {
-        const match = issueId.match(/(\d+)$/)
-        return match ? `#${match[1]}` : issueId
-      })()
-    : null
 
   const latestTime = items.length > 0
     ? items.reduce((latest, item) => {
@@ -251,16 +249,9 @@ function IssueGroup({ issueId, issueTitle, items, badge }) {
         <span className="issue-group-expand">
           {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         </span>
-        {badge && <SourceBadge type={badge} />}
         <div className="issue-group-primary">
-          {displayId ? (
-            <>
-              <span className="issue-group-id">{displayId}</span>
-              {issueTitle && <span className="issue-group-title">{issueTitle}</span>}
-            </>
-          ) : (
-            <span className="issue-group-no-issue">No associated issue</span>
-          )}
+          <span className="issue-group-title">{label}</span>
+          {sublabel && <span className="issue-group-subtitle">{sublabel}</span>}
         </div>
         <div className="issue-group-stats">
           <span className="issue-group-calls">{allEntries.length} calls</span>
@@ -283,148 +274,80 @@ function IssueGroup({ issueId, issueTitle, items, badge }) {
   )
 }
 
-function DirectiveGroup({ directiveId, directiveText, issueGroups }) {
-  const [expanded, setExpanded] = useState(false)
-
-  const totalDuration = issueGroups.reduce((sum, group) => {
-    return sum + group.items.reduce((s, item) => {
-      const wall = item.entries.find(e => e.phase === 'total_wall_time')
-      return s + (wall?.duration_ms || 0)
-    }, 0)
-  }, 0)
-
-  const issueCount = issueGroups.length
-
-  return (
-    <div className="issue-group directive-group">
-      <div className="issue-group-header" onClick={() => setExpanded(!expanded)}>
-        <span className="issue-group-expand">
-          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-        </span>
-        <SourceBadge type="directive" />
-        <div className="issue-group-primary">
-          <span className="issue-group-title">{directiveText || directiveId}</span>
-        </div>
-        <div className="issue-group-stats">
-          <span className="issue-group-calls">{issueCount} {issueCount === 1 ? 'issue' : 'issues'}</span>
-          <span className="issue-group-duration">{formatDuration(totalDuration)}</span>
-        </div>
-      </div>
-      {expanded && (
-        <div className="issue-group-detail directive-children">
-          {issueGroups.map(group => (
-            <IssueGroup
-              key={group.issueKey}
-              issueId={group.issueId}
-              issueTitle={group.issueTitle}
-              items={group.items}
-              badge="issue"
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
-/**
- * Group work items into three tiers:
- * 1. Directives - items with directive_id, grouped by directive then by issue
- * 2. Issues - items with issue_id but no directive_id
- * 3. Untracked - items with neither
- */
-function groupByTier(workItems) {
-  const directiveMap = new Map()  // directive_id -> { directiveText, issueMap }
-  const issueOnly = new Map()     // issue_id -> { issueId, issueTitle, items }
-  const untracked = []            // items with no issue or directive
+/** Classify work items into three tiers: directives, issues, unassigned */
+function classifyWorkItems(workItems) {
+  const directiveGroups = new Map()
+  const issueGroups = new Map()
+  const unassigned = []
 
   for (const item of workItems) {
-    if (item.directive_id) {
-      // Tier 1: Directive
-      if (!directiveMap.has(item.directive_id)) {
-        directiveMap.set(item.directive_id, {
-          directiveId: item.directive_id,
-          directiveText: item.directive_text,
-          issueMap: new Map(),
+    if (item.issue_id) {
+      // Issue tier: has a resolved issue
+      const key = item.issue_id
+      if (!issueGroups.has(key)) {
+        issueGroups.set(key, {
+          key,
+          label: item.issue_title || item.issue_id,
+          sublabel: null,
+          items: []
         })
       }
-      const dGroup = directiveMap.get(item.directive_id)
-      if (item.directive_text && !dGroup.directiveText) {
-        dGroup.directiveText = item.directive_text
+      const group = issueGroups.get(key)
+      if (item.issue_title && !group.label) {
+        group.label = item.issue_title
       }
-      const issueKey = item.issue_id || `_no_issue_${item.work_id}`
-      if (!dGroup.issueMap.has(issueKey)) {
-        dGroup.issueMap.set(issueKey, {
-          issueKey,
-          issueId: item.issue_id,
-          issueTitle: item.issue_title,
-          items: [],
-        })
-      }
-      const iGroup = dGroup.issueMap.get(issueKey)
-      if (item.issue_title && !iGroup.issueTitle) iGroup.issueTitle = item.issue_title
-      iGroup.items.push(item)
-    } else if (item.issue_id) {
-      // Tier 2: Issue only
-      if (!issueOnly.has(item.issue_id)) {
-        issueOnly.set(item.issue_id, {
-          issueKey: item.issue_id,
-          issueId: item.issue_id,
-          issueTitle: item.issue_title,
-          items: [],
-        })
-      }
-      const group = issueOnly.get(item.issue_id)
-      if (item.issue_title && !group.issueTitle) group.issueTitle = item.issue_title
       group.items.push(item)
+    } else if (item.directive_id) {
+      // Directive tier: decomp, char, conflict, compute lifecycle
+      const key = item.directive_id
+      if (!directiveGroups.has(key)) {
+        directiveGroups.set(key, {
+          key,
+          label: item.directive_title || item.directive_id,
+          sublabel: item.work_id,
+          items: []
+        })
+      }
+      directiveGroups.get(key).items.push(item)
     } else {
-      // Tier 3: Untracked
-      untracked.push(item)
+      // Unassigned: not linked to directive or issue
+      unassigned.push(item)
     }
   }
 
-  // Convert directive issueMap to sorted arrays
-  const directives = [...directiveMap.values()].map(d => ({
-    ...d,
-    issueGroups: [...d.issueMap.values()].sort((a, b) => {
+  // Sort each tier by most recent item
+  const sortByRecent = (groups) =>
+    [...groups.values()].sort((a, b) => {
       const aTime = Math.max(...a.items.map(i => new Date(i.created_at).getTime()))
       const bTime = Math.max(...b.items.map(i => new Date(i.created_at).getTime()))
       return bTime - aTime
-    }),
+    })
+
+  // Unassigned: each work item is its own group
+  const unassignedGroups = unassigned.map(item => ({
+    key: item.work_id,
+    label: item.work_id,
+    sublabel: null,
+    items: [item]
   }))
 
-  // Sort directives by most recent activity
-  directives.sort((a, b) => {
-    const aTime = Math.max(...a.issueGroups.flatMap(g => g.items.map(i => new Date(i.created_at).getTime())))
-    const bTime = Math.max(...b.issueGroups.flatMap(g => g.items.map(i => new Date(i.created_at).getTime())))
-    return bTime - aTime
-  })
-
-  const issues = [...issueOnly.values()].sort((a, b) => {
-    const aTime = Math.max(...a.items.map(i => new Date(i.created_at).getTime()))
-    const bTime = Math.max(...b.items.map(i => new Date(i.created_at).getTime()))
-    return bTime - aTime
-  })
-
-  // Wrap untracked items as individual groups
-  const untrackedGroups = untracked.map(item => ({
-    issueKey: `_untracked_${item.work_id}`,
-    issueId: null,
-    issueTitle: null,
-    items: [item],
-  }))
-
-  return { directives, issues, untrackedGroups }
+  return {
+    directives: sortByRecent(directiveGroups),
+    issues: sortByRecent(issueGroups),
+    unassigned: unassignedGroups
+  }
 }
 
 function TimingPage() {
-  const { workItems, aggregates, totalWorkItems, projectSummary, loading, error, refresh } = useTiming({
+  const { workItems, aggregates, totalWorkItems, loading, error, refresh } = useTiming({
     pollInterval: 10000,
     limit: 20
   })
 
-  const [showUntracked, setShowUntracked] = useState(false)
-  const { directives, issues, untrackedGroups } = useMemo(() => groupByTier(workItems), [workItems])
+  const { directives, issues, unassigned } = useMemo(
+    () => classifyWorkItems(workItems),
+    [workItems]
+  )
 
   if (loading && !workItems.length) {
     return (
@@ -438,8 +361,6 @@ function TimingPage() {
       </div>
     )
   }
-
-  const hasData = directives.length > 0 || issues.length > 0 || untrackedGroups.length > 0
 
   return (
     <div className="page">
@@ -463,7 +384,7 @@ function TimingPage() {
       )}
 
       {/* Project Summary */}
-      <ProjectSummary projectSummary={projectSummary} />
+      <ProjectSummary workItems={workItems} totalWorkItems={totalWorkItems} />
 
       {/* Aggregate Stats Section */}
       <section className="timing-section">
@@ -476,95 +397,79 @@ function TimingPage() {
         <AggregateStatsTable aggregates={aggregates} />
       </section>
 
-      {/* Three-Tier Timing Display */}
-      {!hasData ? (
-        <p className="timing-empty">No timing data yet. Timing data will appear when compute instances process work items.</p>
-      ) : (
-        <>
-          {/* Tier 1: Directives */}
-          {directives.length > 0 && (
-            <section className="timing-section">
-              <header className="section-header">
-                <h2 className="section-title">
-                  <Clock size={16} />
-                  Directives
-                  <span className="section-count">{directives.length}</span>
-                </h2>
-              </header>
-              <div className="issue-groups-list">
-                {directives.map(d => (
-                  <DirectiveGroup
-                    key={d.directiveId}
-                    directiveId={d.directiveId}
-                    directiveText={d.directiveText}
-                    issueGroups={d.issueGroups}
-                  />
-                ))}
-              </div>
-            </section>
-          )}
+      {/* Directives Section */}
+      {directives.length > 0 && (
+        <section className="timing-section">
+          <header className="section-header">
+            <h2 className="section-title">
+              <Layers size={16} />
+              Directives
+            </h2>
+          </header>
+          <div className="issue-groups-list">
+            {directives.map(group => (
+              <WorkItemGroup
+                key={group.key}
+                groupKey={group.key}
+                label={group.label}
+                sublabel={group.sublabel}
+                items={group.items}
+              />
+            ))}
+          </div>
+        </section>
+      )}
 
-          {/* Tier 2: Issues (no directive parent) */}
-          {issues.length > 0 && (
-            <section className="timing-section">
-              <header className="section-header">
-                <h2 className="section-title">
-                  <Clock size={16} />
-                  Issues
-                  <span className="section-count">{issues.length}</span>
-                </h2>
-              </header>
-              <div className="issue-groups-list">
-                {issues.map(group => (
-                  <IssueGroup
-                    key={group.issueKey}
-                    issueId={group.issueId}
-                    issueTitle={group.issueTitle}
-                    items={group.items}
-                    badge="issue"
-                  />
-                ))}
-              </div>
-            </section>
-          )}
+      {/* Issues Section */}
+      <section className="timing-section">
+        <header className="section-header">
+          <h2 className="section-title">
+            <Clock size={16} />
+            Issues
+          </h2>
+        </header>
+        {issues.length === 0 ? (
+          <p className="timing-empty">No issue timing data yet. Timing data will appear when compute instances process work items.</p>
+        ) : (
+          <div className="issue-groups-list">
+            {issues.map(group => (
+              <WorkItemGroup
+                key={group.key}
+                groupKey={group.key}
+                label={group.label}
+                sublabel={group.sublabel}
+                items={group.items}
+              />
+            ))}
+          </div>
+        )}
+      </section>
 
-          {/* Tier 3: Untracked */}
-          {untrackedGroups.length > 0 && (
-            <section className="timing-section">
-              <header className="section-header">
-                <h2 className="section-title">
-                  <Clock size={16} />
-                  Untracked
-                  <span className="section-count">{untrackedGroups.length}</span>
-                </h2>
-                <button
-                  className="untracked-toggle"
-                  onClick={() => setShowUntracked(!showUntracked)}
-                >
-                  {showUntracked ? <EyeOff size={14} /> : <Eye size={14} />}
-                  {showUntracked ? 'Hide' : 'Show'}
-                </button>
-              </header>
-              {showUntracked && (
-                <div className="issue-groups-list">
-                  {untrackedGroups.map(group => (
-                    <IssueGroup
-                      key={group.issueKey}
-                      issueId={group.issueId}
-                      issueTitle={group.issueTitle}
-                      items={group.items}
-                      badge="untracked"
-                    />
-                  ))}
-                </div>
-              )}
-            </section>
-          )}
-        </>
+      {/* Unassigned Section */}
+      {unassigned.length > 0 && (
+        <section className="timing-section">
+          <header className="section-header">
+            <h2 className="section-title">
+              <AlertCircle size={16} />
+              Unassigned
+            </h2>
+          </header>
+          <div className="issue-groups-list">
+            {unassigned.map(group => (
+              <WorkItemGroup
+                key={group.key}
+                groupKey={group.key}
+                label={group.label}
+                sublabel={group.sublabel}
+                items={group.items}
+              />
+            ))}
+          </div>
+        </section>
       )}
     </div>
   )
 }
 
 export default TimingPage
-export { formatDuration, cleanToolName, groupByTier, LONG_RUNNING_THRESHOLD_MS }
+export { formatDuration, cleanToolName, classifyWorkItems, sumEntryDurations, LONG_RUNNING_THRESHOLD_MS }

--- a/serving/frontend/src/pages/TimingPage.test.jsx
+++ b/serving/frontend/src/pages/TimingPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatDuration, cleanToolName, groupByTier, LONG_RUNNING_THRESHOLD_MS } from './TimingPage'
+import { formatDuration, cleanToolName, classifyWorkItems, sumEntryDurations, LONG_RUNNING_THRESHOLD_MS } from './TimingPage'
 
 describe('formatDuration', () => {
   it('returns dash for null/undefined', () => {
@@ -53,121 +53,125 @@ describe('LONG_RUNNING_THRESHOLD_MS', () => {
   })
 })
 
-describe('groupByTier', () => {
-  const makeItem = (workId, opts = {}) => ({
+describe('sumEntryDurations', () => {
+  it('returns 0 for empty array', () => {
+    expect(sumEntryDurations([])).toBe(0)
+  })
+
+  it('sums all entry durations excluding total_wall_time', () => {
+    const items = [
+      {
+        entries: [
+          { phase: 'mcp_tool_call', duration_ms: 100 },
+          { phase: 'mcp_tool_call', duration_ms: 200 },
+          { phase: 'total_wall_time', duration_ms: 5000 },
+        ]
+      },
+      {
+        entries: [
+          { phase: 'sdk_launch', duration_ms: 300 },
+        ]
+      }
+    ]
+    expect(sumEntryDurations(items)).toBe(600)
+  })
+
+  it('handles entries with null duration_ms', () => {
+    const items = [
+      {
+        entries: [
+          { phase: 'mcp_tool_call', duration_ms: null },
+          { phase: 'mcp_tool_call', duration_ms: 100 },
+        ]
+      }
+    ]
+    expect(sumEntryDurations(items)).toBe(100)
+  })
+})
+
+describe('classifyWorkItems', () => {
+  const makeItem = (workId, { issueId, issueTitle, directiveId, directiveTitle, createdAt } = {}) => ({
     work_id: workId,
     instance_id: 'compute-1',
-    issue_id: opts.issueId || null,
-    issue_title: opts.issueTitle || null,
-    goal_id: opts.goalId || null,
-    directive_id: opts.directiveId || null,
-    directive_text: opts.directiveText || null,
-    created_at: opts.createdAt || '2024-01-01T00:00:00Z',
+    issue_id: issueId || null,
+    issue_title: issueTitle || null,
+    directive_id: directiveId || null,
+    directive_title: directiveTitle || null,
+    created_at: createdAt || '2024-01-01T00:00:00Z',
     entries: [
       { phase: 'mcp_tool_call', duration_ms: 100, start: '2024-01-01T00:00:00Z', metadata: {} }
     ]
   })
 
   it('returns empty tiers for empty input', () => {
-    const { directives, issues, untrackedGroups } = groupByTier([])
-    expect(directives).toEqual([])
-    expect(issues).toEqual([])
-    expect(untrackedGroups).toEqual([])
+    const result = classifyWorkItems([])
+    expect(result.directives).toEqual([])
+    expect(result.issues).toEqual([])
+    expect(result.unassigned).toEqual([])
   })
 
-  it('groups items with directive_id into directives tier', () => {
+  it('classifies items with issue_id into issues tier', () => {
     const items = [
-      makeItem('w1', { directiveId: 'd-1', directiveText: 'Build feature', issueId: 'i-1', issueTitle: 'Task 1' }),
-      makeItem('w2', { directiveId: 'd-1', directiveText: 'Build feature', issueId: 'i-2', issueTitle: 'Task 2' }),
+      makeItem('w1', { issueId: 'issue-42', issueTitle: 'Fix bug' }),
+      makeItem('w2', { issueId: 'issue-42', issueTitle: 'Fix bug' }),
+      makeItem('w3', { issueId: 'issue-43', issueTitle: 'Add feature' }),
     ]
 
-    const { directives, issues, untrackedGroups } = groupByTier(items)
-    expect(directives).toHaveLength(1)
-    expect(directives[0].directiveId).toBe('d-1')
-    expect(directives[0].directiveText).toBe('Build feature')
-    expect(directives[0].issueGroups).toHaveLength(2)
-    expect(issues).toHaveLength(0)
-    expect(untrackedGroups).toHaveLength(0)
+    const result = classifyWorkItems(items)
+    expect(result.issues).toHaveLength(2)
+    expect(result.directives).toHaveLength(0)
+    expect(result.unassigned).toHaveLength(0)
+
+    const issue42 = result.issues.find(g => g.key === 'issue-42')
+    expect(issue42.items).toHaveLength(2)
+    expect(issue42.label).toBe('Fix bug')
   })
 
-  it('groups items with issue_id but no directive into issues tier', () => {
+  it('classifies items with directive_id into directives tier', () => {
     const items = [
-      makeItem('w1', { issueId: 'i-1', issueTitle: 'Fix bug' }),
-      makeItem('w2', { issueId: 'i-1', issueTitle: 'Fix bug' }),
-      makeItem('w3', { issueId: 'i-2', issueTitle: 'Add test' }),
+      makeItem('decomp-abc', { directiveId: 'dir-1', directiveTitle: 'Build auth' }),
+      makeItem('char-def', { directiveId: 'dir-1', directiveTitle: 'Build auth' }),
     ]
 
-    const { directives, issues, untrackedGroups } = groupByTier(items)
-    expect(directives).toHaveLength(0)
-    expect(issues).toHaveLength(2)
-    expect(issues.find(g => g.issueId === 'i-1').items).toHaveLength(2)
-    expect(untrackedGroups).toHaveLength(0)
+    const result = classifyWorkItems(items)
+    expect(result.directives).toHaveLength(1)
+    expect(result.directives[0].items).toHaveLength(2)
+    expect(result.directives[0].label).toBe('Build auth')
+    expect(result.issues).toHaveLength(0)
+    expect(result.unassigned).toHaveLength(0)
   })
 
-  it('puts items with no issue or directive into untracked tier', () => {
+  it('classifies items without issue or directive into unassigned tier', () => {
     const items = [
       makeItem('w1'),
       makeItem('w2'),
     ]
 
-    const { directives, issues, untrackedGroups } = groupByTier(items)
-    expect(directives).toHaveLength(0)
-    expect(issues).toHaveLength(0)
-    expect(untrackedGroups).toHaveLength(2)
+    const result = classifyWorkItems(items)
+    expect(result.unassigned).toHaveLength(2)
+    expect(result.directives).toHaveLength(0)
+    expect(result.issues).toHaveLength(0)
   })
 
-  it('sorts directives by most recent activity', () => {
+  it('issue_id takes precedence over directive_id for classification', () => {
+    // An item with both issue_id and directive_id goes to the issues tier
     const items = [
-      makeItem('w1', { directiveId: 'd-old', issueId: 'i-1', createdAt: '2024-01-01T01:00:00Z' }),
-      makeItem('w2', { directiveId: 'd-new', issueId: 'i-2', createdAt: '2024-01-01T03:00:00Z' }),
+      makeItem('w1', { issueId: 'issue-42', issueTitle: 'Fix', directiveId: 'dir-1' }),
     ]
 
-    const { directives } = groupByTier(items)
-    expect(directives[0].directiveId).toBe('d-new')
-    expect(directives[1].directiveId).toBe('d-old')
+    const result = classifyWorkItems(items)
+    expect(result.issues).toHaveLength(1)
+    expect(result.directives).toHaveLength(0)
   })
 
-  it('sorts issues by most recent work item', () => {
+  it('sorts groups by most recent work item', () => {
     const items = [
-      makeItem('w1', { issueId: 'i-old', createdAt: '2024-01-01T01:00:00Z' }),
-      makeItem('w2', { issueId: 'i-new', createdAt: '2024-01-01T03:00:00Z' }),
+      makeItem('w1', { issueId: 'issue-42', issueTitle: 'Old', createdAt: '2024-01-01T01:00:00Z' }),
+      makeItem('w2', { issueId: 'issue-43', issueTitle: 'New', createdAt: '2024-01-01T03:00:00Z' }),
     ]
 
-    const { issues } = groupByTier(items)
-    expect(issues[0].issueId).toBe('i-new')
-    expect(issues[1].issueId).toBe('i-old')
-  })
-
-  it('fills in directive text from any item in the group', () => {
-    const items = [
-      makeItem('w1', { directiveId: 'd-1', issueId: 'i-1' }),
-      makeItem('w2', { directiveId: 'd-1', directiveText: 'Build feature', issueId: 'i-2' }),
-    ]
-
-    const { directives } = groupByTier(items)
-    expect(directives[0].directiveText).toBe('Build feature')
-  })
-
-  it('fills in issue title from any item in the group', () => {
-    const items = [
-      makeItem('w1', { issueId: 'i-1' }),
-      makeItem('w2', { issueId: 'i-1', issueTitle: 'Fix the bug' }),
-    ]
-
-    const { issues } = groupByTier(items)
-    expect(issues[0].issueTitle).toBe('Fix the bug')
-  })
-
-  it('handles mixed tiers correctly', () => {
-    const items = [
-      makeItem('w1', { directiveId: 'd-1', issueId: 'i-1', issueTitle: 'Task 1' }),
-      makeItem('w2', { issueId: 'i-2', issueTitle: 'Standalone' }),
-      makeItem('w3'),
-    ]
-
-    const { directives, issues, untrackedGroups } = groupByTier(items)
-    expect(directives).toHaveLength(1)
-    expect(issues).toHaveLength(1)
-    expect(untrackedGroups).toHaveLength(1)
+    const result = classifyWorkItems(items)
+    expect(result.issues[0].label).toBe('New')
+    expect(result.issues[1].label).toBe('Old')
   })
 })

--- a/serving/models/timing.py
+++ b/serving/models/timing.py
@@ -37,14 +37,18 @@ class WorkItemTiming(BaseModel):
     )
     issue_id: Optional[str] = Field(None, description="Associated issue identifier")
     issue_title: Optional[str] = Field(None, description="Associated issue title")
-    goal_id: Optional[str] = Field(None, description="Parent goal identifier")
-    directive_id: Optional[str] = Field(None, description="Originating directive identifier")
-    directive_text: Optional[str] = Field(None, description="Directive summary text")
+    directive_id: Optional[str] = Field(None, description="Associated directive identifier")
+    directive_title: Optional[str] = Field(None, description="Associated directive title")
 
 
 class AggregateStats(BaseModel):
-    """Aggregate timing statistics across recent work items."""
+    """Aggregate timing statistics across recent work items.
+
+    For MCP tool calls, `phase` is MCP_TOOL_CALL and `tool_name` identifies
+    the specific tool.  For non-MCP phases, `tool_name` is None.
+    """
     phase: TimingPhase = Field(..., description="Lifecycle phase")
+    tool_name: Optional[str] = Field(None, description="MCP tool name (cleaned, without claudevn_ prefix)")
     count: int = Field(0, description="Number of measurements")
     avg_ms: float = Field(0.0, description="Average duration in milliseconds")
     p50_ms: float = Field(0.0, description="Median duration in milliseconds")
@@ -54,18 +58,8 @@ class AggregateStats(BaseModel):
     max_ms: float = Field(0.0, description="Maximum duration in milliseconds")
 
 
-class ProjectTimingSummary(BaseModel):
-    """Project-level timing summary for the dashboard."""
-    total_duration_ms: float = Field(0.0, description="Sum of all wall times")
-    directive_count: int = Field(0, description="Unique directives with timing data")
-    issue_count: int = Field(0, description="Unique issues with timing data")
-    timing_event_count: int = Field(0, description="Total timing entries")
-    work_item_count: int = Field(0, description="Total work items")
-
-
 class TimingDashboardResponse(BaseModel):
     """Response for the timing dashboard API."""
     work_items: List[WorkItemTiming] = Field(default_factory=list, description="Recent work item timings")
     aggregates: List[AggregateStats] = Field(default_factory=list, description="Aggregate stats by phase")
     total_work_items: int = Field(0, description="Total work items with timing data")
-    project_summary: Optional[ProjectTimingSummary] = Field(None, description="Project-level timing summary")

--- a/serving/services/timing_service.py
+++ b/serving/services/timing_service.py
@@ -12,7 +12,6 @@ from typing import Dict, List, Optional
 
 from models.timing import (
     AggregateStats,
-    ProjectTimingSummary,
     TimingDashboardResponse,
     TimingEntry,
     TimingPhase,
@@ -205,45 +204,81 @@ class TimingService:
         keys.reverse()
         return [self._memory[k] for k in keys if k in self._memory]
 
+    @staticmethod
+    def _clean_tool_name(name: str) -> str:
+        """Strip common prefixes from MCP tool names."""
+        if name and name.startswith("claudevn_"):
+            return name[len("claudevn_"):]
+        return name
+
     async def get_aggregate_stats(self, limit: int = 100) -> List[AggregateStats]:
         """Compute aggregate stats across recent work items.
+
+        MCP tool calls are broken out by individual tool name rather than
+        being grouped as a single "mcp_tool_call" category.
 
         Args:
             limit: Number of recent work items to aggregate over
 
         Returns:
-            List of AggregateStats, one per phase
+            List of AggregateStats, one per (phase, tool_name) combination
         """
         timings = await self.get_recent_timings(limit)
 
-        # Collect durations by phase
-        by_phase: Dict[TimingPhase, List[float]] = {}
+        # Collect durations by (phase, tool_name) where tool_name is set
+        # only for MCP tool calls.
+        by_key: Dict[tuple, List[float]] = {}
         for timing in timings:
             for entry in timing.entries:
-                if entry.duration_ms is not None:
-                    by_phase.setdefault(entry.phase, []).append(entry.duration_ms)
+                if entry.duration_ms is None:
+                    continue
+                if entry.phase == TimingPhase.MCP_TOOL_CALL:
+                    raw_name = (entry.metadata or {}).get("tool_name", "")
+                    tool_name = self._clean_tool_name(raw_name) if raw_name else "unknown"
+                    key = (entry.phase, tool_name)
+                else:
+                    key = (entry.phase, None)
+                by_key.setdefault(key, []).append(entry.duration_ms)
 
         results = []
+        # Non-MCP phases first (in enum order), then MCP tools sorted by name
         for phase in TimingPhase:
-            durations = by_phase.get(phase, [])
+            if phase == TimingPhase.MCP_TOOL_CALL:
+                continue
+            durations = by_key.get((phase, None), [])
             if not durations:
                 continue
+            results.append(self._make_aggregate(phase, None, durations))
 
-            durations_sorted = sorted(durations)
-            count = len(durations_sorted)
-
-            results.append(AggregateStats(
-                phase=phase,
-                count=count,
-                avg_ms=round(statistics.mean(durations_sorted), 1),
-                p50_ms=round(self._percentile(durations_sorted, 50), 1),
-                p95_ms=round(self._percentile(durations_sorted, 95), 1),
-                p99_ms=round(self._percentile(durations_sorted, 99), 1),
-                min_ms=round(durations_sorted[0], 1),
-                max_ms=round(durations_sorted[-1], 1),
-            ))
+        # MCP tool calls sorted alphabetically by tool name
+        mcp_keys = sorted(
+            (k for k in by_key if k[0] == TimingPhase.MCP_TOOL_CALL),
+            key=lambda k: k[1] or "",
+        )
+        for key in mcp_keys:
+            phase, tool_name = key
+            durations = by_key[key]
+            results.append(self._make_aggregate(phase, tool_name, durations))
 
         return results
+
+    def _make_aggregate(
+        self, phase: TimingPhase, tool_name: Optional[str], durations: List[float]
+    ) -> AggregateStats:
+        """Build an AggregateStats from a list of durations."""
+        durations_sorted = sorted(durations)
+        count = len(durations_sorted)
+        return AggregateStats(
+            phase=phase,
+            tool_name=tool_name,
+            count=count,
+            avg_ms=round(statistics.mean(durations_sorted), 1),
+            p50_ms=round(self._percentile(durations_sorted, 50), 1),
+            p95_ms=round(self._percentile(durations_sorted, 95), 1),
+            p99_ms=round(self._percentile(durations_sorted, 99), 1),
+            min_ms=round(durations_sorted[0], 1),
+            max_ms=round(durations_sorted[-1], 1),
+        )
 
     async def get_dashboard(self, limit: int = 20) -> TimingDashboardResponse:
         """Get dashboard data combining recent timings and aggregates.
@@ -269,22 +304,20 @@ class TimingService:
         else:
             total = len(self._memory)
 
-        # Compute project summary
-        project_summary = self._compute_project_summary(work_items, total)
-
         return TimingDashboardResponse(
             work_items=work_items,
             aggregates=aggregates,
             total_work_items=total,
-            project_summary=project_summary,
         )
 
     async def _enrich_issue_context(
         self, work_items: List[WorkItemTiming]
     ) -> None:
-        """Enrich work items with full lineage context.
+        """Enrich work items with issue and directive context.
 
-        Resolves the chain: work_id → issue → goal → directive.
+        Looks up each work_id in the work map service to find the associated
+        issue ID and title.  Also traces directive-level work items
+        (decomp-*, char-*, conflict-*) back to their parent directive.
         Modifies work items in place.
         """
         try:
@@ -292,16 +325,25 @@ class TimingService:
             wm_service = get_work_map_service()
         except (RuntimeError, ImportError):
             logger.debug("Work map service not available for issue enrichment")
-            return
+            wm_service = None
 
-        # Cache lookups to avoid repeated queries
-        issue_cache = {}  # issue_id -> Issue
-        goal_cache = {}   # goal_id -> Goal
-        directive_cache = {}  # directive_id -> UnifiedDirective
+        # Optional services for directive tracing
+        goal_service = None
+        directive_service = None
+        try:
+            from services.goal_service import get_goal_service
+            goal_service = get_goal_service()
+        except (RuntimeError, ImportError):
+            pass
+        try:
+            from services.unified_directive_service import get_unified_directive_service
+            directive_service = get_unified_directive_service()
+        except (RuntimeError, ImportError):
+            pass
 
         for item in work_items:
-            # Step 1: Resolve issue from work item
-            if not item.issue_id:
+            # Enrich issue context from work map
+            if not item.issue_id and wm_service:
                 try:
                     work = await wm_service.get_work(item.work_id)
                     if work and work.issue_id:
@@ -310,78 +352,77 @@ class TimingService:
                 except Exception:
                     logger.debug(f"Could not look up issue for work_id={item.work_id}")
 
-            # Step 2: Resolve goal from issue
-            if item.issue_id and not item.goal_id:
-                try:
-                    issue = issue_cache.get(item.issue_id)
-                    if issue is None:
-                        issue = await wm_service.get_issue(item.issue_id)
-                        issue_cache[item.issue_id] = issue
-                    if issue and issue.goal_id:
-                        item.goal_id = issue.goal_id
-                except Exception:
-                    logger.debug(f"Could not look up goal for issue_id={item.issue_id}")
+            # Trace directive-level work (decomp-*, char-*, conflict-*)
+            if not item.directive_id:
+                await self._enrich_directive_context(
+                    item, goal_service, directive_service
+                )
 
-            # Step 3: Resolve directive from goal
-            if item.goal_id and not item.directive_id:
-                try:
-                    goal = goal_cache.get(item.goal_id)
-                    if goal is None:
-                        from services.goal_service import get_goal_service
-                        goal_service = get_goal_service()
-                        goal = await goal_service.get_goal(item.goal_id)
-                        goal_cache[item.goal_id] = goal
-                    if goal and goal.directive_id:
-                        item.directive_id = goal.directive_id
-                        # Resolve directive text
-                        if item.directive_id not in directive_cache:
-                            try:
-                                from services.unified_directive_service import get_unified_directive_service
-                                uds = get_unified_directive_service()
-                                directive = await uds.get_directive(
-                                    goal.project_id or "", item.directive_id
-                                )
-                                directive_cache[item.directive_id] = directive
-                            except Exception:
-                                directive_cache[item.directive_id] = None
-                        directive = directive_cache.get(item.directive_id)
-                        if directive:
-                            # Use first 120 chars of directive text as summary
-                            text = directive.text
-                            item.directive_text = text[:120] + ("..." if len(text) > 120 else "")
-                except Exception:
-                    logger.debug(f"Could not look up directive for goal_id={item.goal_id}")
+    async def _enrich_directive_context(
+        self,
+        item: WorkItemTiming,
+        goal_service,
+        directive_service,
+    ) -> None:
+        """Trace a work item back to its parent directive if possible.
 
-    @staticmethod
-    def _compute_project_summary(
-        work_items: List[WorkItemTiming], total_work_items: int
-    ) -> ProjectTimingSummary:
-        """Compute project-level timing summary from enriched work items."""
-        total_duration = 0.0
-        directive_ids = set()
-        issue_ids = set()
-        timing_event_count = 0
+        Handles decomp-{id}, char-{id}, and conflict-{work_id}-{hex} patterns
+        by looking up the goal associated with the decomposition/characterization
+        and then finding the directive that created the goal.
+        """
+        work_id = item.work_id
+        goal_id = None
 
-        for item in work_items:
-            # Sum wall times
-            for entry in item.entries:
-                if entry.phase.value == "total_wall_time" and entry.duration_ms:
-                    total_duration += entry.duration_ms
-            # Count timing entries
-            timing_event_count += len(item.entries)
-            # Collect unique directives and issues
-            if item.directive_id:
-                directive_ids.add(item.directive_id)
-            if item.issue_id:
-                issue_ids.add(item.issue_id)
+        try:
+            if work_id.startswith("decomp-") and goal_service:
+                # decomp-{decomposition_id} — find goal by decomposition_id
+                decomp_id = work_id
+                goals = await goal_service.list_goals()
+                for goal in goals:
+                    if getattr(goal, "decomposition_id", None) == decomp_id:
+                        goal_id = goal.goal_id
+                        break
+            elif work_id.startswith("char-") and goal_service:
+                # char-{id} — characterization tasks tie to a goal similarly
+                goals = await goal_service.list_goals()
+                for goal in goals:
+                    passes = getattr(goal, "decomposition_passes", []) or []
+                    for p in passes:
+                        if isinstance(p, dict) and p.get("characterization_id") == work_id:
+                            goal_id = goal.goal_id
+                            break
+                    if goal_id:
+                        break
+            elif work_id.startswith("conflict-"):
+                # conflict-{original_work_id}-{hex} — no direct goal link;
+                # mark as directive-level system work
+                item.directive_id = "__system__"
+                item.directive_title = "Conflict Resolution"
+                return
+            elif work_id.startswith("compute-"):
+                # compute lifecycle — system-level
+                item.directive_id = "__system__"
+                item.directive_title = "Compute Lifecycle"
+                return
+            else:
+                return  # Not a directive-level work item
 
-        return ProjectTimingSummary(
-            total_duration_ms=round(total_duration, 1),
-            directive_count=len(directive_ids),
-            issue_count=len(issue_ids),
-            timing_event_count=timing_event_count,
-            work_item_count=total_work_items,
-        )
+            # Resolve goal → directive
+            if goal_id and directive_service:
+                directives = await directive_service.list_directives()
+                for d in directives:
+                    outcome = getattr(d, "outcome", None)
+                    if outcome and getattr(outcome, "goal_id_created", None) == goal_id:
+                        item.directive_id = d.directive_id
+                        item.directive_title = getattr(d, "title", None) or d.directive_id
+                        return
+
+            # Could resolve goal but not directive — still mark as directive-level
+            if goal_id:
+                item.directive_id = f"goal:{goal_id}"
+                item.directive_title = f"Goal {goal_id[:8]}..."
+        except Exception:
+            logger.debug(f"Could not trace directive for work_id={work_id}")
 
     # =========================================================================
     # Private helpers

--- a/serving/tests/test_timing_service.py
+++ b/serving/tests/test_timing_service.py
@@ -1,0 +1,238 @@
+"""Tests for timing service aggregate stats and enrichment."""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from serving.models.timing import (
+    AggregateStats,
+    TimingEntry,
+    TimingPhase,
+    WorkItemTiming,
+)
+from serving.services.timing_service import TimingService
+
+
+def _make_entry(phase, duration_ms, tool_name=None):
+    """Create a TimingEntry with optional tool_name metadata."""
+    meta = {}
+    if tool_name:
+        meta["tool_name"] = tool_name
+    return TimingEntry(
+        phase=phase,
+        start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        end=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        duration_ms=duration_ms,
+        metadata=meta,
+    )
+
+
+def _make_work_item(work_id, entries, issue_id=None, issue_title=None):
+    """Create a WorkItemTiming with given entries."""
+    return WorkItemTiming(
+        work_id=work_id,
+        instance_id="compute-1",
+        entries=entries,
+        issue_id=issue_id,
+        issue_title=issue_title,
+    )
+
+
+class TestCleanToolName:
+    """Tests for _clean_tool_name static method."""
+
+    def test_strips_claudevn_prefix(self):
+        assert TimingService._clean_tool_name("claudevn_get_context") == "get_context"
+
+    def test_leaves_names_without_prefix(self):
+        assert TimingService._clean_tool_name("get_context") == "get_context"
+
+    def test_handles_empty_string(self):
+        assert TimingService._clean_tool_name("") == ""
+
+
+class TestGetAggregateStats:
+    """Tests for aggregate stats with per-tool MCP breakdown."""
+
+    @pytest.fixture
+    def service(self):
+        return TimingService(redis_client=None)
+
+    @pytest.mark.asyncio
+    async def test_empty_returns_empty(self, service):
+        stats = await service.get_aggregate_stats(limit=10)
+        assert stats == []
+
+    @pytest.mark.asyncio
+    async def test_non_mcp_phases_aggregated_normally(self, service):
+        service._memory_append_entry(
+            "w1:c1", "w1", "c1",
+            _make_entry(TimingPhase.SDK_LAUNCH, 100.0),
+        )
+        service._memory_append_entry(
+            "w2:c1", "w2", "c1",
+            _make_entry(TimingPhase.SDK_LAUNCH, 200.0),
+        )
+
+        stats = await service.get_aggregate_stats(limit=10)
+        assert len(stats) == 1
+        assert stats[0].phase == TimingPhase.SDK_LAUNCH
+        assert stats[0].tool_name is None
+        assert stats[0].count == 2
+        assert stats[0].avg_ms == 150.0
+
+    @pytest.mark.asyncio
+    async def test_mcp_calls_broken_out_by_tool_name(self, service):
+        service._memory_append_entry(
+            "w1:c1", "w1", "c1",
+            _make_entry(TimingPhase.MCP_TOOL_CALL, 100.0, "claudevn_get_context"),
+        )
+        service._memory_append_entry(
+            "w1:c1", "w1", "c1",
+            _make_entry(TimingPhase.MCP_TOOL_CALL, 200.0, "claudevn_get_context"),
+        )
+        service._memory_append_entry(
+            "w1:c1", "w1", "c1",
+            _make_entry(TimingPhase.MCP_TOOL_CALL, 300.0, "claudevn_report_progress"),
+        )
+
+        stats = await service.get_aggregate_stats(limit=10)
+
+        # Should have 2 MCP groups: get_context and report_progress
+        mcp_stats = [s for s in stats if s.phase == TimingPhase.MCP_TOOL_CALL]
+        assert len(mcp_stats) == 2
+
+        gc = next(s for s in mcp_stats if s.tool_name == "get_context")
+        assert gc.count == 2
+        assert gc.avg_ms == 150.0
+
+        rp = next(s for s in mcp_stats if s.tool_name == "report_progress")
+        assert rp.count == 1
+        assert rp.avg_ms == 300.0
+
+    @pytest.mark.asyncio
+    async def test_mcp_without_tool_name_uses_unknown(self, service):
+        service._memory_append_entry(
+            "w1:c1", "w1", "c1",
+            _make_entry(TimingPhase.MCP_TOOL_CALL, 100.0),
+        )
+
+        stats = await service.get_aggregate_stats(limit=10)
+        mcp_stats = [s for s in stats if s.phase == TimingPhase.MCP_TOOL_CALL]
+        assert len(mcp_stats) == 1
+        assert mcp_stats[0].tool_name == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_non_mcp_before_mcp_in_results(self, service):
+        service._memory_append_entry(
+            "w1:c1", "w1", "c1",
+            _make_entry(TimingPhase.SDK_LAUNCH, 100.0),
+        )
+        service._memory_append_entry(
+            "w1:c1", "w1", "c1",
+            _make_entry(TimingPhase.MCP_TOOL_CALL, 200.0, "claudevn_get_context"),
+        )
+
+        stats = await service.get_aggregate_stats(limit=10)
+        assert len(stats) == 2
+        assert stats[0].phase == TimingPhase.SDK_LAUNCH
+        assert stats[1].phase == TimingPhase.MCP_TOOL_CALL
+        assert stats[1].tool_name == "get_context"
+
+    @pytest.mark.asyncio
+    async def test_mcp_tools_sorted_alphabetically(self, service):
+        service._memory_append_entry(
+            "w1:c1", "w1", "c1",
+            _make_entry(TimingPhase.MCP_TOOL_CALL, 100.0, "claudevn_report_progress"),
+        )
+        service._memory_append_entry(
+            "w1:c1", "w1", "c1",
+            _make_entry(TimingPhase.MCP_TOOL_CALL, 200.0, "claudevn_get_context"),
+        )
+
+        stats = await service.get_aggregate_stats(limit=10)
+        tool_names = [s.tool_name for s in stats if s.phase == TimingPhase.MCP_TOOL_CALL]
+        assert tool_names == ["get_context", "report_progress"]
+
+
+class TestEnrichDirectiveContext:
+    """Tests for directive-level work item enrichment."""
+
+    @pytest.fixture
+    def service(self):
+        return TimingService(redis_client=None)
+
+    @pytest.mark.asyncio
+    async def test_conflict_work_id_marked_as_system(self, service):
+        item = _make_work_item("conflict-w1-abc123", [])
+        await service._enrich_directive_context(item, None, None)
+        assert item.directive_id == "__system__"
+        assert item.directive_title == "Conflict Resolution"
+
+    @pytest.mark.asyncio
+    async def test_compute_work_id_marked_as_system(self, service):
+        item = _make_work_item("compute-lifecycle-xyz", [])
+        await service._enrich_directive_context(item, None, None)
+        assert item.directive_id == "__system__"
+        assert item.directive_title == "Compute Lifecycle"
+
+    @pytest.mark.asyncio
+    async def test_regular_work_id_not_enriched(self, service):
+        item = _make_work_item("regular-work-item", [])
+        await service._enrich_directive_context(item, None, None)
+        assert item.directive_id is None
+        assert item.directive_title is None
+
+    @pytest.mark.asyncio
+    async def test_decomp_traced_to_goal_and_directive(self, service):
+        # Mock goal service
+        mock_goal = MagicMock()
+        mock_goal.goal_id = "goal-1"
+        mock_goal.decomposition_id = "decomp-abc"
+
+        goal_service = AsyncMock()
+        goal_service.list_goals = AsyncMock(return_value=[mock_goal])
+
+        # Mock directive service
+        mock_directive = MagicMock()
+        mock_directive.directive_id = "dir-1"
+        mock_directive.title = "Build authentication"
+        mock_outcome = MagicMock()
+        mock_outcome.goal_id_created = "goal-1"
+        mock_directive.outcome = mock_outcome
+
+        directive_service = AsyncMock()
+        directive_service.list_directives = AsyncMock(return_value=[mock_directive])
+
+        item = _make_work_item("decomp-abc", [])
+        await service._enrich_directive_context(item, goal_service, directive_service)
+
+        assert item.directive_id == "dir-1"
+        assert item.directive_title == "Build authentication"
+
+    @pytest.mark.asyncio
+    async def test_decomp_with_goal_but_no_directive(self, service):
+        mock_goal = MagicMock()
+        mock_goal.goal_id = "goal-1"
+        mock_goal.decomposition_id = "decomp-abc"
+
+        goal_service = AsyncMock()
+        goal_service.list_goals = AsyncMock(return_value=[mock_goal])
+
+        directive_service = AsyncMock()
+        directive_service.list_directives = AsyncMock(return_value=[])
+
+        item = _make_work_item("decomp-abc", [])
+        await service._enrich_directive_context(item, goal_service, directive_service)
+
+        assert item.directive_id == "goal:goal-1"
+
+    @pytest.mark.asyncio
+    async def test_exception_does_not_propagate(self, service):
+        goal_service = AsyncMock()
+        goal_service.list_goals = AsyncMock(side_effect=RuntimeError("boom"))
+
+        item = _make_work_item("decomp-abc", [])
+        # Should not raise
+        await service._enrich_directive_context(item, goal_service, None)
+        assert item.directive_id is None


### PR DESCRIPTION
## Summary
- Fix issue IDs displaying UUID fragments instead of titles — now shows `issue_title` as primary label
- Fix project/directive/issue total time showing 0ms — sums all entry durations instead of only `total_wall_time`
- Break out MCP tool calls by individual tool name in Aggregate Statistics (e.g., `get_context`, `report_progress`)
- Restructure timing page into three clear tiers: **Directives** (decomp/char/conflict work), **Issues** (titled issue work), **Unassigned** (everything else)
- Add directive enrichment to trace `decomp-*`, `char-*`, `conflict-*`, `compute-*` work IDs back to parent directives
- Rename "Untracked" to "Unassigned"

## Changes
- `serving/models/timing.py` — Add `directive_id`/`directive_title` to `WorkItemTiming`, add `tool_name` to `AggregateStats`
- `serving/services/timing_service.py` — Break out MCP aggregation by tool name, add directive enrichment pipeline
- `serving/frontend/src/pages/TimingPage.jsx` — Three-tier UI (Directives/Issues/Unassigned), fix duration aggregation, use title as primary label
- `serving/frontend/src/pages/TimingPage.test.jsx` — Updated tests for new exports (`classifyWorkItems`, `sumEntryDurations`)
- `serving/tests/test_timing_service.py` — New: 15 unit tests for aggregate stats and directive enrichment

## Testing
- [x] Tier 1 unit tests added/updated
- [x] All Tier 1 unit tests passing — 15 backend + 18 frontend tests
- [x] `./scripts/run_unit_tests.sh serving/tests/test_timing_service.py` passes

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issues
Closes #125