### PR TITLE
fix: stop orphan work items from cycling when parent issue is DONE

### DIFF
--- a/serving/services/conversation_event_bridge.py
+++ b/serving/services/conversation_event_bridge.py
@@ -68,7 +68,13 @@ class ConversationEventBridge:
         if not content or not project_id:
             return
 
-        if self._should_rate_limit(project_id, metadata.get('event_type', '')):
+        # Rate-limit per (project, work_id, new_status) to prevent chat spam
+        # from work items cycling between states
+        rate_key = metadata.get('work_id', metadata.get('event_type', ''))
+        new_status = metadata.get('new_status', '')
+        if new_status:
+            rate_key = f"{rate_key}:{new_status}"
+        if self._should_rate_limit(project_id, rate_key):
             return
 
         await service.add_message(

--- a/serving/services/work_orchestrator.py
+++ b/serving/services/work_orchestrator.py
@@ -317,6 +317,21 @@ class WorkOrchestrator:
                 )
             for work in stale_assigned:
                 try:
+                    # If parent issue is already DONE, complete the orphan
+                    # instead of cycling it back to PENDING endlessly.
+                    issue_id = work.issue_id or (work.context.get("issue_id") if work.context else None)
+                    if issue_id:
+                        parent_issue = await work_map.get_issue(issue_id)
+                        if parent_issue and parent_issue.status == IssueStatus.DONE:
+                            await work_map.update_status(
+                                work.work_id, WorkStatus.COMPLETED
+                            )
+                            logger.info(
+                                f"Completed orphan work {work.work_id}: "
+                                f"parent issue {issue_id} is already DONE"
+                            )
+                            continue
+
                     updated = await work_map.reset_assigned_to_pending(
                         work.work_id
                     )
@@ -427,6 +442,17 @@ class WorkOrchestrator:
                 retry_after = self._retry_after.get(work.work_id)
                 if retry_after and now < retry_after:
                     continue
+
+                # Don't retry work whose parent issue is already DONE
+                issue_id = work.issue_id or (work.context.get("issue_id") if work.context else None)
+                if issue_id:
+                    parent_issue = await work_map.get_issue(issue_id)
+                    if parent_issue and parent_issue.status == IssueStatus.DONE:
+                        logger.info(
+                            f"Skipping retry for work {work.work_id}: "
+                            f"parent issue {issue_id} is already DONE"
+                        )
+                        continue
 
                 # Record the compute node that failed (before mark_work_for_retry clears assigned_to)
                 if work.assigned_to:
@@ -668,6 +694,20 @@ class WorkOrchestrator:
                         "requires manual intervention"
                     )
                     continue
+
+                # Skip (and cancel) orphan work whose parent issue is already DONE
+                issue_id = work.issue_id or (work.context.get("issue_id") if work.context else None)
+                if issue_id:
+                    parent_issue = await work_map.get_issue(issue_id)
+                    if parent_issue and parent_issue.status == IssueStatus.DONE:
+                        logger.info(
+                            f"Cancelling orphan work {work.work_id}: "
+                            f"parent issue {issue_id} is already DONE"
+                        )
+                        await work_map.update_status(
+                            work.work_id, WorkStatus.COMPLETED
+                        )
+                        continue
 
                 candidates.append(work)
 


### PR DESCRIPTION
## Summary

- **Bug:** Work items whose parent issue is already DONE cycle endlessly between `pending → assigned → pending`, spamming the chat timeline with dozens of "moved to pending" / "moved to assigned" messages
- **Root cause:** When an issue completes, leftover work items are never cleaned up — the orchestrator keeps dispatching them, the stale-assigned timeout (3 min) resets them, and the cycle repeats
- **Fix:** Added parent-issue-DONE checks in 3 orchestrator paths (`_process_pending_work`, `_detect_and_handle_stale_work`, `_retry_failed_work`) that auto-complete orphan work items. Also improved the `ConversationEventBridge` rate limiter to deduplicate per work item instead of globally

## Changes

| File | Change |
|------|--------|
| `serving/services/work_orchestrator.py` | Skip and auto-complete orphan work items whose parent issue is DONE in 3 code paths |
| `serving/services/conversation_event_bridge.py` | Rate-limit chat messages per `(project, work_id, status)` instead of `(project, event_type)` |

## Test plan

- [ ] Deploy to test environment and verify no more "moved to pending" spam in chat for completed issues
- [ ] Create a new goal, let it decompose and complete — verify work items complete cleanly
- [ ] Verify stale-assigned recovery still works for legitimate orphaned work (parent issue NOT done)
- [ ] Verify failed work retry still works when parent issue is in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)