### PR TITLE
feat: Redesign notification system as dedicated page (#148)

### DIFF
--- a/serving/api/notifications.py
+++ b/serving/api/notifications.py
@@ -73,3 +73,27 @@ async def mark_all_read(
         return {"marked_count": count}
     except RuntimeError:
         return {"marked_count": 0}
+
+
+@router.post("/{notification_id}/dismiss")
+async def dismiss_notification(notification_id: str):
+    """Dismiss (remove) a single notification."""
+    try:
+        service = get_notification_service()
+        found = service.dismiss(notification_id)
+        return {"dismissed": found}
+    except RuntimeError:
+        return {"dismissed": False}
+
+
+@router.post("/dismiss-all")
+async def dismiss_all_notifications(
+    project_id: Optional[str] = Query(None),
+):
+    """Dismiss all read notifications."""
+    try:
+        service = get_notification_service()
+        count = service.dismiss_all(project_id)
+        return {"dismissed_count": count}
+    except RuntimeError:
+        return {"dismissed_count": 0}

--- a/serving/frontend/src/App.jsx
+++ b/serving/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import ProfilePage from './pages/ProfilePage'
 import SSHKeysPage from './pages/SSHKeysPage'
 import AuthSetupPage from './pages/AuthSetupPage'
 import TimingPage from './pages/TimingPage'
+import NotificationsPage from './pages/NotificationsPage'
 import UserManagementPage from './pages/UserManagementPage'
 import LoginPage from './pages/LoginPage'
 import SetPasswordPage from './pages/SetPasswordPage'
@@ -44,6 +45,7 @@ function AuthenticatedApp({ expired, expiringAt, onReauth }) {
             <Route path="/marketplace" element={<SkillsPage />} />
             <Route path="/network" element={<NetworkHealthPage />} />
             <Route path="/timing" element={<TimingPage />} />
+            <Route path="/notifications" element={<NotificationsPage />} />
             <Route path="/settings/profile" element={<ProfilePage />} />
             <Route path="/settings/ssh-keys" element={<SSHKeysPage />} />
             <Route path="/settings/users" element={<UserManagementPage />} />

--- a/serving/frontend/src/api/notifications.js
+++ b/serving/frontend/src/api/notifications.js
@@ -4,6 +4,7 @@ export async function getNotifications(projectId = null, options = {}) {
   const params = new URLSearchParams()
   if (projectId) params.append('project_id', projectId)
   if (options.unreadOnly) params.append('unread_only', 'true')
+  if (options.category) params.append('category', options.category)
   if (options.limit) params.append('limit', String(options.limit))
   const qs = params.toString()
   return request(`/notifications${qs ? `?${qs}` : ''}`)
@@ -25,4 +26,15 @@ export async function markAllNotificationsRead(projectId = null) {
   if (projectId) params.append('project_id', projectId)
   const qs = params.toString()
   return request(`/notifications/read-all${qs ? `?${qs}` : ''}`, { method: 'POST' })
+}
+
+export async function dismissNotification(notificationId) {
+  return request(`/notifications/${notificationId}/dismiss`, { method: 'POST' })
+}
+
+export async function dismissAllNotifications(projectId = null) {
+  const params = new URLSearchParams()
+  if (projectId) params.append('project_id', projectId)
+  const qs = params.toString()
+  return request(`/notifications/dismiss-all${qs ? `?${qs}` : ''}`, { method: 'POST' })
 }

--- a/serving/frontend/src/components/layout/Sidebar.jsx
+++ b/serving/frontend/src/components/layout/Sidebar.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { NavLink } from 'react-router-dom'
-import { Radio, Sparkles, FolderGit2, ListTodo, Play, Target, ChevronDown, Check, Key, Settings, Timer } from 'lucide-react'
+import { Radio, Sparkles, FolderGit2, ListTodo, Play, Target, ChevronDown, Check, Key, Timer } from 'lucide-react'
 import useSystemHealth from '../../hooks/useSystemHealth'
 import { useProjectContext } from '../../contexts/ProjectContext'
 import NotificationBell from '../notifications/NotificationBell'

--- a/serving/frontend/src/components/notifications/NotificationBell.jsx
+++ b/serving/frontend/src/components/notifications/NotificationBell.jsx
@@ -1,136 +1,24 @@
-import { useState, useRef, useEffect } from 'react'
-import { Bell, CheckCheck, Info, CheckCircle2, AlertTriangle, AlertCircle } from 'lucide-react'
+import { NavLink } from 'react-router-dom'
+import { Bell } from 'lucide-react'
 import useNotifications from '../../hooks/useNotifications'
 import './Notifications.css'
 
-const levelIcons = {
-  info: Info,
-  success: CheckCircle2,
-  warning: AlertTriangle,
-  error: AlertCircle,
-}
-
-const levelColors = {
-  info: 'var(--primary)',
-  success: 'var(--success)',
-  warning: 'var(--warning)',
-  error: 'var(--error)',
-}
-
-function timeAgo(dateStr) {
-  const now = Date.now()
-  const then = new Date(dateStr).getTime()
-  const diff = Math.floor((now - then) / 1000)
-  if (diff < 60) return 'just now'
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86400)}d ago`
-}
-
 function NotificationBell({ projectId }) {
-  const [isOpen, setIsOpen] = useState(false)
-  const [panelPos, setPanelPos] = useState(null)
-  const containerRef = useRef(null)
-  const bellRef = useRef(null)
-
-  const { notifications, unreadCount, markRead, markAllRead, refresh } =
-    useNotifications(projectId, { pollInterval: 15000 })
-
-  // Position panel above the bell
-  useEffect(() => {
-    if (isOpen && bellRef.current) {
-      const rect = bellRef.current.getBoundingClientRect()
-      setPanelPos({
-        bottom: window.innerHeight - rect.top + 4,
-        left: rect.left,
-      })
-    }
-  }, [isOpen])
-
-  // Close on outside click
-  useEffect(() => {
-    function handleClick(e) {
-      if (containerRef.current && !containerRef.current.contains(e.target)) {
-        setIsOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
-  }, [])
-
-  // Close on Escape
-  useEffect(() => {
-    function handleKey(e) {
-      if (e.key === 'Escape') setIsOpen(false)
-    }
-    if (isOpen) {
-      document.addEventListener('keydown', handleKey)
-      return () => document.removeEventListener('keydown', handleKey)
-    }
-  }, [isOpen])
-
-  const handleOpen = () => {
-    setIsOpen(!isOpen)
-    if (!isOpen) refresh()
-  }
+  const { unreadCount } = useNotifications(projectId, { pollInterval: 15000 })
 
   return (
-    <div className="notification-bell-container" ref={containerRef}>
-      <button
-        ref={bellRef}
-        className="notification-bell-trigger"
-        onClick={handleOpen}
-        title={unreadCount > 0 ? `${unreadCount} unread notifications` : 'Notifications'}
-      >
-        <Bell size={16} strokeWidth={1.5} />
-        {unreadCount > 0 && (
-          <span className="notification-bell-badge">{unreadCount > 9 ? '9+' : unreadCount}</span>
-        )}
-      </button>
-
-      {isOpen && panelPos && (
-        <div
-          className="notification-panel"
-          style={{ bottom: `${panelPos.bottom}px`, left: `${panelPos.left}px` }}
-        >
-          <div className="notification-panel-header">
-            <span className="notification-panel-title">Notifications</span>
-            {unreadCount > 0 && (
-              <button className="notification-mark-all" onClick={markAllRead} title="Mark all read">
-                <CheckCheck size={14} />
-              </button>
-            )}
-          </div>
-
-          <div className="notification-list">
-            {notifications.length === 0 ? (
-              <div className="notification-empty">No notifications</div>
-            ) : (
-              notifications.map(n => {
-                const Icon = levelIcons[n.level] || Info
-                return (
-                  <button
-                    key={n.notification_id}
-                    className={`notification-item ${n.read ? 'read' : 'unread'}`}
-                    onClick={() => !n.read && markRead(n.notification_id)}
-                  >
-                    <Icon size={14} style={{ color: levelColors[n.level], flexShrink: 0 }} />
-                    <div className="notification-item-content">
-                      <span className="notification-item-title">{n.title}</span>
-                      {n.message && (
-                        <span className="notification-item-message">{n.message}</span>
-                      )}
-                      <span className="notification-item-time">{timeAgo(n.created_at)}</span>
-                    </div>
-                    {!n.read && <span className="notification-unread-dot" />}
-                  </button>
-                )
-              })
-            )}
-          </div>
-        </div>
+    <NavLink
+      to="/notifications"
+      className={({ isActive }) =>
+        `notification-bell-trigger ${isActive ? 'active' : ''}`
+      }
+      title={unreadCount > 0 ? `${unreadCount} unread notifications` : 'Notifications'}
+    >
+      <Bell size={16} strokeWidth={1.5} />
+      {unreadCount > 0 && (
+        <span className="notification-bell-badge">{unreadCount > 9 ? '9+' : unreadCount}</span>
       )}
-    </div>
+    </NavLink>
   )
 }
 

--- a/serving/frontend/src/components/notifications/Notifications.css
+++ b/serving/frontend/src/components/notifications/Notifications.css
@@ -1,10 +1,6 @@
 /* =============================================================================
-   Notification Bell
+   Notification Bell (sidebar badge)
    ============================================================================= */
-
-.notification-bell-container {
-  position: relative;
-}
 
 .notification-bell-trigger {
   display: flex;
@@ -19,11 +15,18 @@
   color: var(--text-muted);
   cursor: pointer;
   transition: all var(--transition-fast);
+  text-decoration: none;
 }
 
 .notification-bell-trigger:hover {
   background: var(--bg-hover);
   color: var(--text);
+}
+
+.notification-bell-trigger.active {
+  background: var(--primary-muted);
+  color: var(--primary);
+  border-color: var(--primary);
 }
 
 .notification-bell-badge {
@@ -42,135 +45,4 @@
   align-items: center;
   justify-content: center;
   line-height: 1;
-}
-
-/* =============================================================================
-   Notification Panel
-   ============================================================================= */
-
-.notification-panel {
-  position: fixed;
-  width: 320px;
-  max-height: 400px;
-  background: var(--bg-primary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0,0,0,0.15));
-  display: flex;
-  flex-direction: column;
-  z-index: 1000;
-  overflow: hidden;
-}
-
-.notification-panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-sm) var(--space-md);
-  border-bottom: 1px solid var(--border);
-}
-
-.notification-panel-title {
-  font-size: var(--font-size-sm);
-  font-weight: 600;
-  color: var(--text);
-}
-
-.notification-mark-all {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  background: transparent;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-}
-
-.notification-mark-all:hover {
-  background: var(--bg-hover);
-  color: var(--primary);
-}
-
-/* =============================================================================
-   Notification List
-   ============================================================================= */
-
-.notification-list {
-  overflow-y: auto;
-  max-height: 340px;
-}
-
-.notification-empty {
-  padding: var(--space-lg);
-  text-align: center;
-  color: var(--text-muted);
-  font-size: var(--font-size-sm);
-}
-
-.notification-item {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-xs);
-  padding: var(--space-xs) var(--space-md);
-  width: 100%;
-  background: transparent;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  text-align: left;
-  cursor: pointer;
-  transition: background var(--transition-fast);
-}
-
-.notification-item:last-child {
-  border-bottom: none;
-}
-
-.notification-item:hover {
-  background: var(--bg-hover);
-}
-
-.notification-item.unread {
-  background: rgba(var(--primary-rgb, 99, 102, 241), 0.04);
-}
-
-.notification-item-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
-}
-
-.notification-item-title {
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-  color: var(--text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.notification-item-message {
-  font-size: var(--font-size-xs);
-  color: var(--text-muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.notification-item-time {
-  font-size: 10px;
-  color: var(--text-muted);
-}
-
-.notification-unread-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--primary);
-  flex-shrink: 0;
-  margin-top: 6px;
 }

--- a/serving/frontend/src/hooks/useNotifications.js
+++ b/serving/frontend/src/hooks/useNotifications.js
@@ -1,5 +1,12 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
-import { getNotifications, getUnreadCount, markNotificationRead, markAllNotificationsRead } from '../api/notifications'
+import {
+  getNotifications,
+  getUnreadCount,
+  markNotificationRead,
+  markAllNotificationsRead,
+  dismissNotification,
+  dismissAllNotifications,
+} from '../api/notifications'
 
 const POLL_INTERVAL_MS = 15000
 
@@ -7,10 +14,10 @@ const POLL_INTERVAL_MS = 15000
  * Hook for notification data with polling.
  *
  * @param {string} projectId - Active project ID
- * @param {Object} options - { pollInterval }
+ * @param {Object} options - { pollInterval, category, unreadOnly }
  */
 function useNotifications(projectId, options = {}) {
-  const { pollInterval = POLL_INTERVAL_MS } = options
+  const { pollInterval = POLL_INTERVAL_MS, category = null, unreadOnly = false } = options
 
   const [notifications, setNotifications] = useState([])
   const [unreadCount, setUnreadCount] = useState(0)
@@ -20,7 +27,11 @@ function useNotifications(projectId, options = {}) {
   const fetchNotifications = useCallback(async () => {
     try {
       setLoading(true)
-      const data = await getNotifications(projectId, { limit: 30 })
+      const data = await getNotifications(projectId, {
+        limit: 100,
+        category: category || undefined,
+        unreadOnly,
+      })
       setNotifications(data.items || [])
       setUnreadCount(data.unread_count || 0)
     } catch {
@@ -28,7 +39,7 @@ function useNotifications(projectId, options = {}) {
     } finally {
       setLoading(false)
     }
-  }, [projectId])
+  }, [projectId, category, unreadOnly])
 
   const fetchUnreadCount = useCallback(async () => {
     try {
@@ -61,6 +72,31 @@ function useNotifications(projectId, options = {}) {
     }
   }, [projectId])
 
+  const dismiss = useCallback(async (notificationId) => {
+    try {
+      await dismissNotification(notificationId)
+      setNotifications(prev => {
+        const removed = prev.find(n => n.notification_id === notificationId)
+        const next = prev.filter(n => n.notification_id !== notificationId)
+        if (removed && !removed.read) {
+          setUnreadCount(c => Math.max(0, c - 1))
+        }
+        return next
+      })
+    } catch {
+      // Silently handle
+    }
+  }, [])
+
+  const dismissAll = useCallback(async () => {
+    try {
+      await dismissAllNotifications(projectId)
+      setNotifications(prev => prev.filter(n => !n.read))
+    } catch {
+      // Silently handle
+    }
+  }, [projectId])
+
   useEffect(() => {
     fetchNotifications()
 
@@ -77,6 +113,8 @@ function useNotifications(projectId, options = {}) {
     refresh: fetchNotifications,
     markRead,
     markAllRead,
+    dismiss,
+    dismissAll,
   }
 }
 

--- a/serving/frontend/src/pages/NotificationsPage.css
+++ b/serving/frontend/src/pages/NotificationsPage.css
@@ -1,0 +1,293 @@
+/* =============================================================================
+   Notifications Page
+   ============================================================================= */
+
+.notif-page-actions {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.notif-action-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+}
+
+.notif-action-btn:hover {
+  background: var(--bg-active);
+  color: var(--text);
+}
+
+.notif-action-danger {
+  color: var(--text-muted);
+}
+
+.notif-action-danger:hover {
+  color: var(--error);
+  border-color: var(--error);
+}
+
+/* Toolbar / Filters */
+
+.notif-toolbar {
+  margin-bottom: var(--space-lg);
+}
+
+.notif-filters {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.notif-filter-group {
+  display: flex;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.notif-filter-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.notif-filter-btn:not(:last-child) {
+  border-right: 1px solid var(--border);
+}
+
+.notif-filter-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.notif-filter-btn.active {
+  background: var(--primary-muted);
+  color: var(--primary);
+}
+
+.notif-filter-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 9px;
+  background: var(--error);
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.notif-filter-sep {
+  width: 1px;
+  height: 20px;
+  background: var(--border);
+}
+
+.notif-category-filter {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-muted);
+}
+
+.notif-category-select {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.notif-category-select:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+/* Empty State */
+
+.notif-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xl) var(--space-lg);
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.notif-empty-icon {
+  margin-bottom: var(--space-md);
+  opacity: 0.3;
+}
+
+.notif-empty-title {
+  font-size: var(--font-size-md);
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin: 0 0 var(--space-xs);
+}
+
+.notif-empty-sub {
+  font-size: var(--font-size-sm);
+  margin: 0;
+}
+
+/* Notification List */
+
+.notif-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.notif-group-label {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: var(--space-sm);
+}
+
+.notif-group {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Notification Card */
+
+.notif-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  margin-bottom: var(--space-xs);
+  transition: background var(--transition-fast);
+}
+
+.notif-card:hover {
+  background: var(--bg-hover);
+}
+
+.notif-card.unread {
+  border-left: 3px solid var(--primary);
+  background: rgba(var(--primary-rgb, 99, 102, 241), 0.04);
+}
+
+.notif-card-icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.notif-card-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.notif-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.notif-card-title {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--text);
+}
+
+.notif-card-time {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.notif-card-message {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  margin: 2px 0 0;
+  line-height: 1.4;
+}
+
+.notif-card-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-top: 4px;
+}
+
+.notif-card-category {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+  background: var(--bg-hover);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.notif-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.notif-card:hover .notif-card-actions {
+  opacity: 1;
+}
+
+.notif-card-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: all var(--transition-fast);
+}
+
+.notif-card-action:hover {
+  background: var(--bg-active);
+  color: var(--primary);
+}
+
+.notif-card-dismiss:hover {
+  color: var(--error);
+}

--- a/serving/frontend/src/pages/NotificationsPage.jsx
+++ b/serving/frontend/src/pages/NotificationsPage.jsx
@@ -1,0 +1,233 @@
+import { useState, useMemo } from 'react'
+import { Bell, CheckCheck, Trash2, Info, CheckCircle2, AlertTriangle, AlertCircle, X, Filter } from 'lucide-react'
+import useNotifications from '../hooks/useNotifications'
+import { useProjectContext } from '../contexts/ProjectContext'
+import './NotificationsPage.css'
+
+const levelIcons = {
+  info: Info,
+  success: CheckCircle2,
+  warning: AlertTriangle,
+  error: AlertCircle,
+}
+
+const levelColors = {
+  info: 'var(--primary)',
+  success: 'var(--success)',
+  warning: 'var(--warning)',
+  error: 'var(--error)',
+}
+
+const categoryLabels = {
+  goal: 'Goal',
+  issue: 'Issue',
+  work: 'Work',
+  compute: 'Compute',
+  system: 'System',
+}
+
+const readFilters = [
+  { value: 'all', label: 'All' },
+  { value: 'unread', label: 'Unread' },
+  { value: 'read', label: 'Read' },
+]
+
+const categoryFilters = [
+  { value: '', label: 'All Types' },
+  { value: 'goal', label: 'Goal' },
+  { value: 'issue', label: 'Issue' },
+  { value: 'work', label: 'Work' },
+  { value: 'compute', label: 'Compute' },
+  { value: 'system', label: 'System' },
+]
+
+function timeAgo(dateStr) {
+  const now = Date.now()
+  const then = new Date(dateStr).getTime()
+  const diff = Math.floor((now - then) / 1000)
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+function groupByDate(notifications) {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const yesterday = new Date(today)
+  yesterday.setDate(yesterday.getDate() - 1)
+
+  const groups = { Today: [], Yesterday: [], Older: [] }
+
+  for (const n of notifications) {
+    const date = new Date(n.created_at)
+    date.setHours(0, 0, 0, 0)
+    if (date.getTime() >= today.getTime()) {
+      groups.Today.push(n)
+    } else if (date.getTime() >= yesterday.getTime()) {
+      groups.Yesterday.push(n)
+    } else {
+      groups.Older.push(n)
+    }
+  }
+
+  return Object.entries(groups).filter(([, items]) => items.length > 0)
+}
+
+function NotificationsPage() {
+  const { activeProject } = useProjectContext()
+  const [readFilter, setReadFilter] = useState('all')
+  const [categoryFilter, setCategoryFilter] = useState('')
+
+  const {
+    notifications,
+    unreadCount,
+    loading,
+    markRead,
+    markAllRead,
+    dismiss,
+    dismissAll,
+  } = useNotifications(activeProject?.project_id, { pollInterval: 15000 })
+
+  const filtered = useMemo(() => {
+    let items = notifications
+    if (readFilter === 'unread') items = items.filter(n => !n.read)
+    if (readFilter === 'read') items = items.filter(n => n.read)
+    if (categoryFilter) items = items.filter(n => n.category === categoryFilter)
+    return items
+  }, [notifications, readFilter, categoryFilter])
+
+  const grouped = useMemo(() => groupByDate(filtered), [filtered])
+
+  const hasReadNotifications = notifications.some(n => n.read)
+
+  return (
+    <div className="page">
+      <header className="page-header">
+        <h1 className="page-title">Notifications</h1>
+        <div className="notif-page-actions">
+          {unreadCount > 0 && (
+            <button className="notif-action-btn" onClick={markAllRead} title="Mark all as read">
+              <CheckCheck size={14} />
+              <span>Mark all read</span>
+            </button>
+          )}
+          {hasReadNotifications && (
+            <button className="notif-action-btn notif-action-danger" onClick={dismissAll} title="Dismiss all read">
+              <Trash2 size={14} />
+              <span>Dismiss read</span>
+            </button>
+          )}
+        </div>
+      </header>
+
+      <div className="notif-toolbar">
+        <div className="notif-filters">
+          <div className="notif-filter-group">
+            {readFilters.map(f => (
+              <button
+                key={f.value}
+                className={`notif-filter-btn ${readFilter === f.value ? 'active' : ''}`}
+                onClick={() => setReadFilter(f.value)}
+              >
+                {f.label}
+                {f.value === 'unread' && unreadCount > 0 && (
+                  <span className="notif-filter-count">{unreadCount}</span>
+                )}
+              </button>
+            ))}
+          </div>
+          <div className="notif-filter-sep" />
+          <div className="notif-category-filter">
+            <Filter size={12} />
+            <select
+              value={categoryFilter}
+              onChange={e => setCategoryFilter(e.target.value)}
+              className="notif-category-select"
+            >
+              {categoryFilters.map(f => (
+                <option key={f.value} value={f.value}>{f.label}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {loading && notifications.length === 0 ? (
+        <div className="notif-empty">
+          <div className="notif-empty-icon"><Bell size={32} /></div>
+          <p>Loading notifications...</p>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="notif-empty">
+          <div className="notif-empty-icon"><Bell size={32} /></div>
+          <p className="notif-empty-title">
+            {readFilter === 'unread' ? 'No unread notifications' :
+             readFilter === 'read' ? 'No read notifications' :
+             'No notifications yet'}
+          </p>
+          <p className="notif-empty-sub">
+            {readFilter === 'all'
+              ? 'System events will appear here as they happen.'
+              : 'Try changing the filter to see more.'}
+          </p>
+        </div>
+      ) : (
+        <div className="notif-list">
+          {grouped.map(([label, items]) => (
+            <div key={label} className="notif-group">
+              <div className="notif-group-label">{label}</div>
+              {items.map(n => {
+                const Icon = levelIcons[n.level] || Info
+                return (
+                  <div
+                    key={n.notification_id}
+                    className={`notif-card ${n.read ? 'read' : 'unread'}`}
+                  >
+                    <div className="notif-card-icon" style={{ color: levelColors[n.level] }}>
+                      <Icon size={16} />
+                    </div>
+                    <div className="notif-card-body">
+                      <div className="notif-card-header">
+                        <span className="notif-card-title">{n.title}</span>
+                        <span className="notif-card-time">{timeAgo(n.created_at)}</span>
+                      </div>
+                      {n.message && <p className="notif-card-message">{n.message}</p>}
+                      <div className="notif-card-meta">
+                        {n.category && (
+                          <span className="notif-card-category">
+                            {categoryLabels[n.category] || n.category}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="notif-card-actions">
+                      {!n.read && (
+                        <button
+                          className="notif-card-action"
+                          onClick={() => markRead(n.notification_id)}
+                          title="Mark as read"
+                        >
+                          <CheckCheck size={14} />
+                        </button>
+                      )}
+                      <button
+                        className="notif-card-action notif-card-dismiss"
+                        onClick={() => dismiss(n.notification_id)}
+                        title="Dismiss"
+                      >
+                        <X size={14} />
+                      </button>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default NotificationsPage

--- a/serving/services/notification_service.py
+++ b/serving/services/notification_service.py
@@ -135,6 +135,36 @@ class NotificationService:
                 count += 1
         return count
 
+    def dismiss(self, notification_id: str) -> bool:
+        """Dismiss (remove) a notification.
+
+        Returns:
+            True if found and removed, False if not found
+        """
+        for n in self._notifications:
+            if n.notification_id == notification_id:
+                self._notifications.remove(n)
+                return True
+        return False
+
+    def dismiss_all(self, project_id: Optional[str] = None) -> int:
+        """Dismiss all read notifications.
+
+        Args:
+            project_id: Only dismiss notifications for this project
+
+        Returns:
+            Number of notifications dismissed
+        """
+        to_remove = [
+            n for n in self._notifications
+            if n.read
+            and (project_id is None or n.project_id == project_id or n.project_id is None)
+        ]
+        for n in to_remove:
+            self._notifications.remove(n)
+        return len(to_remove)
+
     def get_unread_count(self, project_id: Optional[str] = None) -> int:
         """Get count of unread notifications."""
         return sum(

--- a/serving/tests/unit/test_notification_api.py
+++ b/serving/tests/unit/test_notification_api.py
@@ -128,3 +128,53 @@ class TestMarkAllRead:
         resp = client.post("/notifications/read-all?project_id=p1")
         assert resp.status_code == 200
         mock_service.mark_all_read.assert_called_once_with("p1")
+
+
+# =============================================================================
+# POST /notifications/{id}/dismiss
+# =============================================================================
+
+
+class TestDismiss:
+    def test_dismiss(self, client, mock_service):
+        mock_service.dismiss.return_value = True
+        resp = client.post("/notifications/notif_abc/dismiss")
+        assert resp.status_code == 200
+        assert resp.json() == {"dismissed": True}
+        mock_service.dismiss.assert_called_once_with("notif_abc")
+
+    def test_dismiss_not_found(self, client, mock_service):
+        mock_service.dismiss.return_value = False
+        resp = client.post("/notifications/notif_xxx/dismiss")
+        assert resp.json() == {"dismissed": False}
+
+    def test_dismiss_graceful_on_uninitialized(self, client):
+        with patch("api.notifications.get_notification_service", side_effect=RuntimeError):
+            resp = client.post("/notifications/notif_abc/dismiss")
+        assert resp.status_code == 200
+        assert resp.json() == {"dismissed": False}
+
+
+# =============================================================================
+# POST /notifications/dismiss-all
+# =============================================================================
+
+
+class TestDismissAll:
+    def test_dismiss_all(self, client, mock_service):
+        mock_service.dismiss_all.return_value = 5
+        resp = client.post("/notifications/dismiss-all")
+        assert resp.status_code == 200
+        assert resp.json() == {"dismissed_count": 5}
+
+    def test_dismiss_all_with_project(self, client, mock_service):
+        mock_service.dismiss_all.return_value = 2
+        resp = client.post("/notifications/dismiss-all?project_id=p1")
+        assert resp.status_code == 200
+        mock_service.dismiss_all.assert_called_once_with("p1")
+
+    def test_dismiss_all_graceful_on_uninitialized(self, client):
+        with patch("api.notifications.get_notification_service", side_effect=RuntimeError):
+            resp = client.post("/notifications/dismiss-all")
+        assert resp.status_code == 200
+        assert resp.json() == {"dismissed_count": 0}

--- a/serving/tests/unit/test_notification_service.py
+++ b/serving/tests/unit/test_notification_service.py
@@ -163,6 +163,49 @@ class TestUnreadCount:
 
 
 # =============================================================================
+# Dismiss
+# =============================================================================
+
+
+class TestDismiss:
+    def test_dismiss_removes_notification(self, service):
+        n = service.emit(title="Bye")
+        assert service.dismiss(n.notification_id) is True
+        result = service.list_notifications()
+        assert result.total == 0
+
+    def test_dismiss_not_found(self, service):
+        assert service.dismiss("nonexistent") is False
+
+    def test_dismiss_updates_unread_count(self, service):
+        n = service.emit(title="Unread")
+        assert service.get_unread_count() == 1
+        service.dismiss(n.notification_id)
+        assert service.get_unread_count() == 0
+
+    def test_dismiss_all_removes_read_only(self, service):
+        n1 = service.emit(title="Read me")
+        service.emit(title="Still unread")
+        service.mark_read(n1.notification_id)
+        count = service.dismiss_all()
+        assert count == 1
+        result = service.list_notifications()
+        assert result.total == 1
+        assert result.items[0].title == "Still unread"
+
+    def test_dismiss_all_by_project(self, service):
+        n1 = service.emit(title="P1", project_id="proj_1")
+        n2 = service.emit(title="P2", project_id="proj_2")
+        service.mark_read(n1.notification_id)
+        service.mark_read(n2.notification_id)
+        count = service.dismiss_all(project_id="proj_1")
+        assert count == 1
+        result = service.list_notifications()
+        assert result.total == 1
+        assert result.items[0].title == "P2"
+
+
+# =============================================================================
 # Bounded Deque
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- Replace dropdown overlay notification panel with a dedicated `/notifications` page
- Sidebar bell icon now shows unread count badge and navigates to the page (no dropdown)
- Added dismiss/archive functionality (individual and bulk) with new backend endpoints
- Full-page view with read/unread filter, category filter, timestamp grouping, and empty states

## Changes

### Backend
- `serving/services/notification_service.py` — Added `dismiss()` and `dismiss_all()` methods
- `serving/api/notifications.py` — Added `POST /{id}/dismiss` and `POST /dismiss-all` endpoints

### Frontend
- **New:** `NotificationsPage.jsx` + `NotificationsPage.css` — Dedicated page with filters, grouping, dismiss actions
- **Rewritten:** `NotificationBell.jsx` — Stripped to badge-only NavLink (no dropdown)
- **Rewritten:** `Notifications.css` — Simplified to bell trigger + badge styles only
- **Updated:** `useNotifications.js` — Added `dismiss`, `dismissAll`, category/unreadOnly filter params
- **Updated:** `api/notifications.js` — Added `dismissNotification`, `dismissAllNotifications`, `category` param
- **Updated:** `App.jsx` — Added `/notifications` route
- **Updated:** `Sidebar.jsx` — Removed unused `Settings` import

## Testing
- [x] Tier 1 unit tests added for dismiss service methods (5 tests)
- [x] Tier 1 unit tests added for dismiss API endpoints (6 tests)
- [x] All 37 notification tests passing (`./scripts/run_unit_tests.sh`)

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issues
Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)