### PR TITLE
feat: Display ClaudeVN version in sidebar (#124)

### DIFF
--- a/serving/frontend/src/components/layout/Sidebar.css
+++ b/serving/frontend/src/components/layout/Sidebar.css
@@ -23,11 +23,26 @@
   flex-shrink: 0;
 }
 
+.sidebar-brand-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
 .sidebar-brand-text {
   font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text);
   letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.sidebar-brand-version {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  line-height: 1;
 }
 
 .sidebar-divider {

--- a/serving/frontend/src/components/layout/Sidebar.jsx
+++ b/serving/frontend/src/components/layout/Sidebar.jsx
@@ -117,7 +117,7 @@ function ProjectSelector() {
 }
 
 function Sidebar() {
-  const { overallStatus, loading } = useSystemHealth({ pollInterval: 60000 })
+  const { health, overallStatus, loading } = useSystemHealth({ pollInterval: 60000 })
   const { activeProject } = useProjectContext()
 
   const getIndicatorClass = () => {
@@ -154,7 +154,10 @@ function Sidebar() {
     <nav className="sidebar">
       <div className="sidebar-brand">
         <img src="/ClaudeVN-Logo-64x64.png" alt="ClaudeVN" width="28" height="28" />
-        <span className="sidebar-brand-text">ClaudeVN</span>
+        <div className="sidebar-brand-info">
+          <span className="sidebar-brand-text">ClaudeVN</span>
+          {health?.version && <span className="sidebar-brand-version">v{health.version}</span>}
+        </div>
       </div>
 
       <div className="sidebar-divider" />

--- a/serving/frontend/src/components/layout/Sidebar.test.jsx
+++ b/serving/frontend/src/components/layout/Sidebar.test.jsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Sidebar from './Sidebar.jsx'
+
+vi.mock('../../hooks/useSystemHealth', () => ({
+  default: vi.fn(() => ({
+    health: null,
+    overallStatus: 'unknown',
+    loading: true,
+  })),
+}))
+
+vi.mock('../../contexts/ProjectContext', () => ({
+  useProjectContext: vi.fn(() => ({
+    activeProject: null,
+    projects: [],
+    setActiveProject: vi.fn(),
+    loading: false,
+  })),
+}))
+
+import useSystemHealth from '../../hooks/useSystemHealth'
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter>
+      <Sidebar />
+    </MemoryRouter>
+  )
+}
+
+describe('Sidebar', () => {
+  describe('version display', () => {
+    it('shows version when health data includes version', () => {
+      useSystemHealth.mockReturnValue({
+        health: { version: '0.3.0', status: 'healthy' },
+        overallStatus: 'healthy',
+        loading: false,
+      })
+
+      renderSidebar()
+      expect(screen.getByText('v0.3.0')).toBeInTheDocument()
+    })
+
+    it('does not show version when health data is null', () => {
+      useSystemHealth.mockReturnValue({
+        health: null,
+        overallStatus: 'unknown',
+        loading: true,
+      })
+
+      renderSidebar()
+      expect(screen.queryByText(/^v\d/)).not.toBeInTheDocument()
+    })
+
+    it('does not show version when health has no version field', () => {
+      useSystemHealth.mockReturnValue({
+        health: { status: 'healthy' },
+        overallStatus: 'healthy',
+        loading: false,
+      })
+
+      renderSidebar()
+      expect(screen.queryByText(/^v\d/)).not.toBeInTheDocument()
+    })
+
+    it('renders version with correct CSS class', () => {
+      useSystemHealth.mockReturnValue({
+        health: { version: '1.0.0', status: 'healthy' },
+        overallStatus: 'healthy',
+        loading: false,
+      })
+
+      renderSidebar()
+      const versionEl = screen.getByText('v1.0.0')
+      expect(versionEl).toHaveClass('sidebar-brand-version')
+    })
+  })
+
+  describe('brand', () => {
+    it('renders the ClaudeVN brand text', () => {
+      useSystemHealth.mockReturnValue({
+        health: null,
+        overallStatus: 'unknown',
+        loading: true,
+      })
+
+      renderSidebar()
+      expect(screen.getByText('ClaudeVN')).toBeInTheDocument()
+    })
+
+    it('renders the logo image', () => {
+      useSystemHealth.mockReturnValue({
+        health: null,
+        overallStatus: 'unknown',
+        loading: true,
+      })
+
+      renderSidebar()
+      expect(screen.getByAltText('ClaudeVN')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Displays the ClaudeVN version (e.g., `v0.3.0`) below the logo text in the sidebar brand area
- Uses the version already exposed by the `/api/v1/health` endpoint via the existing `useSystemHealth` hook
- No new API endpoints needed — single source of truth remains the root `VERSION` file

## Changes
- **Sidebar.jsx**: Destructure `health` from `useSystemHealth`, wrap brand text in a container div, conditionally render version span
- **Sidebar.css**: Add `.sidebar-brand-info` container for vertical layout, add `.sidebar-brand-version` styling (small, muted font)
- **Sidebar.test.jsx**: New test file with 6 tests covering version display and brand rendering

## Testing
- [x] Tier 1 unit tests added (6 tests, all passing)
- [x] All Tier 1 unit tests passing

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issues
Closes #124