### PR TITLE
feat: Add theme switching with per-user preferences (#223)

### DIFF
--- a/serving/frontend/src/App.jsx
+++ b/serving/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { ToastProvider } from './contexts/ToastContext'
 import { ProjectProvider } from './contexts/ProjectContext'
 import { ConversationProvider } from './contexts/ConversationContext'
 import { AuthProvider, useAuth as useUserAuth } from './contexts/auth/AuthContext'
+import { ThemeProvider } from './contexts/ThemeContext'
 import { ToastContainer } from './components/common/Toast'
 import IconBar from './components/layout/IconBar'
 import ChatRail from './components/layout/ChatRail'
@@ -157,13 +158,15 @@ function ClaudeTokenGate() {
 function App() {
   return (
     <AuthProvider>
-      <ToastProvider>
-        <AppProvider>
-          <CognitoGate>
-            <ClaudeTokenGate />
-          </CognitoGate>
-        </AppProvider>
-      </ToastProvider>
+      <ThemeProvider>
+        <ToastProvider>
+          <AppProvider>
+            <CognitoGate>
+              <ClaudeTokenGate />
+            </CognitoGate>
+          </AppProvider>
+        </ToastProvider>
+      </ThemeProvider>
     </AuthProvider>
   )
 }

--- a/serving/frontend/src/contexts/ThemeContext.jsx
+++ b/serving/frontend/src/contexts/ThemeContext.jsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import { useAuth } from './auth/AuthContext'
+
+const ThemeContext = createContext(null)
+
+const THEMES = ['dark', 'light', 'retro', 'ocean', 'neon']
+const DEFAULT_THEME = 'dark'
+
+function getStorageKey(user) {
+  const id = user?.sub || user?.email || 'default'
+  return `claudevn_theme_${id}`
+}
+
+function loadTheme(user) {
+  const key = getStorageKey(user)
+  const stored = localStorage.getItem(key)
+  if (stored && THEMES.includes(stored)) return stored
+  return DEFAULT_THEME
+}
+
+function applyTheme(theme) {
+  if (theme === DEFAULT_THEME) {
+    document.documentElement.removeAttribute('data-theme')
+  } else {
+    document.documentElement.setAttribute('data-theme', theme)
+  }
+}
+
+export function ThemeProvider({ children }) {
+  const { user } = useAuth()
+  const [theme, setThemeState] = useState(() => loadTheme(user))
+
+  useEffect(() => {
+    const loaded = loadTheme(user)
+    setThemeState(loaded)
+    applyTheme(loaded)
+  }, [user])
+
+  const setTheme = useCallback((newTheme) => {
+    if (!THEMES.includes(newTheme)) return
+    setThemeState(newTheme)
+    applyTheme(newTheme)
+    const key = getStorageKey(user)
+    localStorage.setItem(key, newTheme)
+  }, [user])
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, themes: THEMES }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider')
+  }
+  return context
+}

--- a/serving/frontend/src/contexts/ThemeContext.test.jsx
+++ b/serving/frontend/src/contexts/ThemeContext.test.jsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { ThemeProvider, useTheme } from './ThemeContext'
+
+// Mock the AuthContext
+vi.mock('./auth/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'test@example.com', sub: 'user-123' } }),
+}))
+
+const wrapper = ({ children }) => <ThemeProvider>{children}</ThemeProvider>
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('defaults to dark theme', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    expect(result.current.theme).toBe('dark')
+  })
+
+  it('provides list of available themes', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    expect(result.current.themes).toEqual(['dark', 'light', 'retro', 'ocean', 'neon'])
+  })
+
+  it('changes theme and persists to localStorage', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    act(() => {
+      result.current.setTheme('light')
+    })
+    expect(result.current.theme).toBe('light')
+    expect(localStorage.getItem('claudevn_theme_user-123')).toBe('light')
+  })
+
+  it('applies data-theme attribute for non-dark themes', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    act(() => {
+      result.current.setTheme('ocean')
+    })
+    expect(document.documentElement.getAttribute('data-theme')).toBe('ocean')
+  })
+
+  it('removes data-theme attribute for dark theme', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    act(() => {
+      result.current.setTheme('neon')
+    })
+    expect(document.documentElement.getAttribute('data-theme')).toBe('neon')
+    act(() => {
+      result.current.setTheme('dark')
+    })
+    expect(document.documentElement.getAttribute('data-theme')).toBeNull()
+  })
+
+  it('loads saved theme from localStorage', () => {
+    localStorage.setItem('claudevn_theme_user-123', 'retro')
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    expect(result.current.theme).toBe('retro')
+  })
+
+  it('ignores invalid theme values in localStorage', () => {
+    localStorage.setItem('claudevn_theme_user-123', 'invalid-theme')
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    expect(result.current.theme).toBe('dark')
+  })
+
+  it('ignores invalid theme values in setTheme', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    act(() => {
+      result.current.setTheme('nonexistent')
+    })
+    expect(result.current.theme).toBe('dark')
+  })
+
+  it('throws when used outside ThemeProvider', () => {
+    expect(() => {
+      renderHook(() => useTheme())
+    }).toThrow('useTheme must be used within ThemeProvider')
+  })
+})
+
+describe('ThemeContext per-user isolation', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('uses user sub as storage key', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    act(() => {
+      result.current.setTheme('ocean')
+    })
+    expect(localStorage.getItem('claudevn_theme_user-123')).toBe('ocean')
+    // Other user keys should not be affected
+    expect(localStorage.getItem('claudevn_theme_default')).toBeNull()
+  })
+})

--- a/serving/frontend/src/main.jsx
+++ b/serving/frontend/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import './App.css'
+import './themes.css'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/serving/frontend/src/pages/SettingsPage.css
+++ b/serving/frontend/src/pages/SettingsPage.css
@@ -96,3 +96,104 @@
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
 }
+
+/* Theme Picker */
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: var(--space-md);
+}
+
+.theme-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  background: var(--bg-elevated);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.theme-card:hover {
+  border-color: var(--text-muted);
+}
+
+.theme-card--active {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 1px var(--primary);
+}
+
+.theme-preview {
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  aspect-ratio: 16 / 10;
+}
+
+.theme-preview-bg {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  padding: 4px;
+  gap: 4px;
+}
+
+.theme-preview-sidebar {
+  width: 20%;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.theme-preview-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 3px;
+}
+
+.theme-preview-accent {
+  height: 4px;
+  width: 40%;
+  border-radius: 1px;
+}
+
+.theme-preview-text {
+  height: 3px;
+  width: 80%;
+  border-radius: 1px;
+}
+
+.theme-info {
+  display: flex;
+  flex-direction: column;
+  padding: 0 2px;
+}
+
+.theme-name {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.theme-desc {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.theme-active-badge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: var(--primary);
+  color: var(--text-on-primary);
+  border-radius: 50%;
+}

--- a/serving/frontend/src/pages/SettingsPage.jsx
+++ b/serving/frontend/src/pages/SettingsPage.jsx
@@ -1,12 +1,22 @@
 import { useState } from 'react'
-import { Settings, Save } from 'lucide-react'
+import { Settings, Save, Check } from 'lucide-react'
 import { useDisplayHostname } from '../hooks/useDisplayHostname'
+import { useTheme } from '../contexts/ThemeContext'
 import { useToast } from '../hooks/useToast'
 import './SettingsPage.css'
+
+const THEME_META = {
+  dark: { label: 'Dark', description: 'Default dark theme', colors: ['#0f0f0f', '#1a1a1a', '#7c3aed', '#fafafa'] },
+  light: { label: 'Light', description: 'Clean light theme', colors: ['#f8f8fa', '#ffffff', '#7c3aed', '#1a1a2e'] },
+  retro: { label: 'Retro', description: 'Amber terminal vibes', colors: ['#1a1400', '#261e00', '#f59e0b', '#f5d97a'] },
+  ocean: { label: 'Ocean', description: 'Deep blue seas', colors: ['#0a1628', '#0f1f36', '#06b6d4', '#e0f2fe'] },
+  neon: { label: 'Neon', description: 'Cyberpunk glow', colors: ['#0a0a14', '#12121e', '#e040fb', '#f0e6ff'] },
+}
 
 function SettingsPage() {
   const { displayHostname, setDisplayHostname } = useDisplayHostname()
   const [hostname, setHostname] = useState(displayHostname)
+  const { theme, setTheme, themes } = useTheme()
   const toast = useToast()
 
   const handleSave = (e) => {
@@ -15,12 +25,57 @@ function SettingsPage() {
     toast.success('Settings saved')
   }
 
+  const handleThemeChange = (newTheme) => {
+    setTheme(newTheme)
+    toast.success(`Theme changed to ${THEME_META[newTheme]?.label || newTheme}`)
+  }
+
   const isDirty = hostname !== displayHostname
 
   return (
     <div className="settings-page">
       <div className="page-header">
         <h1>Settings</h1>
+      </div>
+
+      <div className="settings-section">
+        <h2 className="settings-section-title">Theme</h2>
+        <p className="settings-description" style={{ marginBottom: 'var(--space-md)' }}>
+          Choose your preferred color theme. This preference is saved per-user.
+        </p>
+        <div className="theme-grid">
+          {themes.map((t) => {
+            const meta = THEME_META[t]
+            const isActive = theme === t
+            return (
+              <button
+                key={t}
+                className={`theme-card${isActive ? ' theme-card--active' : ''}`}
+                onClick={() => handleThemeChange(t)}
+              >
+                <div className="theme-preview">
+                  <div className="theme-preview-bg" style={{ background: meta.colors[0] }}>
+                    <div className="theme-preview-sidebar" style={{ background: meta.colors[1] }} />
+                    <div className="theme-preview-content">
+                      <div className="theme-preview-accent" style={{ background: meta.colors[2] }} />
+                      <div className="theme-preview-text" style={{ background: meta.colors[3], opacity: 0.6 }} />
+                      <div className="theme-preview-text" style={{ background: meta.colors[3], opacity: 0.3, width: '60%' }} />
+                    </div>
+                  </div>
+                </div>
+                <div className="theme-info">
+                  <span className="theme-name">{meta.label}</span>
+                  <span className="theme-desc">{meta.description}</span>
+                </div>
+                {isActive && (
+                  <div className="theme-active-badge">
+                    <Check size={12} />
+                  </div>
+                )}
+              </button>
+            )
+          })}
+        </div>
       </div>
 
       <form onSubmit={handleSave} className="settings-section">

--- a/serving/frontend/src/themes.css
+++ b/serving/frontend/src/themes.css
@@ -1,0 +1,174 @@
+/* =============================================================================
+   Theme Definitions
+
+   Themes override the color variables defined in :root (App.css).
+   Applied via data-theme attribute on <html>.
+   ============================================================================= */
+
+/* Smooth theme transitions */
+html[data-theme] *,
+html[data-theme] *::before,
+html[data-theme] *::after {
+  transition: background-color 200ms ease, color 200ms ease, border-color 200ms ease, box-shadow 200ms ease;
+}
+
+/* Light Theme */
+html[data-theme="light"] {
+  --primary: #7c3aed;
+  --primary-hover: #6d28d9;
+  --primary-muted: rgba(124, 58, 237, 0.1);
+
+  --bg: #f8f8fa;
+  --bg-elevated: #ffffff;
+  --bg-hover: #f0f0f3;
+  --bg-active: #e8e8ec;
+
+  --border: #e0e0e4;
+  --border-light: #d0d0d6;
+
+  --text: #1a1a2e;
+  --text-secondary: #52525b;
+  --text-muted: #a1a1aa;
+
+  --bg-tertiary: #f0f0f5;
+  --bg-card: var(--bg-elevated);
+  --border-color: var(--border);
+  --border-subtle: #ebebef;
+  --text-primary: var(--text);
+  --text-tertiary: #a1a1aa;
+  --text-on-primary: #fff;
+
+  --color-initiative-muted: rgba(139, 92, 246, 0.08);
+  --primary-alpha: rgba(124, 58, 237, 0.06);
+  --error-alpha: rgba(239, 68, 68, 0.08);
+  --status-online-alpha: rgba(34, 197, 94, 0.1);
+  --status-degraded-alpha: rgba(245, 158, 11, 0.1);
+  --status-offline-alpha: rgba(239, 68, 68, 0.1);
+  --status-pending-alpha: rgba(59, 130, 246, 0.1);
+}
+
+/* Retro Theme - amber/green terminal */
+html[data-theme="retro"] {
+  --primary: #f59e0b;
+  --primary-hover: #d97706;
+  --primary-muted: rgba(245, 158, 11, 0.15);
+
+  --bg: #1a1400;
+  --bg-elevated: #261e00;
+  --bg-hover: #332800;
+  --bg-active: #3d3000;
+
+  --border: #3d3000;
+  --border-light: #4a3a00;
+
+  --text: #f5d97a;
+  --text-secondary: #c4a84a;
+  --text-muted: #8a7530;
+
+  --bg-tertiary: #2a2000;
+  --bg-card: var(--bg-elevated);
+  --border-color: var(--border);
+  --border-subtle: #332800;
+  --text-primary: var(--text);
+  --text-tertiary: #6b5a20;
+  --text-on-primary: #1a1400;
+
+  --status-online: #4ade80;
+  --status-degraded: #f5d97a;
+  --status-offline: #f87171;
+  --status-pending: #f59e0b;
+
+  --color-initiative: #f59e0b;
+  --color-initiative-secondary: #d97706;
+  --color-initiative-muted: rgba(245, 158, 11, 0.1);
+  --primary-alpha: rgba(245, 158, 11, 0.06);
+  --error-alpha: rgba(248, 113, 113, 0.1);
+  --status-online-alpha: rgba(74, 222, 128, 0.12);
+  --status-degraded-alpha: rgba(245, 217, 122, 0.12);
+  --status-offline-alpha: rgba(248, 113, 113, 0.12);
+  --status-pending-alpha: rgba(245, 158, 11, 0.12);
+}
+
+/* Ocean Theme - deep blue/teal */
+html[data-theme="ocean"] {
+  --primary: #06b6d4;
+  --primary-hover: #0891b2;
+  --primary-muted: rgba(6, 182, 212, 0.15);
+
+  --bg: #0a1628;
+  --bg-elevated: #0f1f36;
+  --bg-hover: #142944;
+  --bg-active: #1a3352;
+
+  --border: #1a3352;
+  --border-light: #1f3d60;
+
+  --text: #e0f2fe;
+  --text-secondary: #7dd3fc;
+  --text-muted: #3d7a9e;
+
+  --bg-tertiary: #0d1a2e;
+  --bg-card: var(--bg-elevated);
+  --border-color: var(--border);
+  --border-subtle: #142944;
+  --text-primary: var(--text);
+  --text-tertiary: #2a5a78;
+  --text-on-primary: #0a1628;
+
+  --status-online: #34d399;
+  --status-degraded: #fbbf24;
+  --status-offline: #f87171;
+  --status-pending: #38bdf8;
+
+  --color-initiative: #06b6d4;
+  --color-initiative-secondary: #0891b2;
+  --color-initiative-muted: rgba(6, 182, 212, 0.1);
+  --primary-alpha: rgba(6, 182, 212, 0.06);
+  --error-alpha: rgba(248, 113, 113, 0.1);
+  --status-online-alpha: rgba(52, 211, 153, 0.12);
+  --status-degraded-alpha: rgba(251, 191, 36, 0.12);
+  --status-offline-alpha: rgba(248, 113, 113, 0.12);
+  --status-pending-alpha: rgba(56, 189, 248, 0.12);
+}
+
+/* Neon Theme - cyberpunk neon */
+html[data-theme="neon"] {
+  --primary: #e040fb;
+  --primary-hover: #d500f9;
+  --primary-muted: rgba(224, 64, 251, 0.15);
+
+  --bg: #0a0a14;
+  --bg-elevated: #12121e;
+  --bg-hover: #1a1a28;
+  --bg-active: #222232;
+
+  --border: #222232;
+  --border-light: #2e2e42;
+
+  --text: #f0e6ff;
+  --text-secondary: #b388ff;
+  --text-muted: #6a5a8a;
+
+  --bg-tertiary: #14141e;
+  --bg-card: var(--bg-elevated);
+  --border-color: var(--border);
+  --border-subtle: #1a1a28;
+  --text-primary: var(--text);
+  --text-tertiary: #4a3a6a;
+  --text-on-primary: #0a0a14;
+
+  --status-online: #00e676;
+  --status-degraded: #ffea00;
+  --status-offline: #ff1744;
+  --status-pending: #00b0ff;
+
+  --color-initiative: #e040fb;
+  --color-initiative-secondary: #7c4dff;
+  --color-initiative-muted: rgba(224, 64, 251, 0.1);
+  --primary-alpha: rgba(224, 64, 251, 0.06);
+  --error-alpha: rgba(255, 23, 68, 0.1);
+  --status-online-alpha: rgba(0, 230, 118, 0.12);
+  --status-degraded-alpha: rgba(255, 234, 0, 0.12);
+  --status-offline-alpha: rgba(255, 23, 68, 0.12);
+  --status-pending-alpha: rgba(0, 176, 255, 0.12);
+}


### PR DESCRIPTION
## Summary
- Add theme switching support with 5 themes: dark (default), light, retro, ocean, and neon
- Per-user theme persistence via localStorage keyed by user identity (sub/email)
- Theme picker with visual previews on the Settings page

## Changes
- **themes.css** - Theme definitions using `[data-theme]` attribute selectors with smooth CSS transitions
- **ThemeContext.jsx** - React context for theme state management with per-user localStorage persistence
- **App.jsx** - Wrapped app with ThemeProvider (inside AuthProvider for user access)
- **main.jsx** - Import themes.css
- **SettingsPage.jsx** - Added theme picker grid with visual preview cards and active indicator
- **SettingsPage.css** - Theme picker styles (grid layout, preview cards, active badge)

## Testing
- [x] 10 unit tests for ThemeContext (default theme, persistence, per-user isolation, invalid values)
- [x] All existing tests unaffected (pre-existing failures in unrelated files)
- [x] Frontend builds successfully

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issues
Closes #223