### PR TITLE
docs: Audit and fix outdated documentation (#109)

### DIFF
--- a/.env.compute.example
+++ b/.env.compute.example
@@ -15,6 +15,15 @@
 #   themselves on startup and maintain a heartbeat connection.
 #   No inbound connections to Serving are required - only outbound
 #   HTTP(S) from the compute instance.
+#
+# Variable Naming:
+#   Both CLAUDEVN_* and COMPUTE_* prefixes are supported for backwards
+#   compatibility. Key equivalences:
+#     CLAUDEVN_COMPUTE_ID    ↔ COMPUTE_INSTANCE_ID
+#     CLAUDEVN_COMPUTE_NAME  ↔ COMPUTE_INSTANCE_NAME
+#     CLAUDEVN_SKILLS        ↔ COMPUTE_SKILLS
+#     CLAUDEVN_CAPABILITIES  ↔ COMPUTE_CAPABILITIES
+#     CLAUDEVN_SERVING_URL   ↔ SERVING_URL
 
 # ============================================
 # Required: Remote Serving Instance

--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,7 @@ AUTO_DEREGISTER=false
 # Configure marketplace with: SERVING_URL + AUTO_REGISTER_WITH_SERVING=true
 # Configure compute with: SERVING_URL + COMPUTE_REGISTER_ON_STARTUP=true
 #
-# See: docs/design/specifications/REGISTRATION_ARCHITECTURE.md
+# See: docs/design/specifications/compute-registration.md
 
 # Session management
 SESSION_TIMEOUT=60
@@ -84,10 +84,13 @@ GIT_ENABLE_HTTP=true
 SERVING_LOG_FILE=./logs/serving.log
 
 # ============================================
-# Compute Configuration (Port 8003)
+# Compute Configuration
 # ============================================
+# Compute instances have no HTTP server — they connect outbound
+# to Serving via SSE. COMPUTE_PORT is unused but kept for backwards
+# compatibility with legacy configs.
 COMPUTE_HOST=0.0.0.0
-COMPUTE_PORT=8003
+# COMPUTE_PORT=8003  # Unused — compute has no inbound HTTP server
 
 # Instance identity (auto-generated if not set)
 #COMPUTE_INSTANCE_ID=compute-dev-001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,10 @@
 # Services:
 #   serving      → Coordination hub at http://localhost:8002
 #   marketplace  → Skill marketplace at http://localhost:8003
-#   redis        → Redis at localhost:6379
-#   python-1/2    → Python compute agents
-#   node-1        → Full-stack compute agent
+#   redis        → Redis at localhost:6379 (PR queue, branch state, auth tokens)
+#   python-1     → Code Writer & Test Automator (Python specialist)
+#   python-2     → Debugger & Security Reviewer (Python specialist)
+#   node-1       → Full-stack developer (Node.js + Python)
 #
 # Authentication:
 #   Default: AUTH_MODE=bypass (no login required, dev user assumed)
@@ -271,7 +272,8 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
-  # Compute Instance 3 - Documentation specialist (TEMPORARILY DISABLED)
+  # Compute Instance 3 - Documentation specialist
+  # Disabled: doc-writer skill not yet implemented. Uncomment to enable.
   # compute-3:
   #   build:
   #     context: .

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -647,5 +647,4 @@ Should return available skills.
 
 - [Architecture Overview](design/architecture/v1.0-architecture.md)
 - [Git Infrastructure](design/specifications/git-infrastructure.md)
-- [Deployment Guide](guides/deployment-guide.md)
-- [API Reference](api-reference.md)
+- [Distributed Deployment Guide](guides/distributed-deployment.md)

--- a/docs/design/architecture/v1.0-architecture.md
+++ b/docs/design/architecture/v1.0-architecture.md
@@ -137,7 +137,11 @@ Compute instances are **Claude Code processes** that execute work autonomously.
                                  # e.g., f/task-123/compute-001
 ```
 
-**Note:** Each Compute handles one task at a time. Simple branch workflow - no worktrees needed.
+**Note:** Each Compute handles one task at a time. The workspace structure varies by deployment model:
+- **Distributed (Compute-side Spawner):** Simple clone + branch checkout as shown above
+- **Centralized (Serving-side Spawner):** Uses `/workspace/main` (reference) + `/workspace/active` (worktree)
+
+See [ADR-005](../adr/005-dual-spawner-architecture.md) for details on both models.
 
 #### Rules
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ The simplest way to get started is using Docker Compose, which starts all servic
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/Guarrdon/claudevn.git
+git clone https://github.com/trueorc/claudevn.git
 cd claudevn
 ```
 
@@ -50,9 +50,9 @@ This command starts:
 | **marketplace** | 8003 | Skill catalog and composition service |
 | **serving** | 8002 | Coordination hub, API, and monitoring UI |
 | **SSH Git** | 2222 | Git server for compute instances |
-| **compute-1** | 8010 | Code Writer specialist |
-| **compute-2** | 8011 | Debugger specialist |
-| **compute-3** | 8012 | Documentation Writer specialist |
+| **python-1** | — | Code Writer & Test Automator (outbound SSE to Serving) |
+| **python-2** | — | Debugger & Security Reviewer (outbound SSE to Serving) |
+| **node-1** | — | Full-stack developer (outbound SSE to Serving) |
 
 ### 3. Authenticate Claude Code
 
@@ -412,11 +412,11 @@ Now that you have ClaudeVN running:
 2. **Explore MCP tools** - See [MCP Tools Reference](design/specifications/mcp-tools.md) for the communication protocol
 3. **Author custom skills** - Check [Skill Authoring Guide](skill-authoring-guide.md) to create specialized agents
 4. **Configure advanced settings** - Review [Configuration Reference](configuration-reference.md)
-5. **Deploy to production** - See [Deployment Guide](deployment-guide.md) for production best practices
+5. **Deploy to production** - See [Distributed Deployment Guide](guides/distributed-deployment.md) for production best practices
 
 ## Getting Help
 
-- **GitHub Issues** - Report bugs or request features at [github.com/Guarrdon/claudevn/issues](https://github.com/Guarrdon/claudevn/issues)
+- **GitHub Issues** - Report bugs or request features at [github.com/trueorc/claudevn/issues](https://github.com/trueorc/claudevn/issues)
 - **Documentation** - Browse `docs/` for comprehensive guides and specifications
 - **Architecture Decisions** - See `docs/design/adr/` for design rationale
 

--- a/docs/guides/issue-creation-guide.md
+++ b/docs/guides/issue-creation-guide.md
@@ -108,7 +108,7 @@ After creating an issue, set the project board fields:
 # Get the issue's project item ID
 ITEM_ID=$(gh api graphql -f query='
 {
-  repository(owner: "Guarrdon", name: "claudevn") {
+  repository(owner: "trueorc", name: "claudevn") {
     issue(number: ISSUE_NUMBER) {
       projectItems(first: 1) {
         nodes { id }
@@ -269,7 +269,7 @@ EOF
 Issues are auto-added to the project via GitHub Actions. If not:
 
 ```bash
-gh project item-add 2 --owner Guarrdon --url https://github.com/Guarrdon/claudevn/issues/XX
+gh project item-add 2 --owner trueorc --url https://github.com/trueorc/claudevn/issues/XX
 ```
 
 ### Bulk Update Labels

--- a/docs/guides/uat-checklist.md
+++ b/docs/guides/uat-checklist.md
@@ -40,10 +40,10 @@ The following features lack proper UI support and have GitHub issues filed:
 
 | Gap | Issue | Priority | Status |
 |-----|-------|----------|--------|
-| Infrastructure Health Dashboard | [#328](https://github.com/Guarrdon/claudevn/issues/328) | P2 | Backlog |
-| Goal Creation UI | [#329](https://github.com/Guarrdon/claudevn/issues/329) | P2 | Backlog |
-| Skill Creation UI | [#330](https://github.com/Guarrdon/claudevn/issues/330) | P3 | Backlog |
-| Issue Creation/Editing in WorkMap | [#331](https://github.com/Guarrdon/claudevn/issues/331) | P1 | Backlog |
+| Infrastructure Health Dashboard | [#328](https://github.com/trueorc/claudevn/issues/328) | P2 | Backlog |
+| Goal Creation UI | [#329](https://github.com/trueorc/claudevn/issues/329) | P2 | Backlog |
+| Skill Creation UI | [#330](https://github.com/trueorc/claudevn/issues/330) | P3 | Backlog |
+| Issue Creation/Editing in WorkMap | [#331](https://github.com/trueorc/claudevn/issues/331) | P1 | Backlog |
 
 ---
 
@@ -92,7 +92,7 @@ Before testing, understand the three-tier work hierarchy:
 
 ## Phase 1: Infrastructure Health
 
-> **UI Gap:** No health dashboard exists. See [#328](https://github.com/Guarrdon/claudevn/issues/328)
+> **UI Gap:** No health dashboard exists. See [#328](https://github.com/trueorc/claudevn/issues/328)
 
 ### 1.1 Service Health Checks
 
@@ -117,7 +117,7 @@ Before testing, understand the three-tier work hierarchy:
 
 ## Phase 2: Marketplace & Skills
 
-> **UI Gap:** Cannot create skills from UI. See [#330](https://github.com/Guarrdon/claudevn/issues/330)
+> **UI Gap:** Cannot create skills from UI. See [#330](https://github.com/trueorc/claudevn/issues/330)
 
 ### 2.1 Skill Management
 
@@ -164,7 +164,7 @@ curl -X POST http://localhost:8003/api/v1/skills \
 
 ## Phase 4: Work Map - Goals
 
-> **UI Gap:** Cannot create goals from UI. See [#329](https://github.com/Guarrdon/claudevn/issues/329)
+> **UI Gap:** Cannot create goals from UI. See [#329](https://github.com/trueorc/claudevn/issues/329)
 
 ### 4.1 Goal Management
 
@@ -192,7 +192,7 @@ curl -X POST http://localhost:8002/api/v1/work-map/goals \
 
 ## Phase 5: Work Map - Issues
 
-> **UI Gap:** Cannot create/edit issues directly. See [#331](https://github.com/Guarrdon/claudevn/issues/331)
+> **UI Gap:** Cannot create/edit issues directly. See [#331](https://github.com/trueorc/claudevn/issues/331)
 
 ### 5.1 Issue Creation & Dependencies
 

--- a/serving/README.md
+++ b/serving/README.md
@@ -87,7 +87,7 @@ curl -X POST http://localhost:8002/api/v1/marketplaces/register \
   -H "Content-Type: application/json" \
   -d '{
     "name": "ClaudeVN Central Marketplace",
-    "endpoint": "http://localhost:8001",
+    "endpoint": "http://localhost:8003",
     "capabilities": {
       "agent_count": 10,
       "supports_search": true
@@ -590,7 +590,7 @@ cd ../marketplace && ./start.sh  # Start marketplace
 cd ../serving && ./start.sh       # Start serving
 
 # Register marketplace with serving
-curl -X POST http://localhost:8001/api/v1/integrations/serving/register \
+curl -X POST http://localhost:8003/api/v1/integrations/serving/register \
   -H "Content-Type: application/json" \
   -d '{"serving_url":"http://localhost:8002","marketplace_name":"Test Marketplace"}'
 


### PR DESCRIPTION
## Summary
- Comprehensive documentation audit across the project: fixed broken links, wrong ports, stale repo URLs, and inaccurate descriptions
- 9 files updated, documentation-only changes (no code changes)

## Changes

### Critical Fixes
- **`.env.example`**: Fixed broken link to `REGISTRATION_ARCHITECTURE.md` → `compute-registration.md`
- **`serving/README.md`**: Fixed marketplace port 8001 → 8003 (2 occurrences)
- **`docs/configuration-reference.md`**: Replaced broken `deployment-guide.md` and `api-reference.md` links with existing `distributed-deployment.md`
- **`docs/getting-started.md`**: Fixed broken deployment guide link, corrected compute port table (compute has no HTTP ports), updated repo URLs

### High Priority
- **`docs/getting-started.md`**, **`docs/guides/issue-creation-guide.md`**, **`docs/guides/uat-checklist.md`**: Replaced stale `Guarrdon/claudevn` references with `trueorc/claudevn`
- **`.env.example`**: Clarified COMPUTE_PORT is unused (compute connects outbound via SSE)
- **`docs/design/architecture/v1.0-architecture.md`**: Added dual-spawner deployment model note referencing ADR-005

### Medium Priority
- **`docker-compose.yml`**: Improved service descriptions with compute specializations
- **`.env.compute.example`**: Added CLAUDEVN_*/COMPUTE_* prefix equivalence documentation
- **`docker-compose.yml`**: Clarified disabled compute-3 comment

## Testing
- [x] Documentation-only changes — no tests required
- [x] All referenced files verified to exist
- [x] Port numbers verified against docker-compose.yml and config files

## Issues
Closes #109