### PR TITLE
fix: propagate resource capabilities during compute registration (#225)

### DIFF
--- a/compute/services/sse_event_client.py
+++ b/compute/services/sse_event_client.py
@@ -560,17 +560,36 @@ class SSEEventClient:
         url = f"{self.serving_url}/api/v1/compute/register"
 
         # Build registration payload (manual construction to avoid import issues)
+        capabilities = {
+            "agents": self.capabilities,
+            "tools": [],
+            "features": [],
+            "labels": self.labels,
+            "tools_available": self.tools_available,
+        }
+
+        # Include resources if available (normalize string values like "16gb" → numeric)
+        if self.resources:
+            normalized = {}
+            for key, value in self.resources.items():
+                if isinstance(value, (int, float)):
+                    normalized[key] = value
+                elif isinstance(value, str):
+                    numeric = "".join(c for c in value if c.isdigit() or c == ".")
+                    if numeric:
+                        normalized[key] = float(numeric) if "." in numeric else int(numeric)
+            if normalized:
+                capabilities["resources"] = {
+                    "cpu_count": normalized.get("cpu"),
+                    "memory_gb": normalized.get("memory"),
+                    "gpu_count": normalized.get("gpu"),
+                }
+
         payload = {
             "instance_id": self.compute_id,
             "name": f"Compute {self.compute_id}",
             "endpoint": "sse",
-            "capabilities": {
-                "agents": self.capabilities,
-                "tools": [],
-                "features": [],
-                "labels": self.labels,
-                "tools_available": self.tools_available,
-            },
+            "capabilities": capabilities,
             "metadata": {
                 "connection_type": "sse",
                 "pre_registered": True,

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -438,10 +438,16 @@ async def connect_sse(
                     f"(auth={existing.auth_status.value})"
                 )
             else:
-                # Genuinely pending — preserve PENDING status.
+                # Genuinely pending — preserve PENDING status but update capabilities
+                # (resources are only sent via X-Resources header on SSE connect).
                 # update_heartbeat() only updates the timestamp; it does NOT promote
                 # PENDING → ONLINE. Only explicit approval via POST /{id}/approve does that.
-                await registry.update_heartbeat(compute_id, metadata={"sse_connected": True})
+                await registry.update_instance(
+                    compute_id,
+                    capabilities=instance_capabilities,
+                    metadata={"sse_connected": True},
+                )
+                await registry.update_heartbeat(compute_id)
                 logger.info(f"Compute {compute_id} pre-registered (PENDING preserved), SSE connected")
     except ValueError as e:
         raise HTTPException(


### PR DESCRIPTION
## Summary
- Normalize string resource values (e.g. `"16gb"` → `16`) and include CPU/memory/GPU in the compute registration payload
- Update instance capabilities (not just heartbeat) when a pending compute reconnects via SSE, so `X-Resources` header data actually persists

## Changes
- `compute/services/sse_event_client.py` — Build `capabilities.resources` from normalized resource values during registration
- `serving/api/compute.py` — Use `update_instance()` instead of `update_heartbeat()` for pending reconnects so capabilities are stored

## Context
These were uncommitted fixes left over from #225 (hardware resource metrics). Without them, resource data sent via `X-Resources` headers doesn't fully propagate through registration or SSE reconnection.

## Testing
- [ ] Compute registers with resource capabilities visible in network details
- [ ] Reconnecting compute preserves resource data

Relates to #225

Generated with [Claude Code](https://claude.com/claude-code)