### PR TITLE
fix: raise conversation message limits and filter ChatRail noise

### DIFF
--- a/serving/api/conversation.py
+++ b/serving/api/conversation.py
@@ -14,7 +14,7 @@ router = APIRouter(prefix="/projects/{project_id}/conversation", tags=["conversa
 @router.get("", response_model=ConversationResponse)
 async def get_conversation(
     project_id: str,
-    limit: int = Query(default=50, ge=1, le=200),
+    limit: int = Query(default=500, ge=1, le=500),
     before: Optional[str] = Query(default=None),
     user_id: Optional[str] = Depends(get_optional_user_id),
 ):

--- a/serving/frontend/src/api/conversation.js
+++ b/serving/frontend/src/api/conversation.js
@@ -6,7 +6,7 @@ import { request } from './index.js'
  * @param {string} projectId
  * @param {{ limit?: number, before?: string }} options
  */
-export async function getConversation(projectId, { limit = 50, before = null } = {}) {
+export async function getConversation(projectId, { limit = 500, before = null } = {}) {
   const params = new URLSearchParams({ limit: String(limit) })
   if (before) params.set('before', before)
   return request(`/projects/${encodeURIComponent(projectId)}/conversation?${params}`)

--- a/serving/frontend/src/components/layout/ChatRail.jsx
+++ b/serving/frontend/src/components/layout/ChatRail.jsx
@@ -8,7 +8,18 @@ import useChatTransition from '../../hooks/useChatTransition'
 import { Send, ChevronLeft, ChevronRight, MessageSquare, ExternalLink } from 'lucide-react'
 import './ChatRail.css'
 
-const CHATRAIL_MAX_MESSAGES = 10
+const CHATRAIL_MAX_MESSAGES = 500
+
+// Message types shown in the sidebar rail — keep it focused on completed
+// outcomes and user messages. Full detail lives in the Control Center.
+const CHATRAIL_VISIBLE_TYPES = new Set([
+  'user',
+  'goal_complete',
+  'goal_processing',
+  'directive_applied',
+  'directive_rejected',
+  'error',
+])
 
 function RailProjectHeader() {
   const { activeProject } = useProjectContext()
@@ -44,7 +55,9 @@ function ChatRail() {
   const { stats } = useIssues({ useWebSocket: !!activeProject, pollInterval: activeProject ? 30000 : 0 })
   const prompts = useDirectivePrompts(activeProject ? stats : null)
 
-  const recentMessages = messages.slice(-CHATRAIL_MAX_MESSAGES)
+  const recentMessages = messages
+    .filter(m => CHATRAIL_VISIBLE_TYPES.has(m.type))
+    .slice(-CHATRAIL_MAX_MESSAGES)
 
   // Track unread messages when collapsed
   useEffect(() => {
@@ -168,7 +181,6 @@ function ChatRail() {
             {recentMessages.map((msg) => {
               const isUser = msg.type === 'user' || msg.role === 'user'
               const isError = msg.type === 'error'
-              const isThinking = msg.type === 'thinking'
               const roleClass = isUser ? 'user' : isError ? 'error' : 'system'
               const timestamp = msg.timestamp
                 ? (typeof msg.timestamp === 'string'
@@ -177,8 +189,6 @@ function ChatRail() {
                       ? msg.timestamp
                       : new Date())
                 : new Date()
-
-              if (isThinking) return null
 
               return (
                 <div key={msg.id} className={`chat-rail-message chat-rail-message-${roleClass}`}>


### PR DESCRIPTION
## Summary

Closes #250

- Backend API limit raised from 50/200 to 500/500
- Frontend API default raised from 50 to 500
- ChatRail sidebar raised from 10 to 500, now filters to show only: user messages, completed goals, decomposition progress, applied/rejected directives, and errors
- Strips intermediate workflow noise (thinking, goal_created, directive_preview, attention, promote_suggestion) from the sidebar

## Test plan

- [ ] Verify ChatRail shows user messages and completed outcomes
- [ ] Verify ChatRail no longer shows thinking/goal_created/attention messages
- [ ] Verify Control Center loads up to 500 messages on project switch
- [ ] Verify backend accepts limit=500 without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)