### PR TITLE
feat: Global team presence with 3-day retention and activity tracking (#220)

### DIFF
--- a/serving/api/presence.py
+++ b/serving/api/presence.py
@@ -8,10 +8,10 @@ from api.users import get_current_user_id, get_optional_user_id
 from models.presence import HeartbeatRequest, PresenceResponse
 from services.presence_service import get_presence_service
 
-router = APIRouter(prefix="/projects/{project_id}/presence", tags=["presence"])
+router = APIRouter(tags=["presence"])
 
 
-@router.post("/heartbeat", status_code=204)
+@router.post("/projects/{project_id}/presence/heartbeat", status_code=204)
 async def heartbeat(
     project_id: str,
     body: HeartbeatRequest,
@@ -20,7 +20,6 @@ async def heartbeat(
     """Record or refresh a user's presence heartbeat for a project."""
     service = get_presence_service()
     if not service:
-        # Presence is optional — return 204 silently rather than 503
         return
 
     # Resolve display name from user service
@@ -40,10 +39,11 @@ async def heartbeat(
         user_id=user_id,
         display_name=display_name,
         current_view=body.current_view,
+        project_name=body.project_name,
     )
 
 
-@router.get("", response_model=PresenceResponse)
+@router.get("/projects/{project_id}/presence", response_model=PresenceResponse)
 async def get_presence(
     project_id: str,
     user_id: Optional[str] = Depends(get_optional_user_id),
@@ -54,4 +54,17 @@ async def get_presence(
         return PresenceResponse(users=[])
 
     users = await service.get_active_users(project_id)
+    return PresenceResponse(users=users)
+
+
+@router.get("/presence", response_model=PresenceResponse)
+async def get_global_presence(
+    user_id: Optional[str] = Depends(get_optional_user_id),
+):
+    """Get all active users globally (across all projects)."""
+    service = get_presence_service()
+    if not service:
+        return PresenceResponse(users=[])
+
+    users = await service.get_active_users()
     return PresenceResponse(users=users)

--- a/serving/frontend/src/api/presence.js
+++ b/serving/frontend/src/api/presence.js
@@ -4,12 +4,12 @@ import { request } from './index.js'
  * Send a presence heartbeat for a project.
  *
  * @param {string} projectId
- * @param {{ current_view?: string }} options
+ * @param {{ current_view?: string, project_name?: string }} options
  */
-export async function sendHeartbeat(projectId, { current_view = null } = {}) {
+export async function sendHeartbeat(projectId, { current_view = null, project_name = null } = {}) {
   return request(`/projects/${encodeURIComponent(projectId)}/presence/heartbeat`, {
     method: 'POST',
-    body: JSON.stringify({ current_view }),
+    body: JSON.stringify({ current_view, project_name }),
   })
 }
 
@@ -21,4 +21,13 @@ export async function sendHeartbeat(projectId, { current_view = null } = {}) {
  */
 export async function getPresence(projectId) {
   return request(`/projects/${encodeURIComponent(projectId)}/presence`)
+}
+
+/**
+ * Fetch all active users globally (across all projects).
+ *
+ * @returns {Promise<{ users: Array }>}
+ */
+export async function getGlobalPresence() {
+  return request('/presence')
 }

--- a/serving/frontend/src/components/common/UserAvatar.css
+++ b/serving/frontend/src/components/common/UserAvatar.css
@@ -64,7 +64,7 @@
 }
 
 .user-avatar-status-offline {
-  background: var(--text-muted);
+  background: var(--status-offline);
 }
 
 .user-avatar-status-away {

--- a/serving/frontend/src/components/dashboard/PresenceBar.jsx
+++ b/serving/frontend/src/components/dashboard/PresenceBar.jsx
@@ -2,8 +2,22 @@ import { useState } from 'react'
 import UserAvatar from '../common/UserAvatar'
 import './PresenceBar.css'
 
+function statusToAvatar(status) {
+  if (status === 'online') return 'online'
+  if (status === 'idle') return 'away'
+  return 'offline'
+}
+
+function activityLabel(user) {
+  const parts = []
+  if (user.project_name) parts.push(user.project_name)
+  if (user.current_view) parts.push(user.current_view)
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function PresenceTooltip({ user }) {
-  const view = user.current_view ? `viewing ${user.current_view}` : 'online'
+  const label = activityLabel(user)
+  const view = label ? `viewing ${label}` : user.status
   return (
     <div className="presence-tooltip">
       <span className="presence-tooltip-name">{user.display_name}</span>
@@ -26,7 +40,7 @@ function PresenceAvatar({ user }) {
         displayName={user.display_name}
         size="sm"
         showStatus
-        status={user.status === 'online' ? 'online' : 'away'}
+        status={statusToAvatar(user.status)}
       />
       {showTooltip && <PresenceTooltip user={user} />}
     </div>

--- a/serving/frontend/src/components/dashboard/RightPanels.jsx
+++ b/serving/frontend/src/components/dashboard/RightPanels.jsx
@@ -299,6 +299,19 @@ function TimingPanel({ aggregates, totalWorkItems }) {
   )
 }
 
+function teamStatusToAvatar(status) {
+  if (status === 'online') return 'online'
+  if (status === 'idle') return 'away'
+  return 'offline'
+}
+
+function teamActivityLabel(user) {
+  const parts = []
+  if (user.project_name) parts.push(user.project_name)
+  if (user.current_view) parts.push(user.current_view)
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function TeamPanel({ presenceUsers }) {
   const users = presenceUsers || []
   const onlineCount = users.filter((u) => u.status === 'online').length
@@ -308,30 +321,37 @@ function TeamPanel({ presenceUsers }) {
       <div className="rp-panel-header">
         <Users size={14} className="rp-panel-icon" />
         <h3 className="rp-panel-title">TEAM</h3>
-        {onlineCount > 0 && <span className="rp-panel-count">{onlineCount}</span>}
+        {users.length > 0 && (
+          <span className="rp-panel-count">
+            {onlineCount > 0 ? onlineCount : users.length}
+          </span>
+        )}
       </div>
 
       {users.length === 0 ? (
         <p className="rp-panel-empty">Only you here</p>
       ) : (
         <div className="rp-team-users">
-          {users.map((user) => (
-            <div key={user.user_id} className="rp-team-user">
-              <UserAvatar
-                userId={user.user_id}
-                displayName={user.display_name}
-                size="sm"
-                showStatus
-                status={user.status === 'online' ? 'online' : 'away'}
-              />
-              <div className="rp-team-user-info">
-                <span className="rp-team-user-name">{user.display_name}</span>
-                {user.current_view && (
-                  <span className="rp-team-user-view">{user.current_view}</span>
-                )}
+          {users.map((user) => {
+            const label = teamActivityLabel(user)
+            return (
+              <div key={user.user_id} className="rp-team-user">
+                <UserAvatar
+                  userId={user.user_id}
+                  displayName={user.display_name}
+                  size="sm"
+                  showStatus
+                  status={teamStatusToAvatar(user.status)}
+                />
+                <div className="rp-team-user-info">
+                  <span className="rp-team-user-name">{user.display_name}</span>
+                  {label && (
+                    <span className="rp-team-user-view">{label}</span>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>

--- a/serving/frontend/src/components/dashboard/SummaryCards.jsx
+++ b/serving/frontend/src/components/dashboard/SummaryCards.jsx
@@ -332,7 +332,7 @@ function SummaryCards() {
   const { data: planData } = usePlanSummary(projectId, {
     pollInterval: 15000,
   })
-  const { users } = usePresence(projectId)
+  const { users } = usePresence(projectId, activeProject?.name || null)
   const { aggregates, totalWorkItems } = useTiming(projectId, { pollInterval: 30000 })
 
   if (!activeProject) {

--- a/serving/frontend/src/hooks/usePresence.js
+++ b/serving/frontend/src/hooks/usePresence.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
 import ObservabilityWebSocket from '../services/observabilityWebSocket'
-import { sendHeartbeat, getPresence } from '../api/presence'
+import { sendHeartbeat, getGlobalPresence } from '../api/presence'
 
 // Shared singleton WebSocket instance
 let _ws = null
@@ -13,24 +13,44 @@ function getWebSocket() {
   return _ws
 }
 
-// Extract a short view label from the current pathname
-function viewFromPath(pathname) {
-  if (!pathname) return null
-  const segment = pathname.split('/').filter(Boolean)[0]
-  return segment || 'dashboard'
+// Readable labels for URL path segments
+const VIEW_LABELS = {
+  dashboard: 'Dashboard',
+  backlog: 'Backlog',
+  plan: 'Plan',
+  directives: 'Goals',
+  projects: 'Projects',
+  marketplace: 'Marketplace',
+  network: 'Network',
+  timing: 'Timing',
+  notifications: 'Notifications',
+  settings: 'Settings',
 }
 
 /**
- * Track user presence for a project.
+ * Extract a human-readable view label from the current pathname.
+ * Handles nested routes like /settings/profile → "Settings".
+ */
+function viewFromPath(pathname) {
+  if (!pathname) return 'Dashboard'
+  const segments = pathname.split('/').filter(Boolean)
+  if (segments.length === 0) return 'Dashboard'
+  const primary = segments[0]
+  return VIEW_LABELS[primary] || primary.charAt(0).toUpperCase() + primary.slice(1)
+}
+
+/**
+ * Track user presence globally across all projects.
  *
- * Sends a heartbeat every 30 s with the current route, listens for
- * WebSocket ``presence_update`` events from the server, and falls back
- * to polling GET /presence every 30 s when the WebSocket is unavailable.
+ * Sends a heartbeat every 30 s with the current route and project name,
+ * listens for WebSocket ``presence_update`` events, and falls back to
+ * polling GET /presence every 30 s when the WebSocket is unavailable.
  *
- * @param {string|null} projectId  Active project ID (or null when none selected)
+ * @param {string|null} projectId    Active project ID (or null when none selected)
+ * @param {string|null} projectName  Active project name (for display in activity label)
  * @returns {{ users: Array, sendHeartbeat: Function }}
  */
-export default function usePresence(projectId) {
+export default function usePresence(projectId, projectName) {
   const [users, setUsers] = useState([])
   const location = useLocation()
   const currentView = viewFromPath(location.pathname)
@@ -38,43 +58,41 @@ export default function usePresence(projectId) {
   const heartbeatTimerRef = useRef(null)
 
   // ------------------------------------------------------------------
-  // Fetch current presence list (used for initial load and fallback poll)
+  // Fetch global presence list (used for initial load and fallback poll)
   // ------------------------------------------------------------------
   const fetchPresence = useCallback(async () => {
-    if (!projectId) return
     try {
-      const data = await getPresence(projectId)
+      const data = await getGlobalPresence()
       if (data?.users) setUsers(data.users)
     } catch (err) {
       // Non-critical — ignore silently
     }
-  }, [projectId])
+  }, [])
 
   // ------------------------------------------------------------------
-  // Send heartbeat
+  // Send heartbeat (requires a project to be selected)
   // ------------------------------------------------------------------
   const doHeartbeat = useCallback(async () => {
     if (!projectId) return
     try {
-      await sendHeartbeat(projectId, { current_view: currentView })
+      await sendHeartbeat(projectId, {
+        current_view: currentView,
+        project_name: projectName || null,
+      })
     } catch (err) {
       // Non-critical — ignore silently
     }
-  }, [projectId, currentView])
+  }, [projectId, currentView, projectName])
 
   // ------------------------------------------------------------------
-  // WebSocket listener for presence_update events
+  // WebSocket listener for presence_update events (global)
   // ------------------------------------------------------------------
   useEffect(() => {
-    if (!projectId) return
-
     const ws = getWebSocket()
 
     const handlePresenceUpdate = (eventData) => {
       if (!eventData) return
-      // eventData is the raw payload after type stripping in observabilityWebSocket
-      // The server sends { project_id, users } as the event body
-      if (eventData.project_id === projectId && Array.isArray(eventData.users)) {
+      if (Array.isArray(eventData.users)) {
         setUsers(eventData.users)
       }
     }
@@ -84,26 +102,28 @@ export default function usePresence(projectId) {
     return () => {
       ws.off('presence_update', handlePresenceUpdate)
     }
-  }, [projectId])
+  }, [])
 
   // ------------------------------------------------------------------
-  // Heartbeat timer — fires every 30 s, also on view change
+  // Heartbeat timer — fires every 30 s, also on view/project change
   // ------------------------------------------------------------------
   useEffect(() => {
-    if (!projectId) return
-
-    // Send immediately when project or view changes
-    doHeartbeat()
+    // Always fetch presence (global) even without a project
     fetchPresence()
 
-    heartbeatTimerRef.current = setInterval(doHeartbeat, 30_000)
+    // Only send heartbeats when a project is active
+    if (projectId) {
+      doHeartbeat()
+      heartbeatTimerRef.current = setInterval(doHeartbeat, 30_000)
+    }
+
     pollTimerRef.current = setInterval(fetchPresence, 30_000)
 
     return () => {
       clearInterval(heartbeatTimerRef.current)
       clearInterval(pollTimerRef.current)
     }
-  }, [projectId, currentView, doHeartbeat, fetchPresence])
+  }, [projectId, currentView, projectName, doHeartbeat, fetchPresence])
 
   return { users, sendHeartbeat: doHeartbeat }
 }

--- a/serving/frontend/src/pages/DashboardPage.jsx
+++ b/serving/frontend/src/pages/DashboardPage.jsx
@@ -97,7 +97,7 @@ function ActiveProjectDashboard() {
   const { data: planData } = usePlanSummary(projectId, { pollInterval: 15000 })
   const { aggregates, totalWorkItems } = useTiming(projectId, { pollInterval: 30000 })
   const { health, overallStatus, loading: healthLoading } = useSystemHealth({ pollInterval: 30000 })
-  const { users: presenceUsers } = usePresence(projectId || null)
+  const { users: presenceUsers } = usePresence(projectId || null, activeProject?.name || null)
   const prompts = useDirectivePrompts(activeProject ? stats : null)
   const { transitionClass, scrollPositionRef } = useChatTransition()
 

--- a/serving/models/presence.py
+++ b/serving/models/presence.py
@@ -8,7 +8,8 @@ from pydantic import BaseModel, Field
 
 class UserPresence(BaseModel):
     user_id: str
-    project_id: str
+    project_id: str = ""
+    project_name: Optional[str] = None
     display_name: str = "Unknown"
     status: str = "online"  # online, idle, offline
     current_view: Optional[str] = None  # dashboard, backlog, plan, etc.
@@ -18,6 +19,7 @@ class UserPresence(BaseModel):
 
 class HeartbeatRequest(BaseModel):
     current_view: Optional[str] = None
+    project_name: Optional[str] = None
 
 
 class PresenceResponse(BaseModel):

--- a/serving/services/presence_service.py
+++ b/serving/services/presence_service.py
@@ -1,4 +1,4 @@
-"""Presence service — tracks which users are online in which project view."""
+"""Presence service — tracks which users are online across all projects."""
 
 import json
 import logging
@@ -9,22 +9,27 @@ from models.presence import UserPresence
 
 logger = logging.getLogger(__name__)
 
-# Redis TTL for a presence key (seconds). After this the user is considered offline.
-PRESENCE_TTL = 60
-# Boundary between "online" and "idle" (seconds since last heartbeat)
-IDLE_THRESHOLD = 30
+# Redis TTL for a presence key (seconds).  Users are removed after 3 days of
+# inactivity (no heartbeat).
+PRESENCE_TTL = 3 * 24 * 60 * 60  # 259 200 s  (3 days)
+
+# Status thresholds (seconds since last heartbeat)
+ONLINE_THRESHOLD = 60       # green:  active within last 60 s
+IDLE_THRESHOLD = 10 * 60    # yellow: 1–10 minutes since last heartbeat
+# > IDLE_THRESHOLD → red (offline), retained until PRESENCE_TTL expires
 
 
 class PresenceService:
-    """Manages per-project user presence in Redis.
+    """Manages global user presence in Redis.
 
-    Key format: ``{prefix}presence:{project_id}:{user_id}``
+    Key format: ``{prefix}presence:user:{user_id}``
 
     Each key is a Redis hash with fields:
-        user_id, project_id, display_name, current_view, connected_at, last_heartbeat
+        user_id, project_id, project_name, display_name, current_view,
+        connected_at, last_heartbeat
 
-    The key expires after PRESENCE_TTL seconds — the frontend must send
-    heartbeats at least every 30 s to keep the entry alive.
+    The key expires after PRESENCE_TTL (3 days) — the frontend must send
+    heartbeats at least every 30 s to keep the entry fresh.
     """
 
     def __init__(self, redis_client=None):
@@ -37,11 +42,18 @@ class PresenceService:
     def _prefix(self) -> str:
         return getattr(self._redis, '_prefix', 'claudevn:') if self._redis else 'claudevn:'
 
+    def _user_key(self, user_id: str) -> str:
+        return f"{self._prefix()}presence:user:{user_id}"
+
+    def _all_users_pattern(self) -> str:
+        return f"{self._prefix()}presence:user:*"
+
+    # Legacy per-project helpers (for backward compat during migration)
     def _key(self, project_id: str, user_id: str) -> str:
-        return f"{self._prefix()}presence:{project_id}:{user_id}"
+        return self._user_key(user_id)
 
     def _pattern(self, project_id: str) -> str:
-        return f"{self._prefix()}presence:{project_id}:*"
+        return self._all_users_pattern()
 
     # ------------------------------------------------------------------
     # Public API
@@ -53,16 +65,18 @@ class PresenceService:
         user_id: str,
         display_name: str,
         current_view: Optional[str] = None,
+        project_name: Optional[str] = None,
     ) -> None:
-        """Record or refresh a user's presence for *project_id*.
+        """Record or refresh a user's global presence.
 
-        Sets the Redis hash fields and refreshes the TTL to PRESENCE_TTL seconds.
-        After updating, broadcasts a ``presence_update`` event via the event bus.
+        Stores the user's current project and view so teammates can see
+        what they're working on.  The Redis key expires after PRESENCE_TTL
+        (3 days).  After updating, broadcasts a ``presence_update`` event.
         """
         if not self._redis:
             return
 
-        key = self._key(project_id, user_id)
+        key = self._user_key(user_id)
         now = datetime.now(timezone.utc).isoformat()
 
         try:
@@ -75,7 +89,8 @@ class PresenceService:
 
             mapping = {
                 "user_id": user_id,
-                "project_id": project_id,
+                "project_id": project_id or "",
+                "project_name": project_name or "",
                 "display_name": display_name,
                 "current_view": current_view or "",
                 "last_heartbeat": now,
@@ -87,25 +102,29 @@ class PresenceService:
             logger.warning(f"Presence heartbeat failed for {user_id}: {e}")
             return
 
-        # Broadcast after successful write
+        # Broadcast after successful write (global — no project filter)
         await self._broadcast_update(project_id)
 
-    async def get_active_users(self, project_id: str) -> list[UserPresence]:
-        """Return all users currently present in *project_id*.
+    async def get_active_users(self, project_id: Optional[str] = None) -> list[UserPresence]:
+        """Return all globally tracked users.
+
+        If *project_id* is given the list is filtered to users whose last
+        heartbeat was for that project.  Pass ``None`` to get everyone.
 
         Status is derived from time since last heartbeat:
-        - ``online`` — last heartbeat < IDLE_THRESHOLD seconds ago
-        - ``idle`` — last heartbeat IDLE_THRESHOLD..PRESENCE_TTL seconds ago
+        - ``online``  — within the last 60 s  (green)
+        - ``idle``    — 1–10 minutes ago       (yellow)
+        - ``offline`` — >10 minutes ago        (red, retained up to 3 days)
         """
         if not self._redis:
             return []
 
         try:
             raw = self._redis._redis
-            pattern = self._pattern(project_id)
+            pattern = self._all_users_pattern()
             keys = await raw.keys(pattern)
         except Exception as e:
-            logger.warning(f"Failed to list presence keys for {project_id}: {e}")
+            logger.warning(f"Failed to list presence keys: {e}")
             return []
 
         users: list[UserPresence] = []
@@ -134,10 +153,18 @@ class PresenceService:
                     last_hb = now
 
                 age = (now - last_hb).total_seconds()
-                if age < IDLE_THRESHOLD:
+                if age < ONLINE_THRESHOLD:
                     status = "online"
-                else:
+                elif age < IDLE_THRESHOLD:
                     status = "idle"
+                else:
+                    status = "offline"
+
+                user_project = decoded.get("project_id", "")
+
+                # Optional project filter
+                if project_id and user_project != project_id:
+                    continue
 
                 connected_at_str = decoded.get("connected_at", "")
                 try:
@@ -149,7 +176,8 @@ class PresenceService:
 
                 presence = UserPresence(
                     user_id=decoded.get("user_id", ""),
-                    project_id=decoded.get("project_id", project_id),
+                    project_id=user_project,
+                    project_name=decoded.get("project_name") or None,
                     display_name=decoded.get("display_name", "Unknown"),
                     status=status,
                     current_view=decoded.get("current_view") or None,
@@ -166,10 +194,14 @@ class PresenceService:
     # Internal broadcast
     # ------------------------------------------------------------------
 
-    async def _broadcast_update(self, project_id: str) -> None:
-        """Push a presence_update event to all WebSocket clients."""
+    async def _broadcast_update(self, project_id: Optional[str] = None) -> None:
+        """Push a presence_update event to all WebSocket clients.
+
+        Broadcasts the full global user list so every client can update its
+        team panel regardless of which project it is viewing.
+        """
         try:
-            users = await self.get_active_users(project_id)
+            users = await self.get_active_users()  # global — no filter
             from services.observability_event_bus import get_event_bus
             bus = get_event_bus()
             if not bus:
@@ -179,7 +211,7 @@ class PresenceService:
                 {
                     "type": "presence_update",
                     "event": {
-                        "project_id": project_id,
+                        "project_id": project_id or "",
                         "users": [u.model_dump(mode="json") for u in users],
                     },
                 },

--- a/serving/tests/test_presence_service.py
+++ b/serving/tests/test_presence_service.py
@@ -1,0 +1,307 @@
+"""Tests for presence service — global tracking, thresholds, and status."""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from serving.services.presence_service import (
+    PresenceService,
+    PRESENCE_TTL,
+    ONLINE_THRESHOLD,
+    IDLE_THRESHOLD,
+)
+from serving.models.presence import UserPresence
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_redis_mock(data=None):
+    """Create a mock Redis client wrapping an inner raw mock."""
+    raw = AsyncMock()
+    raw.keys = AsyncMock(return_value=[])
+    raw.hgetall = AsyncMock(return_value={})
+    raw.hget = AsyncMock(return_value=None)
+    raw.hset = AsyncMock()
+    raw.expire = AsyncMock()
+
+    client = MagicMock()
+    client._redis = raw
+    client._prefix = "claudevn:"
+    return client, raw
+
+
+def _presence_hash(user_id, project_id="proj-1", display_name="Alice",
+                   current_view="Backlog", project_name="MyProject",
+                   last_heartbeat=None, connected_at=None):
+    """Build a Redis hash dict (bytes keys/values) for a presence entry."""
+    now = datetime.now(timezone.utc)
+    hb = (last_heartbeat or now).isoformat()
+    ca = (connected_at or now).isoformat()
+    return {
+        b"user_id": user_id.encode(),
+        b"project_id": project_id.encode(),
+        b"project_name": project_name.encode(),
+        b"display_name": display_name.encode(),
+        b"current_view": current_view.encode(),
+        b"last_heartbeat": hb.encode(),
+        b"connected_at": ca.encode(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+class TestConstants:
+    """Verify threshold constants match the spec."""
+
+    def test_presence_ttl_is_3_days(self):
+        assert PRESENCE_TTL == 3 * 24 * 60 * 60
+
+    def test_online_threshold_is_60_seconds(self):
+        assert ONLINE_THRESHOLD == 60
+
+    def test_idle_threshold_is_10_minutes(self):
+        assert IDLE_THRESHOLD == 10 * 60
+
+
+# ---------------------------------------------------------------------------
+# Key format (global, not per-project)
+# ---------------------------------------------------------------------------
+
+class TestKeyFormat:
+    """Presence keys should be global: prefix + user_id only."""
+
+    def test_user_key_format(self):
+        client, _ = _make_redis_mock()
+        svc = PresenceService(redis_client=client)
+        assert svc._user_key("u-1") == "claudevn:presence:user:u-1"
+
+    def test_all_users_pattern(self):
+        client, _ = _make_redis_mock()
+        svc = PresenceService(redis_client=client)
+        assert svc._all_users_pattern() == "claudevn:presence:user:*"
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat
+# ---------------------------------------------------------------------------
+
+class TestHeartbeat:
+    """Heartbeat should store global user key with project context."""
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_stores_project_name(self):
+        client, raw = _make_redis_mock()
+        svc = PresenceService(redis_client=client)
+
+        with patch.object(svc, '_broadcast_update', new_callable=AsyncMock):
+            await svc.heartbeat(
+                project_id="proj-1",
+                user_id="u-1",
+                display_name="Alice",
+                current_view="Backlog",
+                project_name="MyProject",
+            )
+
+        raw.hset.assert_called_once()
+        _, kwargs = raw.hset.call_args
+        mapping = kwargs["mapping"]
+        assert mapping["project_name"] == "MyProject"
+        assert mapping["project_id"] == "proj-1"
+        assert mapping["current_view"] == "Backlog"
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_sets_3_day_ttl(self):
+        client, raw = _make_redis_mock()
+        svc = PresenceService(redis_client=client)
+
+        with patch.object(svc, '_broadcast_update', new_callable=AsyncMock):
+            await svc.heartbeat(
+                project_id="proj-1",
+                user_id="u-1",
+                display_name="Alice",
+            )
+
+        raw.expire.assert_called_once()
+        key, ttl = raw.expire.call_args[0]
+        assert ttl == PRESENCE_TTL
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_preserves_connected_at(self):
+        client, raw = _make_redis_mock()
+        original_time = "2024-06-01T12:00:00+00:00"
+        raw.hget.return_value = original_time.encode()
+        svc = PresenceService(redis_client=client)
+
+        with patch.object(svc, '_broadcast_update', new_callable=AsyncMock):
+            await svc.heartbeat(
+                project_id="proj-1",
+                user_id="u-1",
+                display_name="Alice",
+            )
+
+        _, kwargs = raw.hset.call_args
+        assert kwargs["mapping"]["connected_at"] == original_time
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_uses_global_key(self):
+        client, raw = _make_redis_mock()
+        svc = PresenceService(redis_client=client)
+
+        with patch.object(svc, '_broadcast_update', new_callable=AsyncMock):
+            await svc.heartbeat(
+                project_id="proj-1",
+                user_id="u-1",
+                display_name="Alice",
+            )
+
+        key = raw.hset.call_args[0][0]
+        assert key == "claudevn:presence:user:u-1"
+        assert "proj-1" not in key
+
+
+# ---------------------------------------------------------------------------
+# Status thresholds
+# ---------------------------------------------------------------------------
+
+class TestStatusThresholds:
+    """Verify status assignment: online < 60s, idle 60s-10m, offline > 10m."""
+
+    @pytest.mark.asyncio
+    async def test_online_within_60_seconds(self):
+        client, raw = _make_redis_mock()
+        now = datetime.now(timezone.utc)
+        raw.keys.return_value = [b"claudevn:presence:user:u-1"]
+        raw.hgetall.return_value = _presence_hash(
+            "u-1", last_heartbeat=now - timedelta(seconds=30),
+        )
+        svc = PresenceService(redis_client=client)
+        users = await svc.get_active_users()
+        assert len(users) == 1
+        assert users[0].status == "online"
+
+    @pytest.mark.asyncio
+    async def test_idle_between_1_and_10_minutes(self):
+        client, raw = _make_redis_mock()
+        now = datetime.now(timezone.utc)
+        raw.keys.return_value = [b"claudevn:presence:user:u-1"]
+        raw.hgetall.return_value = _presence_hash(
+            "u-1", last_heartbeat=now - timedelta(minutes=5),
+        )
+        svc = PresenceService(redis_client=client)
+        users = await svc.get_active_users()
+        assert len(users) == 1
+        assert users[0].status == "idle"
+
+    @pytest.mark.asyncio
+    async def test_offline_after_10_minutes(self):
+        client, raw = _make_redis_mock()
+        now = datetime.now(timezone.utc)
+        raw.keys.return_value = [b"claudevn:presence:user:u-1"]
+        raw.hgetall.return_value = _presence_hash(
+            "u-1", last_heartbeat=now - timedelta(minutes=30),
+        )
+        svc = PresenceService(redis_client=client)
+        users = await svc.get_active_users()
+        assert len(users) == 1
+        assert users[0].status == "offline"
+
+    @pytest.mark.asyncio
+    async def test_boundary_at_60_seconds_is_idle(self):
+        client, raw = _make_redis_mock()
+        now = datetime.now(timezone.utc)
+        raw.keys.return_value = [b"claudevn:presence:user:u-1"]
+        raw.hgetall.return_value = _presence_hash(
+            "u-1", last_heartbeat=now - timedelta(seconds=61),
+        )
+        svc = PresenceService(redis_client=client)
+        users = await svc.get_active_users()
+        assert users[0].status == "idle"
+
+    @pytest.mark.asyncio
+    async def test_boundary_at_10_minutes_is_offline(self):
+        client, raw = _make_redis_mock()
+        now = datetime.now(timezone.utc)
+        raw.keys.return_value = [b"claudevn:presence:user:u-1"]
+        raw.hgetall.return_value = _presence_hash(
+            "u-1", last_heartbeat=now - timedelta(seconds=601),
+        )
+        svc = PresenceService(redis_client=client)
+        users = await svc.get_active_users()
+        assert users[0].status == "offline"
+
+
+# ---------------------------------------------------------------------------
+# Global vs per-project
+# ---------------------------------------------------------------------------
+
+class TestGlobalPresence:
+    """Presence should be global with optional project filter."""
+
+    @pytest.mark.asyncio
+    async def test_get_active_users_returns_all_without_filter(self):
+        client, raw = _make_redis_mock()
+        now = datetime.now(timezone.utc)
+        raw.keys.return_value = [
+            b"claudevn:presence:user:u-1",
+            b"claudevn:presence:user:u-2",
+        ]
+
+        async def hgetall_side_effect(key):
+            if b"u-1" in key:
+                return _presence_hash("u-1", project_id="proj-1",
+                                      last_heartbeat=now)
+            return _presence_hash("u-2", project_id="proj-2",
+                                  last_heartbeat=now)
+
+        raw.hgetall.side_effect = hgetall_side_effect
+        svc = PresenceService(redis_client=client)
+        users = await svc.get_active_users()
+        assert len(users) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_active_users_filters_by_project(self):
+        client, raw = _make_redis_mock()
+        now = datetime.now(timezone.utc)
+        raw.keys.return_value = [
+            b"claudevn:presence:user:u-1",
+            b"claudevn:presence:user:u-2",
+        ]
+
+        async def hgetall_side_effect(key):
+            if b"u-1" in key:
+                return _presence_hash("u-1", project_id="proj-1",
+                                      last_heartbeat=now)
+            return _presence_hash("u-2", project_id="proj-2",
+                                  last_heartbeat=now)
+
+        raw.hgetall.side_effect = hgetall_side_effect
+        svc = PresenceService(redis_client=client)
+        users = await svc.get_active_users(project_id="proj-1")
+        assert len(users) == 1
+        assert users[0].user_id == "u-1"
+
+
+# ---------------------------------------------------------------------------
+# Project name in presence
+# ---------------------------------------------------------------------------
+
+class TestProjectName:
+    """Users should have project_name populated from heartbeat."""
+
+    @pytest.mark.asyncio
+    async def test_project_name_returned(self):
+        client, raw = _make_redis_mock()
+        now = datetime.now(timezone.utc)
+        raw.keys.return_value = [b"claudevn:presence:user:u-1"]
+        raw.hgetall.return_value = _presence_hash(
+            "u-1", project_name="MyProject", current_view="Backlog",
+            last_heartbeat=now,
+        )
+        svc = PresenceService(redis_client=client)
+        users = await svc.get_active_users()
+        assert users[0].project_name == "MyProject"
+        assert users[0].current_view == "Backlog"


### PR DESCRIPTION
## Summary
- Redesign presence from per-project to **global** — all team members visible regardless of active project
- Extend retention from 60 seconds to **3 days** before removal
- Implement 3-tier status indicators: **green** (<60s), **yellow** (1–10min), **red** (>10min)
- Fix activity notation stuck on "Dashboard" — now tracks real-time page navigation
- Show project name in activity label (e.g., "MyProject · Backlog")

## Changes

### Backend (Python/FastAPI)
- `serving/services/presence_service.py`: Global Redis key format (`presence:user:{id}`), 3-day TTL, 3-tier status thresholds
- `serving/models/presence.py`: Added `project_name` field to `UserPresence` and `HeartbeatRequest`
- `serving/api/presence.py`: New global `GET /presence` endpoint, updated heartbeat to accept `project_name`

### Frontend (React)
- `serving/frontend/src/hooks/usePresence.js`: Global presence fetching, proper view extraction with readable labels, sends project name in heartbeats
- `serving/frontend/src/api/presence.js`: New `getGlobalPresence()`, updated `sendHeartbeat()` with `project_name`
- `serving/frontend/src/components/dashboard/PresenceBar.jsx`: 3-state status mapping (online/away/offline)
- `serving/frontend/src/components/dashboard/RightPanels.jsx`: Activity label shows "ProjectName · View", 3-state status
- `serving/frontend/src/components/common/UserAvatar.css`: Offline status uses red (--status-offline) instead of muted gray
- `serving/frontend/src/pages/DashboardPage.jsx`, `SummaryCards.jsx`: Pass project name to `usePresence`

## Testing
- [x] 17 unit tests added (`serving/tests/test_presence_service.py`)
- [x] All unit tests passing
- [x] Tests cover: constants, key format, heartbeat, status thresholds, global vs filtered, project name

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed
- [ ] Redis migration: old per-project keys (`presence:{project_id}:{user_id}`) will expire naturally within 60s

## Issues
Closes #220