### PR TITLE
fix: rewrite branch name on rejection re-dispatch

### DIFF
--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -864,17 +864,22 @@ async def _handle_rejection_redispatch(event: ComputeEventRequest) -> None:
         _track_rejection_for_orchestrator(task_id, rejecting_compute)
         return
 
-    # Re-dispatch to the new compute
+    # Re-dispatch to the new compute — rewrite branch name for the new assignee
+    # Branch format is {type}/{issue_id}/{compute_id}, so replace the last segment
+    original_branch = work_data["branch_name"]
+    branch_parts = original_branch.rsplit("/", 1)
+    new_branch = f"{branch_parts[0]}/{new_connection.compute_id}" if len(branch_parts) == 2 else original_branch
+
     logger.info(
         f"Re-dispatching rejected task {task_id} from {rejecting_compute} "
-        f"to {new_connection.compute_id}"
+        f"to {new_connection.compute_id} (branch: {original_branch} -> {new_branch})"
     )
     success = await sse_manager.send_work_assigned(
         compute_id=new_connection.compute_id,
         task_id=work_data["task_id"],
         title=work_data["title"],
         description=work_data["description"],
-        branch_name=work_data["branch_name"],
+        branch_name=new_branch,
         skills=work_data["skills"],
         context=work_data["context"],
         mcp_config=work_data["mcp_config"],


### PR DESCRIPTION
## Summary
- When a compute node rejected a task (at capacity), `_handle_rejection_redispatch()` passed the original branch name (e.g., `b/issue_xxx/python-002`) to the new compute node (e.g., `python-001`)
- The git pre-receive hook correctly blocked the push (`python-001 cannot push to python-002's branch`), causing the task to fail and enter a retry loop
- Fix: rewrite the last segment of the branch name to use the new compute's ID before re-dispatching

## Test plan
- [ ] Deploy and verify rejected tasks get re-dispatched with corrected branch names in logs
- [ ] Confirm the new compute can push to its own branch after re-dispatch
- [ ] Verify the orchestrator retry path (which already worked) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)