### PR TITLE
feat: Expose aggregate hardware resources in health API (#207)

### DIFF
--- a/serving/app.py
+++ b/serving/app.py
@@ -1321,7 +1321,8 @@ async def health_check():
         "redis": redis_stats,
         "compute_registry": {
             "total_instances": compute_stats["total_instances"],
-            "by_status": compute_stats["by_status"]
+            "by_status": compute_stats["by_status"],
+            "total_resources": compute_stats.get("total_resources", {})
         },
         "marketplace_registry": {
             "total_marketplaces": marketplace_stats["total_marketplaces"],

--- a/serving/frontend/src/components/dashboard/LeftPanels.css
+++ b/serving/frontend/src/components/dashboard/LeftPanels.css
@@ -382,6 +382,29 @@
   margin: 0;
 }
 
+/* Aggregate resource stats */
+.lp-resource-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-top: var(--space-xs);
+  padding-top: var(--space-xs);
+  border-top: 1px solid var(--border);
+}
+
+.lp-resource-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.lp-resource-icon {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
 .lp-network-marketplace {
   font-size: var(--font-size-xs);
   color: var(--text-muted);

--- a/serving/frontend/src/components/dashboard/LeftPanels.jsx
+++ b/serving/frontend/src/components/dashboard/LeftPanels.jsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom'
-import { Activity, Cpu, Plus } from 'lucide-react'
+import { Activity, Cpu, Database, Plus, Server } from 'lucide-react'
 import './LeftPanels.css'
 
 // ---------------------------------------------------------------------------
@@ -171,6 +171,7 @@ function NetworkPanel({ health, overallStatus, healthLoading }) {
   const computeByStatus = health?.compute_registry?.by_status ?? {}
   const computeTotal = health?.compute_registry?.total_instances ?? 0
   const computeOnline = computeByStatus.online ?? 0
+  const totalResources = health?.compute_registry?.total_resources ?? {}
 
   const marketplaceByStatus = health?.marketplace_registry?.by_status ?? {}
   const marketplaceTotal = health?.marketplace_registry?.total_instances ?? 0
@@ -228,6 +229,29 @@ function NetworkPanel({ health, overallStatus, healthLoading }) {
       <p className="lp-network-summary">
         {computeOnline} online / {computeTotal} total
       </p>
+
+      {(totalResources.cpu_count || totalResources.memory_gb || totalResources.gpu_count) && (
+        <div className="lp-resource-stats">
+          {totalResources.cpu_count && (
+            <span className="lp-resource-item" title="Total CPU cores">
+              <Cpu size={10} className="lp-resource-icon" />
+              <span>{totalResources.cpu_count} cores</span>
+            </span>
+          )}
+          {totalResources.memory_gb && (
+            <span className="lp-resource-item" title="Total memory">
+              <Server size={10} className="lp-resource-icon" />
+              <span>{totalResources.memory_gb} GB</span>
+            </span>
+          )}
+          {totalResources.gpu_count > 0 && (
+            <span className="lp-resource-item" title={totalResources.gpu_type || 'GPU'}>
+              <Database size={10} className="lp-resource-icon" />
+              <span>{totalResources.gpu_count} GPU{totalResources.gpu_count > 1 ? 's' : ''}</span>
+            </span>
+          )}
+        </div>
+      )}
 
       {marketplaceTotal > 0 && (
         <p className="lp-network-marketplace">

--- a/serving/services/registry_service.py
+++ b/serving/services/registry_service.py
@@ -1067,10 +1067,35 @@ class ComputeRegistry:
             status_counts[instance.status.value] += 1
             auth_counts[instance.auth_status.value] += 1
 
+        # Aggregate hardware resources across all instances
+        total_cpu = 0
+        total_memory = 0.0
+        total_gpu = 0
+        gpu_types = set()
+        for instance in self._instances.values():
+            res = instance.capabilities.resources if instance.capabilities else None
+            if res:
+                if res.cpu_count:
+                    total_cpu += res.cpu_count
+                if res.memory_gb:
+                    total_memory += res.memory_gb
+                if res.gpu_count:
+                    total_gpu += res.gpu_count
+                if res.gpu_type:
+                    gpu_types.add(res.gpu_type)
+
+        total_resources = {
+            "cpu_count": total_cpu if total_cpu > 0 else None,
+            "memory_gb": total_memory if total_memory > 0 else None,
+            "gpu_count": total_gpu if total_gpu > 0 else None,
+            "gpu_type": ", ".join(sorted(gpu_types)) if gpu_types else None,
+        }
+
         return {
             "total_instances": len(self._instances),
             "by_status": dict(status_counts),
             "by_auth_status": dict(auth_counts),
+            "total_resources": total_resources,
             "total_agents": len([k for k in self._capability_index.keys() if k.startswith("agent:")]),
             "total_tools": len([k for k in self._capability_index.keys() if k.startswith("tool:")]),
             "total_labels": len([k for k in self._capability_index.keys() if k.startswith("label:")]),

--- a/serving/tests/test_registry_resource_stats.py
+++ b/serving/tests/test_registry_resource_stats.py
@@ -1,0 +1,111 @@
+"""Unit tests for aggregate hardware resources in registry stats.
+
+Verifies that get_stats() includes total_resources aggregated from
+all registered compute instances (#207).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models.compute import ComputeInstance, InstanceCapabilities, InstanceResources
+from services.registry_service import ComputeRegistry
+
+
+def _make_instance(instance_id, resources=None, status="online"):
+    """Create a ComputeInstance with optional resources."""
+    from models.compute import InstanceStatus
+    inst = ComputeInstance(
+        instance_id=instance_id,
+        name=f"node-{instance_id}",
+        endpoint=f"http://{instance_id}:9000",
+        capabilities=InstanceCapabilities(resources=resources),
+    )
+    inst.status = InstanceStatus(status)
+    return inst
+
+
+@pytest.fixture
+def registry():
+    """Create a ComputeRegistry with a mocked storage backend."""
+    storage = MagicMock()
+    storage.load_all = AsyncMock(return_value=[])
+    reg = ComputeRegistry(storage_backend=storage)
+    return reg
+
+
+class TestGetStatsWithResources:
+    """Verify get_stats includes total_resources."""
+
+    def test_empty_registry_returns_null_resources(self, registry):
+        stats = registry.get_stats()
+        assert "total_resources" in stats
+        assert stats["total_resources"]["cpu_count"] is None
+        assert stats["total_resources"]["memory_gb"] is None
+        assert stats["total_resources"]["gpu_count"] is None
+        assert stats["total_resources"]["gpu_type"] is None
+
+    def test_single_instance_with_resources(self, registry):
+        inst = _make_instance("c1", resources=InstanceResources(
+            cpu_count=8, memory_gb=32.0, gpu_count=1, gpu_type="NVIDIA RTX 4090"
+        ))
+        registry._instances["c1"] = inst
+
+        stats = registry.get_stats()
+        res = stats["total_resources"]
+        assert res["cpu_count"] == 8
+        assert res["memory_gb"] == 32.0
+        assert res["gpu_count"] == 1
+        assert res["gpu_type"] == "NVIDIA RTX 4090"
+
+    def test_multiple_instances_aggregated(self, registry):
+        registry._instances["c1"] = _make_instance("c1", resources=InstanceResources(
+            cpu_count=8, memory_gb=32.0, gpu_count=1, gpu_type="NVIDIA RTX 4090"
+        ))
+        registry._instances["c2"] = _make_instance("c2", resources=InstanceResources(
+            cpu_count=16, memory_gb=64.0, gpu_count=2, gpu_type="NVIDIA RTX 4090"
+        ))
+        registry._instances["c3"] = _make_instance("c3", resources=InstanceResources(
+            cpu_count=4, memory_gb=16.0
+        ))
+
+        stats = registry.get_stats()
+        res = stats["total_resources"]
+        assert res["cpu_count"] == 28
+        assert res["memory_gb"] == 112.0
+        assert res["gpu_count"] == 3
+        assert res["gpu_type"] == "NVIDIA RTX 4090"
+
+    def test_multiple_gpu_types_joined(self, registry):
+        registry._instances["c1"] = _make_instance("c1", resources=InstanceResources(
+            gpu_count=1, gpu_type="NVIDIA RTX 4090"
+        ))
+        registry._instances["c2"] = _make_instance("c2", resources=InstanceResources(
+            gpu_count=2, gpu_type="NVIDIA A100"
+        ))
+
+        stats = registry.get_stats()
+        res = stats["total_resources"]
+        assert res["gpu_count"] == 3
+        # Sorted alphabetically, comma-separated
+        assert res["gpu_type"] == "NVIDIA A100, NVIDIA RTX 4090"
+
+    def test_instance_without_resources_skipped(self, registry):
+        registry._instances["c1"] = _make_instance("c1", resources=InstanceResources(
+            cpu_count=8, memory_gb=32.0
+        ))
+        registry._instances["c2"] = _make_instance("c2", resources=None)
+
+        stats = registry.get_stats()
+        res = stats["total_resources"]
+        assert res["cpu_count"] == 8
+        assert res["memory_gb"] == 32.0
+
+    def test_stats_still_includes_other_fields(self, registry):
+        """Ensure adding total_resources didn't break existing fields."""
+        stats = registry.get_stats()
+        assert "total_instances" in stats
+        assert "by_status" in stats
+        assert "by_auth_status" in stats
+        assert "total_agents" in stats
+        assert "total_tools" in stats


### PR DESCRIPTION
## Summary
- Add `total_resources` (cpu_count, memory_gb, gpu_count, gpu_type) to the `/api/v1/health` endpoint under `compute_registry`
- Display aggregate hardware resources in the Network panel on the Control Center dashboard
- Aggregate across all registered compute instances with support for multiple GPU types

## Changes
- **`serving/services/registry_service.py`** — `get_stats()` now aggregates hardware resources from `instance.capabilities.resources` across all instances
- **`serving/app.py`** — Health endpoint includes `total_resources` in `compute_registry` response
- **`serving/frontend/src/components/dashboard/LeftPanels.jsx`** — NetworkPanel displays CPU cores, memory (GB), and GPU count with type tooltip
- **`serving/frontend/src/components/dashboard/LeftPanels.css`** — Styling for resource stats display
- **`serving/tests/test_registry_resource_stats.py`** — 6 unit tests covering empty registry, single/multiple instances, multiple GPU types, and null resource handling

## Testing
- [x] Tier 1 unit tests added (6 tests, all passing)
- [x] All Tier 1 unit tests passing (`./scripts/run_unit_tests.sh`)
- [ ] Pre-existing failures in test_goal_decomposer.py and test_marketplace_client.py (unrelated)

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issues
Closes #207