### PR TITLE
feat: Cross-block notification indicators (#229)

### DIFF
--- a/serving/frontend/src/components/common/NotificationDot.css
+++ b/serving/frontend/src/components/common/NotificationDot.css
@@ -1,0 +1,33 @@
+.notification-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: notification-dot-in 300ms ease-out;
+}
+
+.notification-dot--red {
+  background: var(--status-offline);
+  box-shadow: 0 0 4px rgba(239, 68, 68, 0.4);
+}
+
+.notification-dot--amber {
+  background: var(--status-degraded);
+  box-shadow: 0 0 4px rgba(245, 158, 11, 0.4);
+}
+
+.notification-dot--blue {
+  background: var(--status-pending);
+  box-shadow: 0 0 4px rgba(99, 102, 241, 0.4);
+}
+
+@keyframes notification-dot-in {
+  from {
+    opacity: 0;
+    transform: scale(0);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/serving/frontend/src/components/common/NotificationDot.jsx
+++ b/serving/frontend/src/components/common/NotificationDot.jsx
@@ -1,0 +1,8 @@
+import './NotificationDot.css'
+
+function NotificationDot({ color = 'red', title }) {
+  const className = `notification-dot notification-dot--${color}`
+  return <span className={className} title={title} aria-label={title} />
+}
+
+export default NotificationDot

--- a/serving/frontend/src/components/common/NotificationDot.test.jsx
+++ b/serving/frontend/src/components/common/NotificationDot.test.jsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import NotificationDot from './NotificationDot'
+
+describe('NotificationDot', () => {
+  it('renders with default red color', () => {
+    const { container } = render(<NotificationDot />)
+    const dot = container.querySelector('.notification-dot')
+    expect(dot).toBeTruthy()
+    expect(dot.classList.contains('notification-dot--red')).toBe(true)
+  })
+
+  it('renders with amber color', () => {
+    const { container } = render(<NotificationDot color="amber" />)
+    const dot = container.querySelector('.notification-dot')
+    expect(dot.classList.contains('notification-dot--amber')).toBe(true)
+  })
+
+  it('renders with blue color', () => {
+    const { container } = render(<NotificationDot color="blue" />)
+    const dot = container.querySelector('.notification-dot')
+    expect(dot.classList.contains('notification-dot--blue')).toBe(true)
+  })
+
+  it('sets title and aria-label', () => {
+    const { container } = render(<NotificationDot title="Test alert" />)
+    const dot = container.querySelector('.notification-dot')
+    expect(dot.getAttribute('title')).toBe('Test alert')
+    expect(dot.getAttribute('aria-label')).toBe('Test alert')
+  })
+})

--- a/serving/frontend/src/components/dashboard/LeftPanels.jsx
+++ b/serving/frontend/src/components/dashboard/LeftPanels.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { Activity, Cpu, Database, FlaskConical, Hammer, HardDrive, MemoryStick, Plus, Server, Shield, TrendingUp } from 'lucide-react'
+import NotificationDot from '../common/NotificationDot'
 import './LeftPanels.css'
 
 // ---------------------------------------------------------------------------
@@ -95,7 +96,7 @@ const PRESET_ICON_MAP = {
   invest: TrendingUp,
 }
 
-function ExecutionPanel({ planData }) {
+function ExecutionPanel({ planData, showNotification, onAcknowledge }) {
   const navigate = useNavigate()
 
   const active = planData?.in_progress_count ?? planData?.active_count ?? 0
@@ -116,10 +117,11 @@ function ExecutionPanel({ planData }) {
   const extraCount = runningItems.length - displayedItems.length
 
   return (
-    <button className="lp-panel lp-panel--clickable lp-panel--grow" onClick={() => navigate('/plan')}>
+    <button className="lp-panel lp-panel--clickable lp-panel--grow" onClick={() => { onAcknowledge?.('execution'); navigate('/plan') }}>
       <div className="lp-panel-header">
         <Activity size={12} className="lp-panel-icon" />
         <span className="lp-panel-title">Execution</span>
+        {showNotification && <NotificationDot color="blue" title="Execution profile changed or blocked items" />}
         {ProfileIcon && (
           <span
             className="lp-profile-indicator"
@@ -186,7 +188,7 @@ function ExecutionPanel({ planData }) {
 // ---------------------------------------------------------------------------
 // Panel 3: Network Health
 // ---------------------------------------------------------------------------
-function NetworkPanel({ health, overallStatus, healthLoading }) {
+function NetworkPanel({ health, overallStatus, healthLoading, showNotification, onAcknowledge }) {
   const navigate = useNavigate()
 
   const computeByStatus = health?.compute_registry?.by_status ?? {}
@@ -222,10 +224,11 @@ function NetworkPanel({ health, overallStatus, healthLoading }) {
   }
 
   return (
-    <button className="lp-panel lp-panel--clickable" onClick={() => navigate('/network')}>
+    <button className="lp-panel lp-panel--clickable" onClick={() => { onAcknowledge?.('network'); navigate('/network') }}>
       <div className="lp-panel-header">
         <Cpu size={12} className="lp-panel-icon" />
         <span className="lp-panel-title">Network</span>
+        {showNotification && <NotificationDot color="red" title="Compute nodes unhealthy or offline" />}
         {!healthLoading && (
           <span className={`lp-health-dot lp-health-dot--${overallStatus ?? 'unknown'}`} />
         )}
@@ -305,6 +308,8 @@ function LeftPanels({
   health,
   overallStatus,
   healthLoading,
+  notifications,
+  onAcknowledge,
 }) {
   return (
     <div className="lp-column">
@@ -314,11 +319,13 @@ function LeftPanels({
         onSelectProject={onSelectProject}
         onNewProject={onNewProject}
       />
-      <ExecutionPanel planData={planData} />
+      <ExecutionPanel planData={planData} showNotification={notifications?.execution} onAcknowledge={onAcknowledge} />
       <NetworkPanel
         health={health}
         overallStatus={overallStatus}
         healthLoading={healthLoading}
+        showNotification={notifications?.network}
+        onAcknowledge={onAcknowledge}
       />
     </div>
   )

--- a/serving/frontend/src/components/dashboard/RightPanels.jsx
+++ b/serving/frontend/src/components/dashboard/RightPanels.jsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { Package, Clock, Users } from 'lucide-react'
 import UserAvatar from '../common/UserAvatar'
+import NotificationDot from '../common/NotificationDot'
 import './RightPanels.css'
 
 function formatDuration(ms) {
@@ -179,7 +180,7 @@ const STATUS_SORT_ORDER = {
   done: 8,
 }
 
-function BacklogPanel({ stats, issues }) {
+function BacklogPanel({ stats, issues, showNotification, onAcknowledge }) {
   const navigate = useNavigate()
 
   const ready = (stats?.by_status?.ready || 0) + (stats?.by_status?.pending || 0)
@@ -211,12 +212,13 @@ function BacklogPanel({ stats, issues }) {
   return (
     <button
       className="rp-panel rp-panel-clickable rp-panel--grow"
-      onClick={() => navigate('/backlog')}
+      onClick={() => { onAcknowledge?.('backlog'); navigate('/backlog') }}
       aria-label="Navigate to backlog"
     >
       <div className="rp-panel-header">
         <Package size={14} className="rp-panel-icon" />
         <h3 className="rp-panel-title">BACKLOG</h3>
+        {showNotification && <NotificationDot color="amber" title="Blocked issues increased" />}
         {total > 0 && <span className="rp-panel-count">{total}</span>}
       </div>
 
@@ -271,7 +273,7 @@ function BacklogPanel({ stats, issues }) {
   )
 }
 
-function TimingPanel({ aggregates, totalWorkItems }) {
+function TimingPanel({ aggregates, totalWorkItems, showNotification, onAcknowledge }) {
   const navigate = useNavigate()
 
   const wallTimeAggregate = aggregates?.find((a) => a.phase === 'total_wall_time')
@@ -292,12 +294,13 @@ function TimingPanel({ aggregates, totalWorkItems }) {
   return (
     <button
       className="rp-panel rp-panel-clickable"
-      onClick={() => navigate('/timing')}
+      onClick={() => { onAcknowledge?.('timing'); navigate('/timing') }}
       aria-label="Navigate to timing"
     >
       <div className="rp-panel-header">
         <Clock size={14} className="rp-panel-icon" />
         <h3 className="rp-panel-title">TIMING</h3>
+        {showNotification && <NotificationDot color="amber" title="Timing exceeds threshold" />}
       </div>
 
       {hasData ? (
@@ -411,11 +414,11 @@ function TeamPanel({ presenceUsers }) {
   )
 }
 
-function RightPanels({ stats, issues, aggregates, totalWorkItems, presenceUsers }) {
+function RightPanels({ stats, issues, aggregates, totalWorkItems, presenceUsers, notifications, onAcknowledge }) {
   return (
     <div className="rp-column">
-      <BacklogPanel stats={stats} issues={issues} />
-      <TimingPanel aggregates={aggregates} totalWorkItems={totalWorkItems} />
+      <BacklogPanel stats={stats} issues={issues} showNotification={notifications?.backlog} onAcknowledge={onAcknowledge} />
+      <TimingPanel aggregates={aggregates} totalWorkItems={totalWorkItems} showNotification={notifications?.timing} onAcknowledge={onAcknowledge} />
       <TeamPanel presenceUsers={presenceUsers} />
     </div>
   )

--- a/serving/frontend/src/hooks/useBlockNotifications.js
+++ b/serving/frontend/src/hooks/useBlockNotifications.js
@@ -1,0 +1,112 @@
+import { useMemo, useCallback, useRef, useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'claudevn_block_notifications'
+
+function loadAcknowledged() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? JSON.parse(raw) : {}
+  } catch {
+    return {}
+  }
+}
+
+function saveAcknowledged(data) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+/**
+ * Derives notification conditions for each observable block and tracks
+ * acknowledgment state via localStorage.
+ *
+ * Returns { notifications, acknowledge } where notifications has boolean
+ * flags for each block, and acknowledge(blockName) clears a block's dot.
+ */
+function useBlockNotifications({ health, overallStatus, planData, stats, aggregates }) {
+  const ackedRef = useRef(loadAcknowledged())
+  const [ackedVersion, setAckedVersion] = useState(0)
+
+  // Reload from localStorage on mount (covers multi-tab)
+  useEffect(() => {
+    ackedRef.current = loadAcknowledged()
+  }, [])
+
+  // --- Derive current notable conditions ---
+
+  // Network: any compute node unhealthy or offline
+  const networkUnhealthyCount = useMemo(() => {
+    const byStatus = health?.compute_registry?.by_status ?? {}
+    return (byStatus.offline ?? 0) + (byStatus.degraded ?? 0)
+  }, [health])
+
+  // Backlog: blocked count
+  const backlogBlockedCount = useMemo(() => {
+    return stats?.blocked_count ?? stats?.by_status?.blocked ?? 0
+  }, [stats])
+
+  // Execution: blocked count + active preset
+  const execBlocked = planData?.blocked_count ?? 0
+  const execPreset = planData?.active_preset ?? null
+
+  // Timing: p95 vs avg ratio — flag when p95 > 2x avg
+  const timingAlert = useMemo(() => {
+    const wallTime = aggregates?.find?.((a) => a.phase === 'total_wall_time')
+    if (!wallTime?.avg_ms || !wallTime?.p95_ms) return false
+    return wallTime.p95_ms > wallTime.avg_ms * 2
+  }, [aggregates])
+
+  const notifications = useMemo(() => {
+    const acked = ackedRef.current
+
+    // Network: red dot if unhealthy nodes exist AND count exceeds acknowledged
+    const network = networkUnhealthyCount > 0 && networkUnhealthyCount > (acked.network_unhealthy ?? 0)
+
+    // Backlog: amber dot if blocked count increased since last ack
+    const backlog = backlogBlockedCount > 0 && backlogBlockedCount > (acked.backlog_blocked ?? 0)
+
+    // Execution: dot if blocked items appeared or preset changed
+    const execBlockedNew = execBlocked > 0 && execBlocked > (acked.exec_blocked ?? 0)
+    const execPresetChanged = execPreset != null && execPreset !== (acked.exec_preset ?? null)
+    const execution = execBlockedNew || execPresetChanged
+
+    // Timing: dot when p95/avg ratio is alarming
+    const timing = timingAlert && !acked.timing_acked
+
+    return { network, backlog, execution, timing }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [networkUnhealthyCount, backlogBlockedCount, execBlocked, execPreset, timingAlert, ackedVersion])
+
+  const acknowledge = useCallback((block) => {
+    const acked = { ...ackedRef.current }
+
+    switch (block) {
+      case 'network':
+        acked.network_unhealthy = networkUnhealthyCount
+        break
+      case 'backlog':
+        acked.backlog_blocked = backlogBlockedCount
+        break
+      case 'execution':
+        acked.exec_blocked = execBlocked
+        acked.exec_preset = execPreset
+        break
+      case 'timing':
+        acked.timing_acked = timingAlert
+        break
+      default:
+        return
+    }
+
+    ackedRef.current = acked
+    saveAcknowledged(acked)
+    setAckedVersion((v) => v + 1)
+  }, [networkUnhealthyCount, backlogBlockedCount, execBlocked, execPreset, timingAlert])
+
+  return { notifications, acknowledge }
+}
+
+export default useBlockNotifications

--- a/serving/frontend/src/hooks/useBlockNotifications.test.js
+++ b/serving/frontend/src/hooks/useBlockNotifications.test.js
@@ -1,0 +1,246 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import useBlockNotifications from './useBlockNotifications'
+
+describe('useBlockNotifications', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  const baseProps = {
+    health: null,
+    overallStatus: 'healthy',
+    planData: null,
+    stats: null,
+    aggregates: null,
+  }
+
+  it('returns no notifications when all data is null', () => {
+    const { result } = renderHook(() => useBlockNotifications(baseProps))
+    expect(result.current.notifications).toEqual({
+      network: false,
+      backlog: false,
+      execution: false,
+      timing: false,
+    })
+  })
+
+  it('shows network notification when compute nodes are offline', () => {
+    const props = {
+      ...baseProps,
+      health: {
+        compute_registry: {
+          by_status: { online: 2, offline: 1 },
+          total_instances: 3,
+        },
+      },
+    }
+    const { result } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.network).toBe(true)
+  })
+
+  it('shows network notification when compute nodes are degraded', () => {
+    const props = {
+      ...baseProps,
+      health: {
+        compute_registry: {
+          by_status: { online: 2, degraded: 1 },
+          total_instances: 3,
+        },
+      },
+    }
+    const { result } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.network).toBe(true)
+  })
+
+  it('does not show network notification when all nodes are online', () => {
+    const props = {
+      ...baseProps,
+      health: {
+        compute_registry: {
+          by_status: { online: 3 },
+          total_instances: 3,
+        },
+      },
+    }
+    const { result } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.network).toBe(false)
+  })
+
+  it('clears network notification after acknowledge', () => {
+    const props = {
+      ...baseProps,
+      health: {
+        compute_registry: {
+          by_status: { online: 2, offline: 1 },
+          total_instances: 3,
+        },
+      },
+    }
+    const { result, rerender } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.network).toBe(true)
+
+    act(() => {
+      result.current.acknowledge('network')
+    })
+
+    rerender()
+    expect(result.current.notifications.network).toBe(false)
+  })
+
+  it('shows backlog notification when blocked count increases', () => {
+    const props = {
+      ...baseProps,
+      stats: { blocked_count: 3, by_status: { blocked: 3 } },
+    }
+    const { result } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.backlog).toBe(true)
+  })
+
+  it('does not show backlog notification when blocked count is zero', () => {
+    const props = {
+      ...baseProps,
+      stats: { blocked_count: 0, by_status: { blocked: 0 } },
+    }
+    const { result } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.backlog).toBe(false)
+  })
+
+  it('clears backlog notification after acknowledge', () => {
+    const props = {
+      ...baseProps,
+      stats: { blocked_count: 2 },
+    }
+    const { result, rerender } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.backlog).toBe(true)
+
+    act(() => {
+      result.current.acknowledge('backlog')
+    })
+
+    rerender()
+    expect(result.current.notifications.backlog).toBe(false)
+  })
+
+  it('shows execution notification when blocked items appear', () => {
+    const props = {
+      ...baseProps,
+      planData: { blocked_count: 2 },
+    }
+    const { result } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.execution).toBe(true)
+  })
+
+  it('shows execution notification when preset changes', () => {
+    const props = {
+      ...baseProps,
+      planData: { blocked_count: 0, active_preset: 'build' },
+    }
+    const { result } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.execution).toBe(true)
+  })
+
+  it('clears execution notification after acknowledge', () => {
+    const props = {
+      ...baseProps,
+      planData: { blocked_count: 1, active_preset: 'build' },
+    }
+    const { result, rerender } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.execution).toBe(true)
+
+    act(() => {
+      result.current.acknowledge('execution')
+    })
+
+    rerender()
+    expect(result.current.notifications.execution).toBe(false)
+  })
+
+  it('shows timing notification when p95 exceeds 2x avg', () => {
+    const props = {
+      ...baseProps,
+      aggregates: [{ phase: 'total_wall_time', avg_ms: 1000, p95_ms: 3000, count: 10 }],
+    }
+    const { result } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.timing).toBe(true)
+  })
+
+  it('does not show timing notification when p95 is within 2x avg', () => {
+    const props = {
+      ...baseProps,
+      aggregates: [{ phase: 'total_wall_time', avg_ms: 1000, p95_ms: 1500, count: 10 }],
+    }
+    const { result } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.timing).toBe(false)
+  })
+
+  it('clears timing notification after acknowledge', () => {
+    const props = {
+      ...baseProps,
+      aggregates: [{ phase: 'total_wall_time', avg_ms: 1000, p95_ms: 3000, count: 10 }],
+    }
+    const { result, rerender } = renderHook(() => useBlockNotifications(props))
+    expect(result.current.notifications.timing).toBe(true)
+
+    act(() => {
+      result.current.acknowledge('timing')
+    })
+
+    rerender()
+    expect(result.current.notifications.timing).toBe(false)
+  })
+
+  it('persists acknowledged state in localStorage', () => {
+    const props = {
+      ...baseProps,
+      health: {
+        compute_registry: {
+          by_status: { online: 2, offline: 1 },
+          total_instances: 3,
+        },
+      },
+    }
+    const { result } = renderHook(() => useBlockNotifications(props))
+
+    act(() => {
+      result.current.acknowledge('network')
+    })
+
+    const stored = JSON.parse(localStorage.getItem('claudevn_block_notifications'))
+    expect(stored.network_unhealthy).toBe(1)
+  })
+
+  it('re-shows notification when condition worsens after acknowledge', () => {
+    // First: 1 offline, acknowledge it
+    const props1 = {
+      ...baseProps,
+      health: {
+        compute_registry: {
+          by_status: { online: 2, offline: 1 },
+          total_instances: 3,
+        },
+      },
+    }
+    const { result, rerender } = renderHook(
+      ({ props }) => useBlockNotifications(props),
+      { initialProps: { props: props1 } }
+    )
+
+    act(() => {
+      result.current.acknowledge('network')
+    })
+
+    // Now: 2 offline — should re-trigger
+    const props2 = {
+      ...baseProps,
+      health: {
+        compute_registry: {
+          by_status: { online: 1, offline: 2 },
+          total_instances: 3,
+        },
+      },
+    }
+    rerender({ props: props2 })
+    expect(result.current.notifications.network).toBe(true)
+  })
+})

--- a/serving/frontend/src/pages/DashboardPage.jsx
+++ b/serving/frontend/src/pages/DashboardPage.jsx
@@ -9,6 +9,7 @@ import useTiming from '../hooks/useTiming'
 import useSystemHealth from '../hooks/useSystemHealth'
 import useDirectivePrompts from '../hooks/useDirectivePrompts'
 import usePresence from '../hooks/usePresence'
+import useBlockNotifications from '../hooks/useBlockNotifications'
 import useChatTransition from '../hooks/useChatTransition'
 import { Plus, ArrowRight } from 'lucide-react'
 import ConversationTimeline from '../components/directives/ConversationTimeline'
@@ -98,6 +99,13 @@ function ActiveProjectDashboard() {
   const { aggregates, totalWorkItems } = useTiming(projectId, { pollInterval: 30000 })
   const { health, overallStatus, loading: healthLoading } = useSystemHealth({ pollInterval: 30000 })
   const { users: presenceUsers } = usePresence(projectId || null, activeProject?.name || null)
+  const { notifications, acknowledge } = useBlockNotifications({
+    health,
+    overallStatus,
+    planData,
+    stats,
+    aggregates,
+  })
   const prompts = useDirectivePrompts(activeProject ? stats : null)
   const { transitionClass, scrollPositionRef } = useChatTransition()
 
@@ -132,6 +140,8 @@ function ActiveProjectDashboard() {
           health={health}
           overallStatus={overallStatus}
           healthLoading={healthLoading}
+          notifications={notifications}
+          onAcknowledge={acknowledge}
         />
       </div>
 
@@ -190,6 +200,8 @@ function ActiveProjectDashboard() {
           aggregates={aggregates}
           totalWorkItems={totalWorkItems}
           presenceUsers={presenceUsers}
+          notifications={notifications}
+          onAcknowledge={acknowledge}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add `NotificationDot` shared component for subtle colored indicator dots in panel headers
- Add `useBlockNotifications` hook that derives notification conditions from existing data and tracks acknowledgment via localStorage
- Wire notification indicators into all four observable blocks on the control center

## Changes
- **New:** `NotificationDot` component (`components/common/NotificationDot.jsx` + CSS) — 7px colored dot with entrance animation, supports red/amber/blue variants
- **New:** `useBlockNotifications` hook (`hooks/useBlockNotifications.js`) — computes notification state for each block:
  - **Network**: red dot when compute nodes are unhealthy or offline
  - **Backlog**: amber dot when blocked issue count increases
  - **Execution**: blue dot when work profile changes or blocked items appear
  - **Timing**: amber dot when p95 exceeds 2x average
- **Modified:** `LeftPanels.jsx` — Execution and Network panels show notification dots and acknowledge on click
- **Modified:** `RightPanels.jsx` — Backlog and Timing panels show notification dots and acknowledge on click
- **Modified:** `DashboardPage.jsx` — integrates hook and passes notification/acknowledge props to both panel columns

## Testing
- [x] 20 unit tests added (16 for hook, 4 for component)
- [x] All tests passing
- [x] Production build succeeds

## Follow-up
- [ ] Create issue for Tier 2 integration tests if needed

## Issues
Closes #229