### PR TITLE
feat: Redesign project form to two-column layout (#138)

### DIFF
--- a/serving/frontend/src/components/projects/ProjectFormModal.jsx
+++ b/serving/frontend/src/components/projects/ProjectFormModal.jsx
@@ -396,52 +396,59 @@ function ProjectFormModal({ isOpen, onClose, onSuccess, project = null }) {
       isOpen={isOpen}
       onClose={onClose}
       title={isEditing ? 'Edit Project' : 'New Project'}
+      width="680px"
     >
       <form onSubmit={handleSubmit}>
-        <div className="form-group">
-          <label className="form-label" htmlFor="project-name">
-            Name
-          </label>
-          <input
-            id="project-name"
-            type="text"
-            className="form-input"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="My Project"
-            autoFocus
-          />
-        </div>
+        <div className="project-form-columns">
+          <div className="project-form-left">
+            <div className="form-group">
+              <label className="form-label" htmlFor="project-name">
+                Name
+              </label>
+              <input
+                id="project-name"
+                type="text"
+                className="form-input"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="My Project"
+                autoFocus
+              />
+            </div>
 
-        <div className="form-group">
-          <label className="form-label" htmlFor="project-description">
-            Description
-          </label>
-          <textarea
-            id="project-description"
-            className="form-textarea"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Optional description..."
-          />
-        </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="project-description">
+                Description
+              </label>
+              <textarea
+                id="project-description"
+                className="form-textarea"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Optional description..."
+              />
+            </div>
 
-        <div className="form-group">
-          <label className="form-label">Icon</label>
-          <IconPicker selectedIcon={icon} onSelect={setIcon} />
-        </div>
+            <div className="form-group">
+              <label className="form-label">Labels</label>
+              <LabelsInput labels={labels} onChange={setLabels} />
+              <p style={{ fontSize: 'var(--font-size-xs)', color: 'var(--text-muted)', marginTop: 'var(--space-xs)' }}>
+                Press Enter or comma to add a label
+              </p>
+            </div>
+          </div>
 
-        <div className="form-group">
-          <label className="form-label">Icon Color</label>
-          <ColorPicker selectedColor={iconColor} onSelect={setIconColor} />
-        </div>
+          <div className="project-form-right">
+            <div className="form-group">
+              <label className="form-label">Icon</label>
+              <IconPicker selectedIcon={icon} onSelect={setIcon} />
+            </div>
 
-        <div className="form-group">
-          <label className="form-label">Labels</label>
-          <LabelsInput labels={labels} onChange={setLabels} />
-          <p style={{ fontSize: 'var(--font-size-xs)', color: 'var(--text-muted)', marginTop: 'var(--space-xs)' }}>
-            Press Enter or comma to add a label
-          </p>
+            <div className="form-group">
+              <label className="form-label">Icon Color</label>
+              <ColorPicker selectedColor={iconColor} onSelect={setIconColor} />
+            </div>
+          </div>
         </div>
 
         {!isEditing && (

--- a/serving/frontend/src/components/projects/Projects.css
+++ b/serving/frontend/src/components/projects/Projects.css
@@ -291,10 +291,28 @@
   font-size: var(--font-size-xs);
 }
 
+/* Project form two-column layout */
+.project-form-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-lg);
+}
+
+.project-form-left,
+.project-form-right {
+  min-width: 0;
+}
+
+@media (max-width: 600px) {
+  .project-form-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Icon picker */
 .icon-picker {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(36px, 1fr));
   gap: var(--space-xs);
   padding: var(--space-sm);
   background: var(--bg);


### PR DESCRIPTION
## Summary
- Split the project form modal into a two-column grid layout (left: Name, Description, Labels; right: Icon picker, Icon color picker)
- Widened modal from 440px to 680px to accommodate the two columns
- Repositories section and action buttons remain full-width below the columns
- Responsive: collapses to single column on viewports ≤600px
- Icon picker grid uses `auto-fill` for flexible column count in narrower containers

## Changes
- `ProjectFormModal.jsx`: Wrapped form fields in `project-form-columns` grid with left/right sections
- `Projects.css`: Added `.project-form-columns`, `.project-form-left`, `.project-form-right` styles with responsive media query; made icon picker grid auto-fill

## Testing
- [x] Vite production build passes
- [x] All 19 existing ProjectFormModal unit tests passing
- [x] Create and edit modes both render correctly (no functional regressions)

## Issues
Closes #138