### PR TITLE
fix: add /releases to public auth routes (#215)

### DIFF
--- a/serving/middleware/cognito_middleware.py
+++ b/serving/middleware/cognito_middleware.py
@@ -34,6 +34,7 @@ PUBLIC_PATH_PREFIXES = (
     "/api/v1/marketplace/register",  # Marketplace registration
     "/api/v1/users/login",           # User login (local auth mode)
     "/api/v1/users/register",        # User registration (local auth mode)
+    "/api/v1/releases",              # Release notes (public, non-sensitive)
 )
 
 # Non-API routes that are always public


### PR DESCRIPTION
## Summary
- Add `/api/v1/releases` to the public routes whitelist in auth middleware
- The What's New popup was failing silently because the releases endpoint returned 401

## Changes
- `serving/middleware/cognito_middleware.py` — Add `/api/v1/releases` to `PUBLIC_PATH_PREFIXES`

## Testing
- [ ] `GET /api/v1/releases` returns 200 without auth token
- [ ] What's New popup appears on app load when version changes

Relates to #215

Generated with [Claude Code](https://claude.com/claude-code)