### PR TITLE
fix: re-fetch ITEM_ID in code-issue Step 11 for board status updates

### DIFF
--- a/.claude/commands/code-issue.md
+++ b/.claude/commands/code-issue.md
@@ -332,6 +332,12 @@ echo "$OPEN_ISSUES"
 
 ### 11. Update DevBoard Status
 
+Re-fetch the project item ID (shell state from Step 3 is not preserved between commands):
+
+```bash
+ITEM_ID=$(gh api graphql -f query='{ repository(owner: "trueorc", name: "claudevn") { issue(number: {ISSUE_NUMBER}) { projectItems(first: 1) { nodes { id } } } } }' --jq '.data.repository.issue.projectItems.nodes[0].id')
+```
+
 **Single-issue mode** — set to "In Review":
 ```bash
 gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"PVT_kwDOD6FTDM4BQFhJ\" itemId: \"$ITEM_ID\" fieldId: \"PVTSSF_lADOD6FTDM4BQFhJzg-Tsck\" value: { singleSelectOptionId: \"4cc61d42\" } }) { projectV2Item { id } } }"


### PR DESCRIPTION
## Summary
- Fixes `/code-issue` workflow silently failing to update GitHub project board status in Step 11

## Root Cause
`$ITEM_ID` was fetched in Step 3 (set "In Progress") but referenced again in Step 11 without re-fetching. Since Claude Code runs each bash command in a separate shell session, the variable was always empty in Step 11, causing the GraphQL mutation to silently fail.

## Changes
- Added `ITEM_ID` re-fetch at the top of Step 11 in `.claude/commands/code-issue.md`

## Impact
- **Single-issue mode**: "In Review" status now correctly set after PR creation
- **Feature-grouped mode**: "Testing" status now correctly set after completion

## Test plan
- [ ] Run `/code-issue` on a test issue and verify board transitions to "In Review" or "Testing"

Generated with [Claude Code](https://claude.com/claude-code)