### PR TITLE
fix: add compute callback routes to auth middleware public paths

### DIFF
--- a/serving/middleware/cognito_middleware.py
+++ b/serving/middleware/cognito_middleware.py
@@ -26,6 +26,9 @@ PUBLIC_PATH_PREFIXES = (
     "/api/v1/compute/connect",       # SSE registration (approval workflow gates access)
     "/api/v1/compute/register",      # Compute registration (starts in PENDING status)
     "/api/v1/compute/refresh-credentials",  # Compute credential refresh
+    "/api/v1/compute/events",        # Compute event callbacks (verified by compute registry)
+    "/api/v1/compute/decomposition/", # Decomposition result submission
+    "/api/v1/compute/characterization/", # Characterization result submission
     "/api/v1/mcp/",                  # MCP tools (uses API key auth)
     "/api/v1/auth/credentials",      # Compute credential fetching
     "/api/v1/auth/token",            # Claude token management (internal)

--- a/serving/services/assignment_service.py
+++ b/serving/services/assignment_service.py
@@ -488,7 +488,7 @@ class AssignmentService:
 
         # Validate status transition
         valid_transitions = {
-            WorkStatus.PENDING: [WorkStatus.ASSIGNED],
+            WorkStatus.PENDING: [WorkStatus.ASSIGNED, WorkStatus.COMPLETED],
             WorkStatus.ASSIGNED: [WorkStatus.IN_PROGRESS, WorkStatus.BLOCKED, WorkStatus.PENDING],
             WorkStatus.IN_PROGRESS: [WorkStatus.BLOCKED, WorkStatus.REVIEW, WorkStatus.COMPLETED, WorkStatus.FAILED],
             WorkStatus.BLOCKED: [WorkStatus.IN_PROGRESS, WorkStatus.PENDING],

--- a/serving/services/presence_service.py
+++ b/serving/services/presence_service.py
@@ -83,9 +83,7 @@ class PresenceService:
             raw = self._redis._redis
             # Read existing connected_at so we don't reset it on refresh
             existing_connected_at = await raw.hget(key, "connected_at")
-            connected_at = (
-                existing_connected_at.decode() if existing_connected_at else now
-            )
+            connected_at = existing_connected_at if existing_connected_at else now
 
             mapping = {
                 "user_id": user_id,


### PR DESCRIPTION
## Summary

- **Auth middleware blocking compute callbacks**: When `AUTH_MODE=local` was introduced, `/compute/events`, `/compute/decomposition/*/result`, and `/compute/characterization/*/result` endpoints started requiring UI auth tokens. Compute nodes don't have these tokens, so all callbacks returned 401. This left all SSE computes permanently "busy" and blocked all work dispatch.
- **Orphan work item transition**: Allow `PENDING → COMPLETED` status transition so the orchestrator can clean up orphan work items whose parent issue is already DONE, instead of logging invalid transition warnings every poll cycle.
- **Presence heartbeat decode error**: Remove `.decode()` call on Redis value that's already a string (`decode_responses=True`), fixing the `'str' object has no attribute 'decode'` warning on every heartbeat.

## Test plan

- [ ] Rebuild and restart serving container
- [ ] Send a new directive to hello-proj and verify decomposition results are received
- [ ] Verify work items appear in backlog/plan
- [ ] Verify compute nodes successfully complete assigned work
- [ ] Verify orphan work items are cleaned up without warnings
- [ ] Verify no presence heartbeat errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)