### PR TITLE
feat: Expand project icon color palette from 12 to 18 colors (#155)

### DIFF
--- a/serving/frontend/src/components/projects/ProjectFormModal.jsx
+++ b/serving/frontend/src/components/projects/ProjectFormModal.jsx
@@ -24,13 +24,19 @@ const COLORS = [
   '#6366f1', // indigo (default primary)
   '#8b5cf6', // violet
   '#a855f7', // purple
+  '#d946ef', // fuchsia
   '#ec4899', // pink
+  '#f43f5e', // rose
   '#ef4444', // red
   '#f97316', // orange
+  '#f59e0b', // amber
   '#eab308', // yellow
+  '#84cc16', // lime
   '#22c55e', // green
+  '#10b981', // emerald
   '#14b8a6', // teal
   '#06b6d4', // cyan
+  '#0ea5e9', // sky
   '#3b82f6', // blue
   '#64748b', // slate
 ]


### PR DESCRIPTION
## Summary
- Adds 6 new colors (fuchsia, rose, amber, lime, emerald, sky) from the Tailwind palette to the project icon color picker
- Total palette expanded from 12 to 18 visually distinct colors

## Changes
- Updated `COLORS` array in `serving/frontend/src/components/projects/ProjectFormModal.jsx`

## Testing
- [x] All 19 existing unit tests passing
- [x] CSS uses `flex-wrap: wrap` — colors wrap properly at any count
- [x] No functional regressions (selection, persistence, display logic unchanged)

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)