### PR TITLE
fix: settings page routing and padding

### DIFF
--- a/serving/frontend/src/App.jsx
+++ b/serving/frontend/src/App.jsx
@@ -54,6 +54,7 @@ function AuthenticatedApp({ expired, expiringAt, onReauth }) {
               <Route path="/network" element={<NetworkHealthPage />} />
               <Route path="/timing" element={<TimingPage />} />
               <Route path="/notifications" element={<NotificationsPage />} />
+              <Route path="/settings" element={<Navigate to="/settings/general" replace />} />
               <Route path="/settings/profile" element={<ProfilePage />} />
               <Route path="/settings/ssh-keys" element={<SSHKeysPage />} />
               <Route path="/settings/general" element={<SettingsPage />} />

--- a/serving/frontend/src/pages/SettingsPage.jsx
+++ b/serving/frontend/src/pages/SettingsPage.jsx
@@ -33,7 +33,7 @@ function SettingsPage() {
   const isDirty = hostname !== displayHostname
 
   return (
-    <div className="settings-page">
+    <div className="page settings-page">
       <div className="page-header">
         <h1>Settings</h1>
       </div>


### PR DESCRIPTION
## Summary
- Add redirect from `/settings` to `/settings/general` so the gear icon in the IconBar works again
- Add shared `.page` class to SettingsPage for consistent padding with other pages

## Test plan
- [ ] Click the settings gear icon in the IconBar — should navigate to the settings page
- [ ] Verify settings page has consistent padding/spacing with other pages (e.g. Dashboard)
- [ ] Verify theme switching still works on the settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)