### PR TITLE
feat: filter timing page by selected project (#156)

### DIFF
--- a/serving/api/timing.py
+++ b/serving/api/timing.py
@@ -24,10 +24,11 @@ router = APIRouter(prefix="/timing", tags=["timing"])
 )
 async def get_dashboard(
     limit: int = Query(20, ge=1, le=100, description="Number of recent work items"),
+    project_id: Optional[str] = Query(None, description="Filter by project ID"),
 ):
     """Get combined dashboard with recent work item timings and aggregate stats."""
     service = get_timing_service()
-    return await service.get_dashboard(limit)
+    return await service.get_dashboard(limit, project_id=project_id)
 
 
 @router.get(

--- a/serving/frontend/src/api/timing.js
+++ b/serving/frontend/src/api/timing.js
@@ -1,7 +1,11 @@
 import { request } from './index.js'
 
-export async function getTimingDashboard(limit = 20) {
-  return request(`/timing/dashboard?limit=${limit}`)
+export async function getTimingDashboard(limit = 20, projectId = null) {
+  let url = `/timing/dashboard?limit=${limit}`
+  if (projectId) {
+    url += `&project_id=${encodeURIComponent(projectId)}`
+  }
+  return request(url)
 }
 
 export async function getWorkItemTiming(workId, instanceId) {

--- a/serving/frontend/src/hooks/useTiming.js
+++ b/serving/frontend/src/hooks/useTiming.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { getTimingDashboard } from '../api/timing'
 
-function useTiming(options = {}) {
+function useTiming(projectId, options = {}) {
   const { pollInterval = 10000, limit = 20 } = options
 
   const [dashboard, setDashboard] = useState(null)
@@ -9,8 +9,13 @@ function useTiming(options = {}) {
   const [error, setError] = useState(null)
 
   const load = useCallback(async () => {
+    if (!projectId) {
+      setDashboard(null)
+      setLoading(false)
+      return
+    }
     try {
-      const data = await getTimingDashboard(limit)
+      const data = await getTimingDashboard(limit, projectId)
       setDashboard(data)
       setError(null)
     } catch (err) {
@@ -18,7 +23,7 @@ function useTiming(options = {}) {
     } finally {
       setLoading(false)
     }
-  }, [limit])
+  }, [limit, projectId])
 
   const refresh = useCallback(() => {
     load()
@@ -27,11 +32,11 @@ function useTiming(options = {}) {
   useEffect(() => {
     load()
 
-    if (pollInterval > 0) {
+    if (pollInterval > 0 && projectId) {
       const interval = setInterval(load, pollInterval)
       return () => clearInterval(interval)
     }
-  }, [load, pollInterval])
+  }, [load, pollInterval, projectId])
 
   return {
     dashboard,

--- a/serving/frontend/src/pages/TimingPage.jsx
+++ b/serving/frontend/src/pages/TimingPage.jsx
@@ -1,6 +1,8 @@
 import { useState, useMemo } from 'react'
-import { RefreshCw, Clock, BarChart3, Timer, ChevronDown, ChevronRight, Layers, AlertCircle } from 'lucide-react'
+import { RefreshCw, Clock, BarChart3, Timer, ChevronDown, ChevronRight, Layers, AlertCircle, FolderOpen } from 'lucide-react'
 import Spinner from '../components/common/Spinner'
+import EmptyState from '../components/common/EmptyState'
+import { useProjectContext } from '../contexts/ProjectContext'
 import useTiming from '../hooks/useTiming'
 import './TimingPage.css'
 
@@ -403,7 +405,10 @@ function classifyWorkItems(workItems) {
 }
 
 function TimingPage() {
-  const { workItems, aggregates, totalWorkItems, loading, error, refresh } = useTiming({
+  const { activeProject } = useProjectContext()
+  const activeProjectId = activeProject?.project_id || null
+
+  const { workItems, aggregates, totalWorkItems, loading, error, refresh } = useTiming(activeProjectId, {
     pollInterval: 10000,
     limit: 20
   })
@@ -412,6 +417,24 @@ function TimingPage() {
     () => classifyWorkItems(workItems),
     [workItems]
   )
+
+  if (!activeProjectId) {
+    return (
+      <div className="page">
+        <header className="page-header">
+          <h1 className="page-title">
+            <Timer size={20} />
+            Timing
+          </h1>
+        </header>
+        <EmptyState
+          icon={FolderOpen}
+          title="Select a Project"
+          description="Please select a project from the sidebar to view timing data."
+        />
+      </div>
+    )
+  }
 
   if (loading && !workItems.length) {
     return (

--- a/serving/models/timing.py
+++ b/serving/models/timing.py
@@ -48,6 +48,7 @@ class WorkItemTiming(BaseModel):
     cache_creation_tokens: Optional[int] = Field(None, description="Cache creation tokens")
     num_turns: Optional[int] = Field(None, description="Number of conversation turns")
     session_id: Optional[str] = Field(None, description="SDK session ID")
+    project_id: Optional[str] = Field(None, description="Associated project identifier")
 
 
 class AggregateStats(BaseModel):

--- a/serving/services/timing_service.py
+++ b/serving/services/timing_service.py
@@ -278,7 +278,19 @@ class TimingService:
             List of AggregateStats, one per (phase, tool_name) combination
         """
         timings = await self.get_recent_timings(limit)
+        return self._compute_aggregates(timings)
 
+    def _compute_aggregates(
+        self, timings: List[WorkItemTiming]
+    ) -> List[AggregateStats]:
+        """Compute aggregate stats from a list of work item timings.
+
+        Args:
+            timings: Work item timings to aggregate over
+
+        Returns:
+            List of AggregateStats, one per (phase, tool_name) combination
+        """
         # Collect durations by (phase, tool_name) where tool_name is set
         # for MCP tool calls and TOOL_USE entries.
         by_key: Dict[tuple, List[float]] = {}
@@ -344,26 +356,43 @@ class TimingService:
             max_ms=round(durations_sorted[-1], 1),
         )
 
-    async def get_dashboard(self, limit: int = 20) -> TimingDashboardResponse:
+    async def get_dashboard(
+        self, limit: int = 20, project_id: Optional[str] = None
+    ) -> TimingDashboardResponse:
         """Get dashboard data combining recent timings and aggregates.
 
         Enriches work items with issue context from the work map service
-        when available.
+        when available.  When ``project_id`` is provided, results are
+        filtered to only include work items belonging to that project.
 
         Args:
             limit: Number of recent work items to show
+            project_id: Optional project ID to filter by
 
         Returns:
             TimingDashboardResponse
         """
-        work_items = await self.get_recent_timings(limit)
-        aggregates = await self.get_aggregate_stats(100)
+        # Fetch more items than requested so we have enough after filtering
+        fetch_limit = limit * 3 if project_id else limit
+        work_items = await self.get_recent_timings(fetch_limit)
 
-        # Enrich work items with issue context
+        # Enrich work items with issue and project context
         await self._enrich_issue_context(work_items)
 
+        # Filter by project if requested
+        if project_id:
+            work_items = [w for w in work_items if w.project_id == project_id]
+
+        # Trim to requested limit
+        work_items = work_items[:limit]
+
+        # Compute aggregates from the (possibly filtered) work items
+        aggregates = self._compute_aggregates(work_items)
+
         # Count total work items
-        if self._redis:
+        if project_id:
+            total = len(work_items)
+        elif self._redis:
             total = await self._redis_count()
         else:
             total = len(self._memory)
@@ -406,13 +435,16 @@ class TimingService:
             pass
 
         for item in work_items:
-            # Enrich issue context from work map
-            if not item.issue_id and wm_service:
+            # Enrich issue and project context from work map
+            if wm_service and (not item.issue_id or not item.project_id):
                 try:
                     work = await wm_service.get_work(item.work_id)
-                    if work and work.issue_id:
-                        item.issue_id = work.issue_id
-                        item.issue_title = work.title
+                    if work:
+                        if work.issue_id and not item.issue_id:
+                            item.issue_id = work.issue_id
+                            item.issue_title = work.title
+                        if getattr(work, 'project_id', None) and not item.project_id:
+                            item.project_id = work.project_id
                 except Exception:
                     logger.debug(f"Could not look up issue for work_id={item.work_id}")
 

--- a/serving/tests/test_timing_service.py
+++ b/serving/tests/test_timing_service.py
@@ -27,7 +27,7 @@ def _make_entry(phase, duration_ms, tool_name=None):
     )
 
 
-def _make_work_item(work_id, entries, issue_id=None, issue_title=None):
+def _make_work_item(work_id, entries, issue_id=None, issue_title=None, project_id=None):
     """Create a WorkItemTiming with given entries."""
     return WorkItemTiming(
         work_id=work_id,
@@ -35,6 +35,7 @@ def _make_work_item(work_id, entries, issue_id=None, issue_title=None):
         entries=entries,
         issue_id=issue_id,
         issue_title=issue_title,
+        project_id=project_id,
     )
 
 
@@ -357,3 +358,103 @@ class TestUpdateSessionMetrics:
         assert timing.total_cost_usd == 0.10
         assert timing.input_tokens is None
         assert timing.num_turns is None
+
+
+class TestDashboardProjectFilter:
+    """Tests for project_id filtering in get_dashboard."""
+
+    @pytest.fixture
+    def service(self):
+        return TimingService(redis_client=None)
+
+    def _seed_items(self, service):
+        """Seed service with work items that have project_id set."""
+        # Use service's append method to create items, then set project_id
+        service._memory_append_entry(
+            "w1:c1", "w1", "c1",
+            _make_entry(TimingPhase.SDK_LAUNCH, 100.0),
+        )
+        service._memory["w1:c1"].project_id = "proj-a"
+
+        service._memory_append_entry(
+            "w2:c1", "w2", "c1",
+            _make_entry(TimingPhase.SDK_LAUNCH, 200.0),
+        )
+        service._memory["w2:c1"].project_id = "proj-a"
+
+        service._memory_append_entry(
+            "w3:c1", "w3", "c1",
+            _make_entry(TimingPhase.SDK_LAUNCH, 300.0),
+        )
+        service._memory["w3:c1"].project_id = "proj-b"
+
+        service._memory_append_entry(
+            "w4:c1", "w4", "c1",
+            _make_entry(TimingPhase.SDK_LAUNCH, 400.0),
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_all(self, service):
+        self._seed_items(service)
+        # Patch out enrichment since items already have project_id set
+        with patch.object(service, "_enrich_issue_context", new_callable=AsyncMock):
+            result = await service.get_dashboard(limit=10)
+        assert len(result.work_items) == 4
+
+    @pytest.mark.asyncio
+    async def test_filter_by_project_a(self, service):
+        self._seed_items(service)
+        with patch.object(service, "_enrich_issue_context", new_callable=AsyncMock):
+            result = await service.get_dashboard(limit=10, project_id="proj-a")
+        assert len(result.work_items) == 2
+        assert all(w.project_id == "proj-a" for w in result.work_items)
+
+    @pytest.mark.asyncio
+    async def test_filter_by_project_b(self, service):
+        self._seed_items(service)
+        with patch.object(service, "_enrich_issue_context", new_callable=AsyncMock):
+            result = await service.get_dashboard(limit=10, project_id="proj-b")
+        assert len(result.work_items) == 1
+        assert result.work_items[0].work_id == "w3"
+
+    @pytest.mark.asyncio
+    async def test_filter_nonexistent_project_returns_empty(self, service):
+        self._seed_items(service)
+        with patch.object(service, "_enrich_issue_context", new_callable=AsyncMock):
+            result = await service.get_dashboard(limit=10, project_id="proj-z")
+        assert len(result.work_items) == 0
+        assert result.total_work_items == 0
+
+    @pytest.mark.asyncio
+    async def test_aggregates_scoped_to_filtered_items(self, service):
+        self._seed_items(service)
+        with patch.object(service, "_enrich_issue_context", new_callable=AsyncMock):
+            result = await service.get_dashboard(limit=10, project_id="proj-a")
+        # Aggregates should only be from proj-a items (100ms and 200ms)
+        sdk_stats = [a for a in result.aggregates if a.phase == TimingPhase.SDK_LAUNCH]
+        assert len(sdk_stats) == 1
+        assert sdk_stats[0].count == 2
+        assert sdk_stats[0].avg_ms == 150.0
+
+    @pytest.mark.asyncio
+    async def test_enrichment_sets_project_id(self, service):
+        """Test that _enrich_issue_context populates project_id from work_map_service."""
+        item = _make_work_item("w1", [])
+        assert item.project_id is None
+
+        mock_work = MagicMock()
+        mock_work.issue_id = "issue-1"
+        mock_work.title = "Test issue"
+        mock_work.project_id = "proj-x"
+
+        mock_wm_service = AsyncMock()
+        mock_wm_service.get_work = AsyncMock(return_value=mock_work)
+
+        with patch(
+            "services.work_map_service.get_work_map_service",
+            return_value=mock_wm_service,
+        ):
+            await service._enrich_issue_context([item])
+
+        assert item.project_id == "proj-x"
+        assert item.issue_id == "issue-1"


### PR DESCRIPTION
## Summary
- Add `project_id` filtering to timing dashboard API and frontend
- Timing page now scoped to the currently selected project, consistent with Backlog, Plan, and Goals pages
- Shows "Select a Project" empty state when no project is selected

## Changes
- **Backend**: Added `project_id` field to `WorkItemTiming` model, populated via `work_map_service` during enrichment. `/timing/dashboard` endpoint accepts optional `project_id` query parameter. Aggregates are computed from filtered items.
- **Frontend**: `useTiming` hook now takes `projectId` as first arg. `TimingPage` uses `useProjectContext()` to get selected project. API client passes `project_id` to backend.
- **Tests**: 6 new unit tests for project filtering (dashboard filter, aggregate scoping, enrichment)

## Testing
- [x] Tier 1 unit tests added (27/27 passing)
- [x] All existing tests still passing

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issues
Closes #156