### PR TITLE
feat: Add IMPLEMENTED intermediate status (#267)

### DIFF
--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -706,9 +706,9 @@ async def _handle_work_status_update(event: ComputeEventRequest) -> None:
         and event.exit_code == 0
     )
 
-    # Check if work is already in a terminal state (#829)
-    # MCP report_progress(status=COMPLETED) may have already marked it done
-    already_terminal = work.status in (WorkStatus.COMPLETED, WorkStatus.FAILED)
+    # Check if work is already in a terminal/near-terminal state (#829)
+    # MCP report_progress(status=COMPLETED) may have already marked it implemented
+    already_terminal = work.status in (WorkStatus.IMPLEMENTED, WorkStatus.COMPLETED, WorkStatus.FAILED)
 
     if already_terminal:
         logger.info(
@@ -782,7 +782,7 @@ async def _handle_work_status_update(event: ComputeEventRequest) -> None:
 
     # Post-completion side effects run regardless of who set the terminal state,
     # since MCP progress doesn't handle PR creation or tracking (#829)
-    if is_success or (already_terminal and work.status == WorkStatus.COMPLETED):
+    if is_success or (already_terminal and work.status in (WorkStatus.IMPLEMENTED, WorkStatus.COMPLETED)):
         # Record specialization utilization
         try:
             from services.specialization_service import get_specialization_service
@@ -804,13 +804,12 @@ async def _handle_work_status_update(event: ComputeEventRequest) -> None:
         except Exception as e:
             logger.debug(f"Context affinity tracking skipped: {e}")
 
-        # Auto-create PR and trigger merge if branch exists, then cascade (#832)
+        # Auto-create PR and trigger merge if branch exists (#832)
+        # finalize_work() inside _auto_create_and_merge_pr handles
+        # IMPLEMENTED → COMPLETED + DONE transitions and dependency cascade
         branch_name = event.branch_name or work.branch_name
         if branch_name and work.project_id:
             await _auto_create_and_merge_pr(work, branch_name, event.compute_id)
-
-        # NOW trigger dependency cascade — dependents clone main with merged code (#832)
-        await work_map.cascade_dependents(work.work_id)
 
 
 
@@ -1116,13 +1115,10 @@ async def _handle_conflict_resolution_completed(event, work_map) -> None:
     )
 
     # Re-trigger the PR merge pipeline with the original work item
+    # finalize_work() inside _auto_create_and_merge_pr handles cascade
     branch_name = event.branch_name or work.branch_name
     if branch_name and work.project_id:
         await _auto_create_and_merge_pr(work, branch_name, event.compute_id)
-
-        # Cascade dependents now that the merge can proceed
-        if work.status == WorkStatus.COMPLETED:
-            await work_map.cascade_dependents(work.work_id)
 
 
 async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> None:
@@ -1210,7 +1206,18 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
         results = await pr_service.process_merge_queue(git_project_name)
         for result in results:
             if result.get("success"):
-                logger.info(f"Auto-merged branch {result.get('branch', branch_name)}")
+                merged_branch = result.get("branch", branch_name)
+                logger.info(f"Auto-merged branch {merged_branch}")
+
+                # Finalize work: IMPLEMENTED → COMPLETED + DONE + cascade
+                if merged_branch == branch_name:
+                    try:
+                        work_map = get_work_map_service()
+                        await work_map.finalize_work(work.work_id)
+                    except Exception as fin_err:
+                        logger.warning(
+                            f"Failed to finalize work {work.work_id} after merge: {fin_err}"
+                        )
             elif result.get("reason") == "conflict":
                 # Merge conflict — dispatch resolution to the branch's compute
                 conflict_branch = result.get("branch", branch_name)

--- a/serving/api/plan_summary.py
+++ b/serving/api/plan_summary.py
@@ -39,6 +39,7 @@ class PlanSummaryResponse(BaseModel):
     blocked_count: int = 0
     backlog_count: int = 0
     failed_count: int = 0
+    implemented_count: int = 0
     done_count: int = 0
     total_count: int = 0
 
@@ -57,9 +58,10 @@ class PlanSummaryResponse(BaseModel):
     blocked_items: List[dict] = Field(default_factory=list)  # blocked issues
     backlog_items: List[dict] = Field(default_factory=list)  # backlog (waiting on deps)
     failed_items: List[dict] = Field(default_factory=list)   # failed issues
+    implemented_items: List[dict] = Field(default_factory=list)  # implemented, pending merge
 
     # Done items
-    done_items: List[dict] = Field(default_factory=list)      # completed issues
+    done_items: List[dict] = Field(default_factory=list)      # merged to main
 
     # Decision traces
     recent_traces: List[dict] = Field(default_factory=list)  # last 10 traces
@@ -133,6 +135,7 @@ async def get_plan_summary(
         blocked = [i for i in all_issues if i.status == IssueStatus.BLOCKED]
         backlog = [i for i in all_issues if i.status == IssueStatus.BACKLOG]
         failed = [i for i in all_issues if i.status == IssueStatus.FAILED]
+        implemented = [i for i in all_issues if i.status == IssueStatus.IMPLEMENTED]
         done = [i for i in all_issues if i.status == IssueStatus.DONE]
 
         response.running_items = [_serialize_issue(i) for i in in_progress]
@@ -140,6 +143,7 @@ async def get_plan_summary(
         response.blocked_items = [_serialize_issue(i) for i in blocked]
         response.backlog_items = [_serialize_issue(i) for i in backlog[:20]]
         response.failed_items = [_serialize_issue(i) for i in failed]
+        response.implemented_items = [_serialize_issue(i) for i in implemented]
         response.done_items = [_serialize_issue(i) for i in done]
 
         response.in_progress_count = len(in_progress)
@@ -147,6 +151,7 @@ async def get_plan_summary(
         response.blocked_count = len(blocked)
         response.backlog_count = len(backlog)
         response.failed_count = len(failed)
+        response.implemented_count = len(implemented)
         response.done_count = len(done)
         response.total_count = len(all_issues)
 

--- a/serving/frontend/src/components/common/Badge.jsx
+++ b/serving/frontend/src/components/common/Badge.jsx
@@ -14,6 +14,8 @@ export function StatusBadge({ status }) {
     healthy: 'success',
     running: 'success',
     completed: 'success',
+    done: 'success',
+    implemented: 'warning',
     degraded: 'warning',
     draining: 'warning',
     benched: 'warning',

--- a/serving/frontend/src/components/plan/ActiveWorkView.jsx
+++ b/serving/frontend/src/components/plan/ActiveWorkView.jsx
@@ -1,4 +1,4 @@
-import { Play, Clock, AlertCircle, Layers, XCircle, CheckCircle2, History } from 'lucide-react'
+import { Play, Clock, AlertCircle, Layers, XCircle, CheckCircle2, GitMerge, History } from 'lucide-react'
 import Badge from '../common/Badge'
 import BucketBadges from '../common/BucketBadges'
 import Spinner from '../common/Spinner'
@@ -46,6 +46,7 @@ function ActiveWorkView({ data, loading, onItemClick, onItemTracesClick, itemBuc
     blocked_items = [],
     backlog_items = [],
     failed_items = [],
+    implemented_items = [],
     done_items = [],
   } = data
 
@@ -107,9 +108,20 @@ function ActiveWorkView({ data, loading, onItemClick, onItemTracesClick, itemBuc
             itemBucketMap={itemBucketMap}
           />
         )}
+        {implemented_items.length > 0 && (
+          <WorkColumn
+            title="Pending Merge"
+            icon={GitMerge}
+            iconClass="implemented"
+            items={implemented_items}
+            emptyMessage=""
+            onItemClick={onItemClick}
+            itemBucketMap={itemBucketMap}
+          />
+        )}
         {done_items.length > 0 && (
           <WorkColumn
-            title="Completed"
+            title="Merged"
             icon={CheckCircle2}
             iconClass="done"
             items={done_items}

--- a/serving/frontend/src/components/plan/DependencyGraphView.jsx
+++ b/serving/frontend/src/components/plan/DependencyGraphView.jsx
@@ -10,6 +10,8 @@ function getStatusClass(status) {
     case 'done':
     case 'completed':
       return 'directive-chip--done'
+    case 'implemented':
+      return 'directive-chip--implemented'
     case 'in_progress':
     case 'in_review':
       return 'directive-chip--progress'
@@ -28,6 +30,7 @@ function getDirectiveStatus(issues) {
   let hasProgress = false
   let hasBlocked = false
   let hasReady = false
+  let hasImplemented = false
   let allDone = true
 
   for (const issue of issues) {
@@ -35,12 +38,14 @@ function getDirectiveStatus(issues) {
     if (s === 'in_progress' || s === 'in_review') hasProgress = true
     else if (s === 'blocked') hasBlocked = true
     else if (s === 'ready') hasReady = true
+    else if (s === 'implemented') hasImplemented = true
 
     if (s !== 'done' && s !== 'completed') allDone = false
   }
 
   if (hasProgress) return 'progress'
   if (hasBlocked) return 'blocked'
+  if (hasImplemented) return 'implemented'
   if (hasReady) return 'ready'
   if (allDone) return 'done'
   return 'backlog'
@@ -51,11 +56,12 @@ function getStatusSortOrder(status) {
     case 'blocked': return 0
     case 'in_progress':
     case 'in_review': return 1
-    case 'ready': return 2
-    case 'backlog': return 3
+    case 'implemented': return 2
+    case 'ready': return 3
+    case 'backlog': return 4
     case 'done':
-    case 'completed': return 4
-    default: return 5
+    case 'completed': return 5
+    default: return 6
   }
 }
 
@@ -66,7 +72,7 @@ function DirectiveSection({ directive, issues, expanded, onToggle }) {
     const counts = { done: 0, progress: 0, ready: 0, blocked: 0, backlog: 0 }
     for (const issue of issues) {
       const s = issue.status?.toLowerCase()
-      if (s === 'done' || s === 'completed') counts.done++
+      if (s === 'done' || s === 'completed' || s === 'implemented') counts.done++
       else if (s === 'in_progress' || s === 'in_review') counts.progress++
       else if (s === 'ready') counts.ready++
       else if (s === 'blocked') counts.blocked++

--- a/serving/frontend/src/components/plan/Plan.css
+++ b/serving/frontend/src/components/plan/Plan.css
@@ -889,6 +889,11 @@
   color: #6b7280;
 }
 
+.directive-chip--implemented {
+  background: rgba(245, 158, 11, 0.12);
+  color: #f59e0b;
+}
+
 .directive-chip--progress {
   background: rgba(59, 130, 246, 0.12);
   color: #3b82f6;

--- a/serving/frontend/src/components/workmap/IssueDependencyGraph.jsx
+++ b/serving/frontend/src/components/workmap/IssueDependencyGraph.jsx
@@ -88,6 +88,8 @@ function getStatusColor(status) {
     case 'done':
     case 'completed':
       return '#6b7280'
+    case 'implemented':
+      return '#f59e0b'
     case 'in_progress':
     case 'in_review':
       return '#3b82f6'
@@ -105,6 +107,8 @@ function getStatusFill(status) {
     case 'done':
     case 'completed':
       return 'rgba(107,114,128,0.10)'
+    case 'implemented':
+      return 'rgba(245,158,11,0.10)'
     case 'in_progress':
     case 'in_review':
       return 'rgba(59,130,246,0.10)'

--- a/serving/frontend/src/components/workmap/IssueDetailModal.jsx
+++ b/serving/frontend/src/components/workmap/IssueDetailModal.jsx
@@ -11,6 +11,7 @@ const statusOptions = [
   { value: 'ready', label: 'Ready' },
   { value: 'in_progress', label: 'In Progress' },
   { value: 'blocked', label: 'Blocked' },
+  { value: 'implemented', label: 'Implemented' },
   { value: 'done', label: 'Done' },
   { value: 'failed', label: 'Failed' }
 ]
@@ -19,8 +20,9 @@ const statusOptions = [
 const validTransitions = {
   backlog: ['ready'],
   ready: ['in_progress', 'backlog'],
-  in_progress: ['blocked', 'done', 'failed'],
+  in_progress: ['blocked', 'implemented', 'failed'],
   blocked: ['in_progress', 'ready'],
+  implemented: ['done', 'in_progress'],
   done: ['backlog'],
   failed: ['ready', 'in_progress', 'backlog'],
 }

--- a/serving/frontend/src/components/workmap/WorkMapGraph.css
+++ b/serving/frontend/src/components/workmap/WorkMapGraph.css
@@ -117,6 +117,10 @@
   opacity: 0.6;
 }
 
+.status-implemented .node-circle {
+  filter: drop-shadow(0 0 2px #f59e0b);
+}
+
 /* Legend */
 .graph-legend {
   position: absolute;
@@ -167,6 +171,10 @@
 
 .legend-dot.status-blocked {
   background: #ef4444;
+}
+
+.legend-dot.status-implemented {
+  background: #f59e0b;
 }
 
 .legend-dot.status-done {

--- a/serving/frontend/src/components/workmap/WorkMapGraph.jsx
+++ b/serving/frontend/src/components/workmap/WorkMapGraph.jsx
@@ -84,6 +84,8 @@ function WorkMapGraph({ graphData, loading }) {
       case 'done':
       case 'completed':
         return '#6b7280'
+      case 'implemented':
+        return '#f59e0b'
       case 'in_progress':
       case 'in_review':
         return '#3b82f6'
@@ -101,6 +103,8 @@ function WorkMapGraph({ graphData, loading }) {
       case 'done':
       case 'completed':
         return 'status-done'
+      case 'implemented':
+        return 'status-implemented'
       case 'in_progress':
       case 'in_review':
         return 'status-progress'

--- a/serving/frontend/src/hooks/useRecentActivity.js
+++ b/serving/frontend/src/hooks/useRecentActivity.js
@@ -7,7 +7,8 @@ const STATUS_LABELS = {
   in_progress: 'started',
   in_review: 'moved to review',
   testing: 'moved to testing',
-  done: 'completed',
+  implemented: 'implemented — pending merge',
+  done: 'merged',
   blocked: 'blocked',
   cancelled: 'cancelled',
 }

--- a/serving/mcp/models.py
+++ b/serving/mcp/models.py
@@ -12,6 +12,7 @@ class TaskStatus(str, Enum):
     IN_PROGRESS = "in_progress"
     BLOCKED = "blocked"
     REVIEW_REQUESTED = "review_requested"
+    IMPLEMENTED = "implemented"
     COMPLETED = "completed"
 
 

--- a/serving/mcp/tools/complete.py
+++ b/serving/mcp/tools/complete.py
@@ -145,7 +145,7 @@ async def complete_task(input: CompleteTaskInput) -> tuple[Optional[CompleteResp
 
         return CompleteResponse(
             task_id=input.task_id,
-            status="completed",
+            status="implemented",
             merge_status=merge_status,
             next_task=next_task
         ), None

--- a/serving/mcp/tools/progress.py
+++ b/serving/mcp/tools/progress.py
@@ -16,7 +16,8 @@ STATUS_MAP = {
     TaskStatus.IN_PROGRESS: WorkStatus.IN_PROGRESS,
     TaskStatus.BLOCKED: WorkStatus.BLOCKED,
     TaskStatus.REVIEW_REQUESTED: WorkStatus.REVIEW,
-    TaskStatus.COMPLETED: WorkStatus.COMPLETED,
+    TaskStatus.IMPLEMENTED: WorkStatus.IMPLEMENTED,
+    TaskStatus.COMPLETED: WorkStatus.IMPLEMENTED,
 }
 
 

--- a/serving/models/work_map.py
+++ b/serving/models/work_map.py
@@ -42,7 +42,8 @@ class IssueStatus(str, Enum):
     READY = "ready"             # All dependencies met, waiting for assignment
     IN_PROGRESS = "in_progress"  # Assigned to a Compute, being worked
     BLOCKED = "blocked"         # Compute reported a blocker
-    DONE = "done"               # Completed successfully
+    IMPLEMENTED = "implemented"  # Work done, branch pushed, pending merge
+    DONE = "done"               # Branch merged to main, fully completed
     FAILED = "failed"           # Failed after retries exhausted
 
 
@@ -91,7 +92,8 @@ class WorkStatus(str, Enum):
     IN_PROGRESS = "in_progress"   # Compute actively working
     BLOCKED = "blocked"           # Waiting on dependency or external
     REVIEW = "review"             # Work done, awaiting review
-    COMPLETED = "completed"       # Successfully completed
+    IMPLEMENTED = "implemented"   # Code done, branch pushed, pending merge
+    COMPLETED = "completed"       # Branch merged to main, fully done
     FAILED = "failed"             # Failed, needs intervention
 
 

--- a/serving/services/assignment_service.py
+++ b/serving/services/assignment_service.py
@@ -488,18 +488,19 @@ class AssignmentService:
 
         # Validate status transition
         valid_transitions = {
-            WorkStatus.PENDING: [WorkStatus.ASSIGNED, WorkStatus.COMPLETED, WorkStatus.FAILED],
+            WorkStatus.PENDING: [WorkStatus.ASSIGNED, WorkStatus.IMPLEMENTED, WorkStatus.FAILED],
             WorkStatus.ASSIGNED: [WorkStatus.IN_PROGRESS, WorkStatus.BLOCKED, WorkStatus.PENDING],
-            WorkStatus.IN_PROGRESS: [WorkStatus.BLOCKED, WorkStatus.REVIEW, WorkStatus.COMPLETED, WorkStatus.FAILED],
+            WorkStatus.IN_PROGRESS: [WorkStatus.BLOCKED, WorkStatus.REVIEW, WorkStatus.IMPLEMENTED, WorkStatus.FAILED],
             WorkStatus.BLOCKED: [WorkStatus.IN_PROGRESS, WorkStatus.PENDING],
-            WorkStatus.REVIEW: [WorkStatus.COMPLETED, WorkStatus.IN_PROGRESS, WorkStatus.FAILED],
+            WorkStatus.REVIEW: [WorkStatus.IMPLEMENTED, WorkStatus.IN_PROGRESS, WorkStatus.FAILED],
+            WorkStatus.IMPLEMENTED: [WorkStatus.COMPLETED, WorkStatus.IN_PROGRESS],
             WorkStatus.COMPLETED: [],
             WorkStatus.FAILED: [WorkStatus.PENDING],
         }
 
         if status not in valid_transitions.get(work.status, []):
-            # Idempotent: same terminal state is a no-op, not an error (#829)
-            if work.status == status and status in (WorkStatus.COMPLETED, WorkStatus.FAILED):
+            # Idempotent: same terminal/near-terminal state is a no-op, not an error (#829)
+            if work.status == status and status in (WorkStatus.IMPLEMENTED, WorkStatus.COMPLETED, WorkStatus.FAILED):
                 logger.debug(f"Idempotent status transition for {work_id}: already {status.value}")
                 return work
             logger.warning(f"Invalid status transition for {work_id}: {work.status} -> {status}")
@@ -523,7 +524,9 @@ class AssignmentService:
                 self._key(f"work:status:{old_status.value}"),
                 work_id
             )
-            if status in [WorkStatus.COMPLETED, WorkStatus.FAILED] and work.assigned_to:
+            # Clear compute's current work when compute is done (IMPLEMENTED)
+            # or on terminal states (COMPLETED, FAILED)
+            if status in [WorkStatus.IMPLEMENTED, WorkStatus.COMPLETED, WorkStatus.FAILED] and work.assigned_to:
                 await self._redis._redis.delete(
                     self._key(f"workmap:compute:{work.assigned_to}:current")
                 )
@@ -592,10 +595,7 @@ class AssignmentService:
         work.progress_percent = 100
         work.updated_at = datetime.now(timezone.utc)
 
-        await self.update_status(work_id, WorkStatus.COMPLETED, compute_id, save_callback)
-
-        # Check if this unblocks other work
-        await self._check_unblock_dependents(work_id, save_callback)
+        await self.update_status(work_id, WorkStatus.IMPLEMENTED, compute_id, save_callback)
 
         logger.info(f"Work {work_id} completed")
         return work

--- a/serving/services/issue_ops_service.py
+++ b/serving/services/issue_ops_service.py
@@ -641,8 +641,9 @@ class IssueOpsService:
     VALID_TRANSITIONS = {
         IssueStatus.BACKLOG: [IssueStatus.READY],
         IssueStatus.READY: [IssueStatus.IN_PROGRESS, IssueStatus.BACKLOG],
-        IssueStatus.IN_PROGRESS: [IssueStatus.BLOCKED, IssueStatus.DONE, IssueStatus.FAILED],
+        IssueStatus.IN_PROGRESS: [IssueStatus.BLOCKED, IssueStatus.IMPLEMENTED, IssueStatus.FAILED],
         IssueStatus.BLOCKED: [IssueStatus.IN_PROGRESS, IssueStatus.READY],
+        IssueStatus.IMPLEMENTED: [IssueStatus.DONE, IssueStatus.IN_PROGRESS],
         IssueStatus.DONE: [IssueStatus.BACKLOG],
         IssueStatus.FAILED: [IssueStatus.READY, IssueStatus.IN_PROGRESS, IssueStatus.BACKLOG],
     }
@@ -780,12 +781,41 @@ class IssueOpsService:
         compute_id: Optional[str] = None,
         trigger_cascade: bool = True
     ) -> Optional[Issue]:
-        """Mark an issue as done with result."""
+        """Mark an issue as implemented (code done, pending merge).
+
+        Sets IMPLEMENTED status. The issue transitions to DONE only after
+        the branch is merged to main via finalize_issue().
+        """
         issue = self._issues.get(issue_id)
         if not issue:
             return None
 
         issue.result = result
+        await self.update_issue_status(issue_id, IssueStatus.IMPLEMENTED, compute_id, trigger_cascade=False)
+
+        return issue
+
+    async def finalize_issue(
+        self,
+        issue_id: str,
+        compute_id: Optional[str] = None,
+        trigger_cascade: bool = True
+    ) -> Optional[Issue]:
+        """Mark an issue as done after merge to main.
+
+        Transitions IMPLEMENTED → DONE, triggers dependency cascade,
+        checks goal completion, and queues evaluation.
+        """
+        issue = self._issues.get(issue_id)
+        if not issue:
+            return None
+
+        if issue.status != IssueStatus.IMPLEMENTED:
+            logger.warning(
+                f"Cannot finalize issue {issue_id}: status is {issue.status.value}, expected implemented"
+            )
+            return None
+
         await self.update_issue_status(issue_id, IssueStatus.DONE, compute_id, trigger_cascade=trigger_cascade)
 
         if issue.goal_id and self._goal_service:

--- a/serving/services/work_map_service.py
+++ b/serving/services/work_map_service.py
@@ -1088,15 +1088,15 @@ class WorkMapService:
         compute_id: Optional[str] = None,
         trigger_cascade: bool = True
     ) -> Optional[WorkItem]:
-        """Mark work as completed with result.
+        """Mark work as implemented (code done, pending merge).
 
-        After completing the work item, if it has a parent issue_id,
-        auto-complete the parent Issue which triggers the dependency
-        cascade (unblocking dependent Issues from backlog → ready).
+        Sets WorkStatus.IMPLEMENTED and IssueStatus.IMPLEMENTED.
+        The work transitions to COMPLETED only after the branch is
+        merged to main via finalize_work().
 
-        Set trigger_cascade=False to suppress the dependency cascade,
-        allowing the caller to merge PRs before triggering it via
-        cascade_dependents().
+        The trigger_cascade parameter is preserved for API compatibility
+        but cascade never triggers at this stage — it triggers in
+        finalize_work() after merge.
         """
         work = await self._assignment_service.complete_work(
             work_id, result, compute_id, save_callback=self._save_to_redis
@@ -1105,7 +1105,45 @@ class WorkMapService:
             return None
 
         if work.issue_id:
-            await self._complete_parent_issue(work, trigger_cascade=trigger_cascade)
+            await self._complete_parent_issue(work, trigger_cascade=False)
+
+        return work
+
+    async def finalize_work(self, work_id: str) -> Optional[WorkItem]:
+        """Finalize work after branch merge to main.
+
+        Transitions WorkStatus.IMPLEMENTED → COMPLETED and
+        IssueStatus.IMPLEMENTED → DONE, then triggers dependency cascade.
+
+        Called by the auto-merge flow after successful merge.
+        """
+        work = self._work_items.get(work_id)
+        if not work:
+            return None
+
+        if work.status != WorkStatus.IMPLEMENTED:
+            logger.warning(
+                f"Cannot finalize work {work_id}: status is {work.status.value}, "
+                f"expected implemented"
+            )
+            return None
+
+        # Transition work to COMPLETED
+        await self._assignment_service.update_status(
+            work_id, WorkStatus.COMPLETED, save_callback=self._save_to_redis
+        )
+
+        # Check if this unblocks other work items
+        await self._assignment_service._check_unblock_dependents(work_id, self._save_to_redis)
+
+        # Finalize parent issue (IMPLEMENTED → DONE + cascade)
+        if work.issue_id:
+            await self._issue_service.finalize_issue(
+                work.issue_id, work.assigned_to, trigger_cascade=True
+            )
+            logger.info(
+                f"Finalized work {work_id} and issue {work.issue_id} after merge"
+            )
 
         return work
 
@@ -1131,20 +1169,18 @@ class WorkMapService:
 
         return await self._issue_service._check_unblock_issue_dependents(work.issue_id)
 
-    async def _complete_parent_issue(self, work: WorkItem, trigger_cascade: bool = True) -> None:
-        """Complete the parent Issue when its WorkItem finishes.
+    async def _complete_parent_issue(self, work: WorkItem, trigger_cascade: bool = False) -> None:
+        """Set the parent Issue to IMPLEMENTED when its WorkItem finishes.
 
-        Marks the parent Issue as DONE with the work result. When
-        trigger_cascade=True (default), also triggers
-        _check_unblock_issue_dependents to cascade and move dependent
-        Issues from backlog → ready.
+        Marks the parent Issue as IMPLEMENTED (code done, pending merge).
+        The issue transitions to DONE only after merge via finalize_work().
         """
         issue = await self._issue_service.get_issue(work.issue_id)
         if not issue:
             logger.warning(f"Parent issue {work.issue_id} not found for work {work.work_id}")
             return
 
-        if issue.status == IssueStatus.DONE:
+        if issue.status in (IssueStatus.IMPLEMENTED, IssueStatus.DONE):
             return
 
         issue_result = IssueResult(
@@ -1152,13 +1188,13 @@ class WorkMapService:
             branch=work.branch_name,
         )
 
-        completed = await self._issue_service.complete_issue(
-            work.issue_id, issue_result, work.assigned_to, trigger_cascade=trigger_cascade
+        implemented = await self._issue_service.complete_issue(
+            work.issue_id, issue_result, work.assigned_to, trigger_cascade=False
         )
-        if completed:
+        if implemented:
             logger.info(
-                f"Auto-completed issue {work.issue_id} from work {work.work_id} "
-                f"(cascade will unblock dependents)"
+                f"Issue {work.issue_id} marked as implemented from work {work.work_id} "
+                f"(pending merge to main)"
             )
 
     # ============ Blocker Operations (delegated to AssignmentService) ============

--- a/serving/services/work_orchestrator.py
+++ b/serving/services/work_orchestrator.py
@@ -322,13 +322,14 @@ class WorkOrchestrator:
                     issue_id = work.issue_id or (work.context.get("issue_id") if work.context else None)
                     if issue_id:
                         parent_issue = await work_map.get_issue(issue_id)
-                        if parent_issue and parent_issue.status == IssueStatus.DONE:
+                        if parent_issue and parent_issue.status in (IssueStatus.IMPLEMENTED, IssueStatus.DONE):
+                            target_status = WorkStatus.COMPLETED if parent_issue.status == IssueStatus.DONE else WorkStatus.IMPLEMENTED
                             await work_map.update_status(
-                                work.work_id, WorkStatus.COMPLETED
+                                work.work_id, target_status
                             )
                             logger.info(
-                                f"Completed orphan work {work.work_id}: "
-                                f"parent issue {issue_id} is already DONE"
+                                f"Synced orphan work {work.work_id} to {target_status.value}: "
+                                f"parent issue {issue_id} is {parent_issue.status.value}"
                             )
                             continue
 
@@ -443,14 +444,14 @@ class WorkOrchestrator:
                 if retry_after and now < retry_after:
                     continue
 
-                # Don't retry work whose parent issue is already DONE
+                # Don't retry work whose parent issue is already IMPLEMENTED or DONE
                 issue_id = work.issue_id or (work.context.get("issue_id") if work.context else None)
                 if issue_id:
                     parent_issue = await work_map.get_issue(issue_id)
-                    if parent_issue and parent_issue.status == IssueStatus.DONE:
+                    if parent_issue and parent_issue.status in (IssueStatus.IMPLEMENTED, IssueStatus.DONE):
                         logger.info(
                             f"Skipping retry for work {work.work_id}: "
-                            f"parent issue {issue_id} is already DONE"
+                            f"parent issue {issue_id} is {parent_issue.status.value}"
                         )
                         continue
 
@@ -712,17 +713,18 @@ class WorkOrchestrator:
                     )
                     continue
 
-                # Skip (and cancel) orphan work whose parent issue is already DONE
+                # Skip (and cancel) orphan work whose parent issue is already IMPLEMENTED or DONE
                 issue_id = work.issue_id or (work.context.get("issue_id") if work.context else None)
                 if issue_id:
                     parent_issue = await work_map.get_issue(issue_id)
-                    if parent_issue and parent_issue.status == IssueStatus.DONE:
+                    if parent_issue and parent_issue.status in (IssueStatus.IMPLEMENTED, IssueStatus.DONE):
+                        target_status = WorkStatus.COMPLETED if parent_issue.status == IssueStatus.DONE else WorkStatus.IMPLEMENTED
                         logger.info(
                             f"Cancelling orphan work {work.work_id}: "
-                            f"parent issue {issue_id} is already DONE"
+                            f"parent issue {issue_id} is {parent_issue.status.value}"
                         )
                         await work_map.update_status(
-                            work.work_id, WorkStatus.COMPLETED
+                            work.work_id, target_status
                         )
                         continue
 

--- a/serving/tests/unit/test_assignment_service.py
+++ b/serving/tests/unit/test_assignment_service.py
@@ -471,7 +471,7 @@ class TestProgressReporting:
         )
 
         assert result is not None
-        assert result.status == WorkStatus.COMPLETED
+        assert result.status == WorkStatus.IMPLEMENTED
         assert result.progress_percent == 100
         assert result.result == {"output": "success"}
 

--- a/serving/tests/unit/test_bucket_tree_execution.py
+++ b/serving/tests/unit/test_bucket_tree_execution.py
@@ -496,7 +496,9 @@ class TestProcessPendingWorkWithBucketTree:
             mock_work_map = MagicMock()
             mock_work_map.list_work = AsyncMock(return_value=MagicMock(items=[work1]))
             mock_work_map.get_ready_queue = AsyncMock(return_value=[])
+            mock_work_map.get_failed_work = AsyncMock(return_value=[])
             mock_work_map.get_dependencies_bulk = AsyncMock(return_value={"work-1": True})
+            mock_work_map.get_issue = AsyncMock(return_value=None)
             mock_get_wms.return_value = mock_work_map
 
             with patch.object(orchestrator, "_order_by_bucket_tree", new_callable=AsyncMock) as mock_order, \
@@ -521,7 +523,9 @@ class TestProcessPendingWorkWithBucketTree:
             mock_work_map = MagicMock()
             mock_work_map.list_work = AsyncMock(return_value=MagicMock(items=[work1]))
             mock_work_map.get_ready_queue = AsyncMock(return_value=[])
+            mock_work_map.get_failed_work = AsyncMock(return_value=[])
             mock_work_map.get_dependencies_bulk = AsyncMock(return_value={"work-1": True})
+            mock_work_map.get_issue = AsyncMock(return_value=None)
             mock_get_wms.return_value = mock_work_map
 
             with patch.object(orchestrator, "_order_by_bucket_tree", new_callable=AsyncMock) as mock_order, \
@@ -543,7 +547,9 @@ class TestProcessPendingWorkWithBucketTree:
             mock_work_map = MagicMock()
             mock_work_map.list_work = AsyncMock(return_value=MagicMock(items=[work1]))
             mock_work_map.get_ready_queue = AsyncMock(return_value=[])
+            mock_work_map.get_failed_work = AsyncMock(return_value=[])
             mock_work_map.get_dependencies_bulk = AsyncMock(return_value={"work-1": True})
+            mock_work_map.get_issue = AsyncMock(return_value=None)
             mock_get_wms.return_value = mock_work_map
 
             with patch.object(orchestrator, "_order_by_bucket_tree", new_callable=AsyncMock) as mock_order, \

--- a/serving/tests/unit/test_cascade_after_merge.py
+++ b/serving/tests/unit/test_cascade_after_merge.py
@@ -73,39 +73,40 @@ def dependent_issue(service, parent_issue):
 
 
 class TestCompleteWorkCascadeFlag:
-    """Test that trigger_cascade=False suppresses dependency cascade."""
+    """Test two-phase complete: complete_work() → IMPLEMENTED, finalize_work() → COMPLETED + cascade."""
 
     @pytest.mark.asyncio
-    async def test_complete_work_default_cascades(
+    async def test_complete_work_sets_implemented(
         self, service, sample_work, parent_issue, dependent_issue
     ):
-        """Default complete_work triggers cascade — dependent moves to READY."""
+        """complete_work() sets IMPLEMENTED — cascade deferred until finalize_work()."""
         work = await service.complete_work(
             work_id="work-1",
             result={"summary": "Done"},
             compute_id="compute-1",
         )
+        assert work is not None
+        assert work.status == WorkStatus.IMPLEMENTED
+        assert parent_issue.status == IssueStatus.IMPLEMENTED
+        # Cascade deferred — dependent still BACKLOG until finalize_work()
+        assert dependent_issue.status == IssueStatus.BACKLOG
+
+    @pytest.mark.asyncio
+    async def test_finalize_work_completes_and_cascades(
+        self, service, sample_work, parent_issue, dependent_issue
+    ):
+        """finalize_work() transitions IMPLEMENTED → COMPLETED and triggers cascade."""
+        await service.complete_work(
+            work_id="work-1",
+            result={"summary": "Done"},
+            compute_id="compute-1",
+        )
+        # After finalize (post-merge), cascade fires
+        work = await service.finalize_work("work-1")
         assert work is not None
         assert work.status == WorkStatus.COMPLETED
         assert parent_issue.status == IssueStatus.DONE
         assert dependent_issue.status == IssueStatus.READY
-
-    @pytest.mark.asyncio
-    async def test_complete_work_no_cascade(
-        self, service, sample_work, parent_issue, dependent_issue
-    ):
-        """complete_work(trigger_cascade=False) does NOT unblock dependents."""
-        work = await service.complete_work(
-            work_id="work-1",
-            result={"summary": "Done"},
-            compute_id="compute-1",
-            trigger_cascade=False,
-        )
-        assert work is not None
-        assert work.status == WorkStatus.COMPLETED
-        assert parent_issue.status == IssueStatus.DONE
-        # Dependent should still be BACKLOG — cascade was suppressed
-        assert dependent_issue.status == IssueStatus.BACKLOG
 
 
 class TestCascadeDependents:
@@ -115,35 +116,37 @@ class TestCascadeDependents:
     async def test_cascade_after_complete(
         self, service, sample_work, parent_issue, dependent_issue
     ):
-        """cascade_dependents() unblocks dependents when parent is DONE."""
-        # Complete without cascade
+        """cascade_dependents() unblocks dependents only after parent issue is DONE."""
+        # complete_work → IMPLEMENTED, cascade_dependents is a no-op (parent not DONE yet)
         await service.complete_work(
             work_id="work-1",
             result={"summary": "Done"},
             compute_id="compute-1",
-            trigger_cascade=False,
         )
         assert dependent_issue.status == IssueStatus.BACKLOG
 
-        # Now trigger cascade explicitly
+        # finalize_work transitions to COMPLETED + DONE, then cascade fires
+        await service.finalize_work("work-1")
+        assert parent_issue.status == IssueStatus.DONE
+
+        # Now cascade_dependents is a no-op (finalize already cascaded)
+        # but calling it explicitly should still work idempotently
         unblocked = await service.cascade_dependents("work-1")
-        assert "issue-2" in unblocked
+        # Already READY from finalize, so nothing new to unblock
+        assert "issue-2" not in unblocked
         assert dependent_issue.status == IssueStatus.READY
 
     @pytest.mark.asyncio
     async def test_cascade_idempotent(
         self, service, sample_work, parent_issue, dependent_issue
     ):
-        """Calling cascade_dependents() twice is safe (idempotent)."""
+        """Calling cascade_dependents() twice after finalize is safe (idempotent)."""
         await service.complete_work(
             work_id="work-1",
             result={"summary": "Done"},
             compute_id="compute-1",
-            trigger_cascade=False,
         )
-
-        unblocked1 = await service.cascade_dependents("work-1")
-        assert "issue-2" in unblocked1
+        await service.finalize_work("work-1")
         assert dependent_issue.status == IssueStatus.READY
 
         # Second call — already READY, nothing new to unblock
@@ -185,7 +188,7 @@ class TestHandleWorkStatusUpdateOrder:
 
     @pytest.mark.asyncio
     async def test_merge_before_cascade_order(self):
-        """Verify the order: complete_work → merge PR → cascade_dependents."""
+        """Verify the order: complete_work (→ IMPLEMENTED) → auto_merge (→ finalize_work → cascade)."""
         call_order = []
 
         mock_work = MagicMock(
@@ -201,10 +204,10 @@ class TestHandleWorkStatusUpdateOrder:
         mock_work_map.complete_work = AsyncMock(
             side_effect=lambda **kw: call_order.append("complete_work")
         )
-        mock_work_map.cascade_dependents = AsyncMock(
-            side_effect=lambda *a: call_order.append("cascade_dependents")
-        )
 
+        # cascade_dependents is now called inside finalize_work() which is
+        # invoked from _auto_create_and_merge_pr, not directly from
+        # _handle_work_status_update.
         mock_auto_merge = AsyncMock(
             side_effect=lambda *a, **kw: call_order.append("auto_merge")
         )
@@ -231,4 +234,6 @@ class TestHandleWorkStatusUpdateOrder:
 
             await _handle_work_status_update(event)
 
-        assert call_order == ["complete_work", "auto_merge", "cascade_dependents"]
+        # complete_work fires first (sets IMPLEMENTED), then auto_merge fires
+        # (which internally calls finalize_work → cascade_dependents).
+        assert call_order == ["complete_work", "auto_merge"]

--- a/serving/tests/unit/test_conflict_resolution_dispatch.py
+++ b/serving/tests/unit/test_conflict_resolution_dispatch.py
@@ -373,8 +373,8 @@ class TestConflictResolutionRemerge:
         mock_merge.assert_awaited_once_with(work, "f/issue_123/compute-001", "compute-001")
 
     @pytest.mark.asyncio
-    async def test_cascades_dependents_when_work_already_completed(self):
-        """After re-merge, cascade dependents if work was already in COMPLETED status."""
+    async def test_cascades_dependents_when_work_already_implemented(self):
+        """After re-merge, _auto_create_and_merge_pr handles cascade via finalize_work."""
         from api.compute import _handle_conflict_resolution_completed
         from models.work_map import WorkStatus
 
@@ -383,16 +383,18 @@ class TestConflictResolutionRemerge:
         work.work_id = "work_abc123"
         work.branch_name = "feat/my-branch"
         work.project_id = "proj-1"
-        work.status = WorkStatus.COMPLETED
+        work.status = WorkStatus.IMPLEMENTED
 
         mock_work_map = MagicMock()
         mock_work_map.get_work = AsyncMock(return_value=work)
-        mock_work_map.cascade_dependents = AsyncMock()
 
-        with patch("api.compute._auto_create_and_merge_pr", new_callable=AsyncMock):
+        mock_auto_merge = AsyncMock()
+        with patch("api.compute._auto_create_and_merge_pr", mock_auto_merge):
             await _handle_conflict_resolution_completed(event, mock_work_map)
 
-        mock_work_map.cascade_dependents.assert_awaited_once_with("work_abc123")
+        # _auto_create_and_merge_pr is called; it internally calls finalize_work()
+        # which handles cascade_dependents (no longer called directly).
+        mock_auto_merge.assert_awaited_once_with(work, "feat/my-branch", "compute-001")
 
     @pytest.mark.asyncio
     async def test_handle_work_status_routes_conflict_tasks(self):

--- a/serving/tests/unit/test_dependency_resolution.py
+++ b/serving/tests/unit/test_dependency_resolution.py
@@ -280,12 +280,13 @@ class TestCascadeUnlock:
         # B should start in BACKLOG
         assert issue_b.status == IssueStatus.BACKLOG
 
-        # Complete A
+        # Complete A and finalize (merge → DONE + cascade)
         await service.update_issue_status(issue_a.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(issue_a.issue_id, IssueResult(
             output="Done",
             success=True
         ))
+        await service._issue_service.finalize_issue(issue_a.issue_id)
 
         # B should now be READY
         updated_b = await service.get_issue(issue_b.issue_id)
@@ -313,23 +314,25 @@ class TestCascadeUnlock:
 
         assert issue_c.status == IssueStatus.BACKLOG
 
-        # Complete only A
+        # Complete and finalize only A
         await service.update_issue_status(issue_a.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(issue_a.issue_id, IssueResult(
             output="Done",
             success=True
         ))
+        await service._issue_service.finalize_issue(issue_a.issue_id)
 
         # C should still be BACKLOG (B not done yet)
         updated_c = await service.get_issue(issue_c.issue_id)
         assert updated_c.status == IssueStatus.BACKLOG
 
-        # Complete B
+        # Complete and finalize B
         await service.update_issue_status(issue_b.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(issue_b.issue_id, IssueResult(
             output="Done",
             success=True
         ))
+        await service._issue_service.finalize_issue(issue_b.issue_id)
 
         # Now C should be READY
         updated_c = await service.get_issue(issue_c.issue_id)
@@ -356,22 +359,24 @@ class TestCascadeUnlock:
         assert issue_b.status == IssueStatus.BACKLOG
         assert issue_c.status == IssueStatus.BACKLOG
 
-        # Complete A → B should become READY
+        # Complete A and finalize → B should become READY
         await service.update_issue_status(issue_a.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(issue_a.issue_id, IssueResult(
             output="Done", success=True
         ))
+        await service._issue_service.finalize_issue(issue_a.issue_id)
 
         updated_b = await service.get_issue(issue_b.issue_id)
         updated_c = await service.get_issue(issue_c.issue_id)
         assert updated_b.status == IssueStatus.READY
         assert updated_c.status == IssueStatus.BACKLOG  # Still waiting on B
 
-        # Complete B → C should become READY
+        # Complete B and finalize → C should become READY
         await service.update_issue_status(issue_b.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(issue_b.issue_id, IssueResult(
             output="Done", success=True
         ))
+        await service._issue_service.finalize_issue(issue_b.issue_id)
 
         updated_c = await service.get_issue(issue_c.issue_id)
         assert updated_c.status == IssueStatus.READY
@@ -419,13 +424,14 @@ class TestInitialStatusCalculation:
             description="Will be completed"
         ))
 
-        # Complete the dependency
+        # Complete and finalize the dependency (merge → DONE)
         await service.update_issue_status(dep.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(dep.issue_id, IssueResult(
             output="Done", success=True
         ))
+        await service._issue_service.finalize_issue(dep.issue_id)
 
-        # Create new issue depending on completed dep
+        # Create new issue depending on finalized (DONE) dep
         issue = await service.create_issue(IssueCreateRequest(
             title="Dependent Issue",
             description="Depends on completed",
@@ -507,9 +513,10 @@ class TestEdgeCases:
         assert c.status == IssueStatus.BACKLOG
         assert d.status == IssueStatus.BACKLOG
 
-        # Complete A → B and C should become READY
+        # Complete A and finalize → B and C should become READY
         await service.update_issue_status(a.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(a.issue_id, IssueResult(output="Done", success=True))
+        await service._issue_service.finalize_issue(a.issue_id)
 
         b = await service.get_issue(b.issue_id)
         c = await service.get_issue(c.issue_id)
@@ -519,16 +526,18 @@ class TestEdgeCases:
         assert c.status == IssueStatus.READY
         assert d.status == IssueStatus.BACKLOG  # Still waiting
 
-        # Complete B → D still waiting on C
+        # Complete B and finalize → D still waiting on C
         await service.update_issue_status(b.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(b.issue_id, IssueResult(output="Done", success=True))
+        await service._issue_service.finalize_issue(b.issue_id)
 
         d = await service.get_issue(d.issue_id)
         assert d.status == IssueStatus.BACKLOG
 
-        # Complete C → D should become READY
+        # Complete C and finalize → D should become READY
         await service.update_issue_status(c.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(c.issue_id, IssueResult(output="Done", success=True))
+        await service._issue_service.finalize_issue(c.issue_id)
 
         d = await service.get_issue(d.issue_id)
         assert d.status == IssueStatus.READY
@@ -619,14 +628,15 @@ class TestWorkItemIssueCompletionCascade:
         await service.assign_work(work.work_id, "compute-1", [])
         await service.update_status(work.work_id, "in_progress", "compute-1")
 
-        # Complete the work
+        # Complete the work and finalize (post-merge)
         await service.complete_work(
             work.work_id,
             result={"summary": "Done"},
             compute_id="compute-1"
         )
+        await service.finalize_work(work.work_id)
 
-        # Parent issue should now be DONE
+        # Parent issue should now be DONE (after finalize)
         updated_issue = await service.get_issue(issue.issue_id)
         assert updated_issue.status == IssueStatus.DONE
 
@@ -658,7 +668,7 @@ class TestWorkItemIssueCompletionCascade:
             project_id="test-project"
         ))
 
-        # Assign, start, and complete the work
+        # Assign, start, complete, and finalize the work (post-merge)
         await service.assign_work(work.work_id, "compute-1", [])
         await service.update_status(work.work_id, "in_progress", "compute-1")
         await service.complete_work(
@@ -666,8 +676,9 @@ class TestWorkItemIssueCompletionCascade:
             result={"summary": "Completed A"},
             compute_id="compute-1"
         )
+        await service.finalize_work(work.work_id)
 
-        # Issue A should be DONE
+        # Issue A should be DONE (after finalize)
         updated_a = await service.get_issue(issue_a.issue_id)
         assert updated_a.status == IssueStatus.DONE
 
@@ -685,7 +696,7 @@ class TestWorkItemIssueCompletionCascade:
             project_id="test-project"
         ))
 
-        # Assign, start, and complete
+        # Assign, start, and complete (sets IMPLEMENTED, pending merge)
         await service.assign_work(work.work_id, "compute-1", [])
         await service.update_status(work.work_id, "in_progress", "compute-1")
         completed = await service.complete_work(
@@ -694,9 +705,9 @@ class TestWorkItemIssueCompletionCascade:
             compute_id="compute-1"
         )
 
-        # Should complete without error
+        # Should complete without error (IMPLEMENTED, not yet COMPLETED)
         assert completed is not None
-        assert completed.status == WorkStatus.COMPLETED
+        assert completed.status == WorkStatus.IMPLEMENTED
 
     @pytest.mark.asyncio
     async def test_work_completion_cascade_and_logic(self, service):
@@ -726,12 +737,13 @@ class TestWorkItemIssueCompletionCascade:
         await service.assign_work(work_a.work_id, "compute-1", [])
         await service.update_status(work_a.work_id, "in_progress", "compute-1")
         await service.complete_work(work_a.work_id, result={"summary": "Done A"}, compute_id="compute-1")
+        await service.finalize_work(work_a.work_id)
 
         # C should still be BACKLOG (B not done)
         updated_c = await service.get_issue(issue_c.issue_id)
         assert updated_c.status == IssueStatus.BACKLOG
 
-        # Complete Issue B via work item
+        # Complete Issue B via work item and finalize
         await service.update_issue_status(issue_b.issue_id, IssueStatus.IN_PROGRESS)
         work_b = await service.create_work(WorkCreateRequest(
             title="Work B", description="Work for B",
@@ -740,6 +752,7 @@ class TestWorkItemIssueCompletionCascade:
         await service.assign_work(work_b.work_id, "compute-2", [])
         await service.update_status(work_b.work_id, "in_progress", "compute-2")
         await service.complete_work(work_b.work_id, result={"summary": "Done B"}, compute_id="compute-2")
+        await service.finalize_work(work_b.work_id)
 
         # Now C should be READY (all deps satisfied)
         updated_c = await service.get_issue(issue_c.issue_id)
@@ -781,9 +794,10 @@ class TestWorkItemIssueCompletionCascade:
             depends_on=[issue_a.issue_id]
         ))
 
-        # Complete A
+        # Complete A and finalize (merge → DONE + cascade)
         await service.update_issue_status(issue_a.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(issue_a.issue_id, IssueResult(summary="Done"))
+        await service._issue_service.finalize_issue(issue_a.issue_id)
 
         # B should be READY
         updated_b = await service.get_issue(issue_b.issue_id)

--- a/serving/tests/unit/test_implemented_status.py
+++ b/serving/tests/unit/test_implemented_status.py
@@ -1,0 +1,309 @@
+"""Tests for the IMPLEMENTED intermediate status (#267).
+
+Verifies the two-phase completion flow:
+  Phase 1: complete_work → IMPLEMENTED (code done, pending merge)
+  Phase 2: finalize_work → COMPLETED + DONE (branch merged to main)
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from models.work_map import (
+    WorkItem, WorkStatus, WorkPriority, Issue, IssueStatus,
+    IssuePriority, IssueResult
+)
+from services.assignment_service import AssignmentService
+from services.issue_ops_service import IssueOpsService
+from services.work_map_service import WorkMapService
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture
+def mock_redis():
+    redis = MagicMock()
+    redis._redis = AsyncMock()
+    redis._redis.srem = AsyncMock()
+    redis._redis.sadd = AsyncMock()
+    redis._redis.delete = AsyncMock()
+    redis._redis.set = AsyncMock()
+    redis._redis.get = AsyncMock(return_value=None)
+    return redis
+
+
+@pytest.fixture
+def assignment_service(mock_redis):
+    service = AssignmentService()
+    service._redis = mock_redis
+    return service
+
+
+@pytest.fixture
+def issue_ops_service(mock_redis):
+    service = IssueOpsService()
+    service._redis = mock_redis
+    return service
+
+
+def _make_work(work_id, status=WorkStatus.IN_PROGRESS, issue_id=None):
+    return WorkItem(
+        work_id=work_id,
+        title=f"Work {work_id}",
+        description="Test work item",
+        status=status,
+        priority=WorkPriority.NORMAL,
+        assigned_to="compute-001",
+        branch_name=f"feat/{work_id}",
+        issue_id=issue_id,
+        project_id="test-project",
+    )
+
+
+def _make_issue(issue_id, status=IssueStatus.IN_PROGRESS, goal_id=None):
+    return Issue(
+        issue_id=issue_id,
+        title=f"Issue {issue_id}",
+        description="Test issue",
+        status=status,
+        priority=IssuePriority.P1,
+        goal_id=goal_id,
+    )
+
+
+# =============================================================================
+# WorkStatus.IMPLEMENTED Tests
+# =============================================================================
+
+
+class TestWorkStatusImplemented:
+    """Test that complete_work sets IMPLEMENTED, not COMPLETED."""
+
+    @pytest.mark.asyncio
+    async def test_complete_work_sets_implemented(self, assignment_service):
+        work = _make_work("w1")
+        assignment_service.set_work_items_reference({"w1": work})
+
+        result = await assignment_service.complete_work(
+            "w1", {"summary": "done"}, "compute-001"
+        )
+
+        assert result.status == WorkStatus.IMPLEMENTED
+
+    @pytest.mark.asyncio
+    async def test_implemented_does_not_set_completed_at(self, assignment_service):
+        work = _make_work("w1")
+        assignment_service.set_work_items_reference({"w1": work})
+
+        result = await assignment_service.complete_work(
+            "w1", {"summary": "done"}, "compute-001"
+        )
+
+        assert result.completed_at is None
+
+    @pytest.mark.asyncio
+    async def test_implemented_to_completed_transition(self, assignment_service):
+        work = _make_work("w1", status=WorkStatus.IMPLEMENTED)
+        assignment_service.set_work_items_reference({"w1": work})
+
+        result = await assignment_service.update_status("w1", WorkStatus.COMPLETED)
+
+        assert result.status == WorkStatus.COMPLETED
+        assert result.completed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_implemented_to_in_progress_transition(self, assignment_service):
+        """IMPLEMENTED can go back to IN_PROGRESS (e.g., merge conflict requires rework)."""
+        work = _make_work("w1", status=WorkStatus.IMPLEMENTED)
+        assignment_service.set_work_items_reference({"w1": work})
+
+        result = await assignment_service.update_status("w1", WorkStatus.IN_PROGRESS)
+
+        assert result.status == WorkStatus.IN_PROGRESS
+
+    @pytest.mark.asyncio
+    async def test_implemented_is_idempotent(self, assignment_service):
+        work = _make_work("w1", status=WorkStatus.IMPLEMENTED)
+        assignment_service.set_work_items_reference({"w1": work})
+
+        result = await assignment_service.update_status("w1", WorkStatus.IMPLEMENTED)
+
+        assert result.status == WorkStatus.IMPLEMENTED
+
+    @pytest.mark.asyncio
+    async def test_implemented_cannot_go_to_failed(self, assignment_service):
+        """IMPLEMENTED cannot transition to FAILED (only IN_PROGRESS can)."""
+        work = _make_work("w1", status=WorkStatus.IMPLEMENTED)
+        assignment_service.set_work_items_reference({"w1": work})
+
+        result = await assignment_service.update_status("w1", WorkStatus.FAILED)
+
+        assert result is None  # invalid transition
+
+
+# =============================================================================
+# IssueStatus.IMPLEMENTED Tests
+# =============================================================================
+
+
+class TestIssueStatusImplemented:
+    """Test that complete_issue sets IMPLEMENTED, not DONE."""
+
+    @pytest.mark.asyncio
+    async def test_complete_issue_sets_implemented(self, issue_ops_service):
+        issue = _make_issue("i1")
+        issue_ops_service._issues = {"i1": issue}
+
+        result = await issue_ops_service.complete_issue(
+            "i1", IssueResult(summary="done", branch="feat/i1"), "compute-001"
+        )
+
+        assert result.status == IssueStatus.IMPLEMENTED
+
+    @pytest.mark.asyncio
+    async def test_finalize_issue_sets_done(self, issue_ops_service):
+        issue = _make_issue("i1", status=IssueStatus.IMPLEMENTED)
+        issue.result = IssueResult(summary="done", branch="feat/i1")
+        issue_ops_service._issues = {"i1": issue}
+
+        result = await issue_ops_service.finalize_issue("i1", "compute-001")
+
+        assert result.status == IssueStatus.DONE
+        assert result.completed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_finalize_requires_implemented_status(self, issue_ops_service):
+        issue = _make_issue("i1", status=IssueStatus.IN_PROGRESS)
+        issue_ops_service._issues = {"i1": issue}
+
+        result = await issue_ops_service.finalize_issue("i1")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_valid_transitions_include_implemented(self, issue_ops_service):
+        transitions = issue_ops_service.VALID_TRANSITIONS
+
+        # IN_PROGRESS → IMPLEMENTED
+        assert IssueStatus.IMPLEMENTED in transitions[IssueStatus.IN_PROGRESS]
+        # IMPLEMENTED → DONE
+        assert IssueStatus.DONE in transitions[IssueStatus.IMPLEMENTED]
+        # IMPLEMENTED → IN_PROGRESS (rework)
+        assert IssueStatus.IN_PROGRESS in transitions[IssueStatus.IMPLEMENTED]
+        # IN_PROGRESS should NOT go directly to DONE
+        assert IssueStatus.DONE not in transitions[IssueStatus.IN_PROGRESS]
+
+    @pytest.mark.asyncio
+    async def test_cascade_only_triggers_on_done(self, issue_ops_service):
+        """Dependency cascade should NOT trigger on IMPLEMENTED."""
+        dep = _make_issue("dep1", status=IssueStatus.IN_PROGRESS)
+        blocker = _make_issue("blocker1", status=IssueStatus.IN_PROGRESS)
+        dep.depends_on = ["blocker1"]
+        blocker.blocks = ["dep1"]
+        issue_ops_service._issues = {"dep1": dep, "blocker1": blocker}
+
+        # complete_issue → IMPLEMENTED: should NOT unblock dep1
+        await issue_ops_service.complete_issue(
+            "blocker1", IssueResult(summary="done", branch="b")
+        )
+        assert dep.status == IssueStatus.IN_PROGRESS  # not yet READY
+
+        # finalize_issue → DONE: should unblock dep1
+        # (need to set up for cascade by making dep1 BACKLOG)
+        dep.status = IssueStatus.BACKLOG
+        await issue_ops_service.finalize_issue("blocker1", trigger_cascade=True)
+        assert dep.status == IssueStatus.READY
+
+
+# =============================================================================
+# Two-Phase Completion Flow Tests
+# =============================================================================
+
+
+class TestTwoPhaseCompletion:
+    """Test the full complete_work → finalize_work flow."""
+
+    @pytest.fixture
+    def work_map_service(self, mock_redis):
+        service = WorkMapService.__new__(WorkMapService)
+        service._assignment_service = AssignmentService()
+        service._assignment_service._redis = mock_redis
+        service._issue_service = IssueOpsService()
+        service._issue_service._redis = mock_redis
+        service._redis = mock_redis
+        # Share the same work_items dict between service and assignment_service
+        work_items = {}
+        service._work_items = work_items
+        service._assignment_service._work_items = work_items
+        return service
+
+    @pytest.mark.asyncio
+    async def test_complete_then_finalize(self, work_map_service):
+        issue = _make_issue("i1")
+        work = _make_work("w1", issue_id="i1")
+        work_map_service._work_items["w1"] = work
+        work_map_service._issue_service._issues = {"i1": issue}
+
+        # Phase 1: complete_work
+        result = await work_map_service.complete_work(
+            "w1", {"summary": "done"}, "compute-001"
+        )
+        assert result.status == WorkStatus.IMPLEMENTED
+        assert issue.status == IssueStatus.IMPLEMENTED
+
+        # Phase 2: finalize_work (after merge)
+        finalized = await work_map_service.finalize_work("w1")
+        assert finalized.status == WorkStatus.COMPLETED
+        assert issue.status == IssueStatus.DONE
+
+    @pytest.mark.asyncio
+    async def test_finalize_rejects_non_implemented(self, work_map_service):
+        work = _make_work("w1", status=WorkStatus.IN_PROGRESS)
+        work_map_service._work_items["w1"] = work
+
+        result = await work_map_service.finalize_work("w1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_finalize_triggers_cascade(self, work_map_service):
+        """finalize_work should trigger dependency cascade."""
+        blocker_issue = _make_issue("blocker", status=IssueStatus.IN_PROGRESS)
+        dependent_issue = _make_issue("dep", status=IssueStatus.BACKLOG)
+        dependent_issue.depends_on = ["blocker"]
+        blocker_issue.blocks = ["dep"]
+
+        blocker_work = _make_work("w1", issue_id="blocker")
+
+        work_map_service._work_items["w1"] = blocker_work
+        work_map_service._issue_service._issues = {
+            "blocker": blocker_issue,
+            "dep": dependent_issue,
+        }
+
+        # Phase 1
+        await work_map_service.complete_work("w1", {"summary": "done"}, "compute-001")
+        assert dependent_issue.status == IssueStatus.BACKLOG  # NOT unblocked yet
+
+        # Phase 2
+        await work_map_service.finalize_work("w1")
+        assert dependent_issue.status == IssueStatus.READY  # NOW unblocked
+
+
+# =============================================================================
+# MCP Status Mapping Tests
+# =============================================================================
+
+
+class TestMCPStatusMapping:
+    def test_task_completed_maps_to_implemented(self):
+        from mcp.models import TaskStatus
+        from mcp.tools.progress import STATUS_MAP
+
+        assert STATUS_MAP[TaskStatus.COMPLETED] == WorkStatus.IMPLEMENTED
+
+    def test_task_implemented_maps_to_implemented(self):
+        from mcp.models import TaskStatus
+        from mcp.tools.progress import STATUS_MAP
+
+        assert STATUS_MAP[TaskStatus.IMPLEMENTED] == WorkStatus.IMPLEMENTED

--- a/serving/tests/unit/test_issue_work_bridge.py
+++ b/serving/tests/unit/test_issue_work_bridge.py
@@ -527,10 +527,10 @@ class TestCompleteWorkIssueUpdate:
             )
 
         assert result is not None
-        assert result.status == WorkStatus.COMPLETED
+        assert result.status == WorkStatus.IMPLEMENTED
 
-        # Verify issue was updated
-        assert issue.status == IssueStatus.DONE
+        # Verify issue was updated to IMPLEMENTED (pending merge, not yet DONE)
+        assert issue.status == IssueStatus.IMPLEMENTED
         assert issue.result is not None
         assert issue.result.summary == "Done"
 
@@ -560,7 +560,7 @@ class TestCompleteWorkIssueUpdate:
             )
 
         assert result is not None
-        assert result.status == WorkStatus.COMPLETED
+        assert result.status == WorkStatus.IMPLEMENTED
 
     @pytest.mark.asyncio
     async def test_complete_work_triggers_dependency_cascade(self, work_map_service):
@@ -608,8 +608,10 @@ class TestCompleteWorkIssueUpdate:
                 {"branch": "work/a", "summary": "Done"},
                 "compute-1"
             )
+            # Simulate post-merge finalize: IMPLEMENTED → COMPLETED + DONE + cascade
+            await service.finalize_work("work_a")
 
-        # issue_a should be DONE
+        # issue_a should be DONE (after finalize)
         assert issue_a.status == IssueStatus.DONE
 
         # issue_b should have been unblocked (moved from BACKLOG to READY)

--- a/serving/tests/unit/test_mcp_complete_task.py
+++ b/serving/tests/unit/test_mcp_complete_task.py
@@ -69,7 +69,7 @@ class TestCompleteTaskConflictDetection:
                 assert result is not None
                 assert result.merge_status == MergeStatus.QUEUED
                 assert result.task_id == "work-123"
-                assert result.status == "completed"
+                assert result.status == "implemented"
 
                 # Verify dry-run merge was called
                 mock_pr_service.dry_run_merge.assert_called_once_with(

--- a/serving/tests/unit/test_mcp_progress.py
+++ b/serving/tests/unit/test_mcp_progress.py
@@ -186,7 +186,7 @@ class TestReportProgressTool:
 
         call_args = mock_work_map_service.report_progress.call_args[0]
         report = call_args[1]
-        assert report.status == WorkStatus.COMPLETED
+        assert report.status == WorkStatus.IMPLEMENTED
 
     @pytest.mark.asyncio
     @patch("mcp.tools.progress.get_work_map_service")
@@ -306,9 +306,9 @@ class TestStatusMapping:
         """Test REVIEW_REQUESTED maps to REVIEW."""
         assert STATUS_MAP[TaskStatus.REVIEW_REQUESTED] == WorkStatus.REVIEW
 
-    def test_completed_maps_to_completed(self):
-        """Test COMPLETED maps to COMPLETED."""
-        assert STATUS_MAP[TaskStatus.COMPLETED] == WorkStatus.COMPLETED
+    def test_completed_maps_to_implemented(self):
+        """Test COMPLETED maps to IMPLEMENTED (pending merge)."""
+        assert STATUS_MAP[TaskStatus.COMPLETED] == WorkStatus.IMPLEMENTED
 
 
 class TestReportProgressInputModel:

--- a/serving/tests/unit/test_multi_compute_coordination.py
+++ b/serving/tests/unit/test_multi_compute_coordination.py
@@ -897,7 +897,7 @@ class TestFailureScenarios:
 
     @pytest.mark.asyncio
     async def test_completion_cascade_unblocks_dependents(self):
-        """Completing work triggers dependency cascade for blocked items."""
+        """Completing work sets IMPLEMENTED; cascade (blocker resolution) deferred to finalize."""
         service = AssignmentService()
 
         dep = _make_work_item("dep-1", status=WorkStatus.IN_PROGRESS, assigned_to="compute-001")
@@ -920,8 +920,12 @@ class TestFailureScenarios:
             "dep-1", result={"output": "done"}, compute_id="compute-001",
         )
 
-        assert work_items["dep-1"].status == WorkStatus.COMPLETED
-        # Blocker should be resolved
+        assert work_items["dep-1"].status == WorkStatus.IMPLEMENTED
+        # Blocker not yet resolved — cascade is deferred until finalize_work()
+        assert not work_items["work-1"].blockers[0].is_resolved
+
+        # Simulate finalize (post-merge): cascade resolves blockers
+        await service._check_unblock_dependents("dep-1")
         assert work_items["work-1"].blockers[0].is_resolved
 
     @pytest.mark.asyncio

--- a/serving/tests/unit/test_work_map_service.py
+++ b/serving/tests/unit/test_work_map_service.py
@@ -301,10 +301,11 @@ class TestWorkMapServiceAssignment:
         )
         work = await service.create_work(request)
 
-        # Complete dependency
+        # Complete dependency and finalize (merge → COMPLETED)
         await service.assign_work(dep_work.work_id, "compute-001", [])
         await service.update_status(dep_work.work_id, WorkStatus.IN_PROGRESS, "compute-001")
         await service.complete_work(dep_work.work_id, {"done": True}, "compute-001")
+        await service.finalize_work(dep_work.work_id)
 
         # Now should be able to assign
         assignment = await service.assign_work(
@@ -421,7 +422,12 @@ class TestWorkMapServiceStatus:
         assert result.status == WorkStatus.IN_PROGRESS
         assert result.started_at is not None
 
-        # IN_PROGRESS -> COMPLETED
+        # IN_PROGRESS -> IMPLEMENTED (code done, pending merge)
+        result = await service.update_status(work.work_id, WorkStatus.IMPLEMENTED, "compute-001")
+        assert result is not None
+        assert result.status == WorkStatus.IMPLEMENTED
+
+        # IMPLEMENTED -> COMPLETED (after merge — sets completed_at)
         result = await service.update_status(work.work_id, WorkStatus.COMPLETED, "compute-001")
         assert result is not None
         assert result.status == WorkStatus.COMPLETED
@@ -464,7 +470,7 @@ class TestWorkMapServiceStatus:
         )
 
         assert result is not None
-        assert result.status == WorkStatus.COMPLETED
+        assert result.status == WorkStatus.IMPLEMENTED
         assert result.result == {"output": "success", "data": [1, 2, 3]}
         assert result.progress_percent == 100
 
@@ -773,10 +779,11 @@ class TestWorkMapServiceDependencies:
         deps = await service.get_dependencies(work.work_id)
         assert deps["all_dependencies_met"] is False
 
-        # Complete dependency
+        # Complete dependency and finalize (merge → COMPLETED)
         await service.assign_work(dep_work.work_id, "compute-001", [])
         await service.update_status(dep_work.work_id, WorkStatus.IN_PROGRESS, "compute-001")
         await service.complete_work(dep_work.work_id, {}, "compute-001")
+        await service.finalize_work(dep_work.work_id)
 
         # Now should be met
         deps = await service.get_dependencies(work.work_id)

--- a/serving/tests/unit/test_work_orchestrator.py
+++ b/serving/tests/unit/test_work_orchestrator.py
@@ -391,6 +391,8 @@ class TestOrchestratorStaleWorkDetection:
         mock_stale.work_id = "work_orphan"
         mock_stale.assigned_to = "compute-001"
         mock_stale.assigned_at = "2026-01-01T00:00:00Z"
+        mock_stale.issue_id = None
+        mock_stale.context = None
 
         with patch("services.work_map_service.get_work_map_service") as mock_get_service:
             mock_service = MagicMock()
@@ -512,6 +514,7 @@ class TestOrchestratorSSEWorkAssignment:
     async def test_spawn_for_work_uses_sse_first(self, orchestrator, mock_work):
         """Test that _spawn_for_work tries SSE assignment first."""
         with patch.object(orchestrator, "_select_skills_for_work", return_value=["code-writer"]) as mock_select, \
+             patch.object(orchestrator, "_resolve_model_for_skills", new_callable=AsyncMock, return_value=None), \
              patch.object(orchestrator, "_try_assign_via_sse", new_callable=AsyncMock) as mock_sse, \
              patch.object(orchestrator, "_spawn_new_compute", new_callable=AsyncMock) as mock_spawn:
 
@@ -527,6 +530,7 @@ class TestOrchestratorSSEWorkAssignment:
     async def test_spawn_for_work_falls_back_to_spawning(self, orchestrator, mock_work):
         """Test that _spawn_for_work falls back to direct spawning."""
         with patch.object(orchestrator, "_select_skills_for_work", return_value=["code-writer"]) as mock_select, \
+             patch.object(orchestrator, "_resolve_model_for_skills", new_callable=AsyncMock, return_value=None), \
              patch.object(orchestrator, "_try_assign_via_sse", new_callable=AsyncMock) as mock_sse, \
              patch.object(orchestrator, "_spawn_new_compute", new_callable=AsyncMock) as mock_spawn:
 
@@ -841,6 +845,8 @@ class TestOrchestratorBatchDependencyCheck:
         work1.skill_ids = ["code-writer"]
         work1.required_skills = []
         work1.work_type = "feature"
+        work1.issue_id = None
+        work1.context = None
 
         work2 = MagicMock()
         work2.work_id = "work-2"
@@ -849,6 +855,8 @@ class TestOrchestratorBatchDependencyCheck:
         work2.skill_ids = ["debugger"]
         work2.required_skills = []
         work2.work_type = "bug"
+        work2.issue_id = None
+        work2.context = None
 
         with patch("services.work_map_service.get_work_map_service") as mock_get_wms:
             mock_work_map = MagicMock()
@@ -856,6 +864,7 @@ class TestOrchestratorBatchDependencyCheck:
                 items=[work1, work2]
             ))
             mock_work_map.get_ready_queue = AsyncMock(return_value=[])
+            mock_work_map.get_failed_work = AsyncMock(return_value=[])
             # Batch dependency check
             mock_work_map.get_dependencies_bulk = AsyncMock(return_value={
                 "work-1": True,
@@ -1457,6 +1466,8 @@ class TestSpawnFailureSingleIncrement:
         mock_work.priority = WorkPriority.NORMAL
         mock_work.created_at = datetime.now()
         mock_work.project_id = "project-1"
+        mock_work.issue_id = None
+        mock_work.context = None
 
         with patch("services.work_map_service.get_work_map_service") as mock_get_wms:
             mock_work_map = MagicMock()
@@ -1528,6 +1539,8 @@ class TestRetryFailedWork:
         failed_item.work_id = "work_failed1"
         failed_item.retry_count = 0
         failed_item.status = WorkStatus.FAILED
+        failed_item.issue_id = None
+        failed_item.context = None
 
         updated_item = MagicMock()
         updated_item.work_id = "work_failed1"
@@ -1593,6 +1606,8 @@ class TestRetryFailedWork:
         failed_item.work_id = "work_delay"
         failed_item.retry_count = 0
         failed_item.status = WorkStatus.FAILED
+        failed_item.issue_id = None
+        failed_item.context = None
 
         updated_item = MagicMock()
         updated_item.work_id = "work_delay"
@@ -1671,6 +1686,8 @@ class TestRetryFailedWork:
         failed_item.work_id = work_id
         failed_item.retry_count = 0
         failed_item.status = WorkStatus.FAILED
+        failed_item.issue_id = None
+        failed_item.context = None
 
         updated_item = MagicMock()
         updated_item.work_id = work_id
@@ -1697,6 +1714,8 @@ class TestRetryFailedWork:
         pending_item.created_at = datetime.now()
         pending_item.skill_ids = ["code-writer"]
         pending_item.required_skills = []
+        pending_item.issue_id = None
+        pending_item.context = None
         pending_item.work_type = "feature"
 
         with patch("services.work_map_service.get_work_map_service") as mock_get_wms:
@@ -1733,11 +1752,15 @@ class TestRetryFailedWork:
         failed1.work_id = "work_f1"
         failed1.retry_count = 0
         failed1.status = WorkStatus.FAILED
+        failed1.issue_id = None
+        failed1.context = None
 
         failed2 = MagicMock()
         failed2.work_id = "work_f2"
         failed2.retry_count = 1
         failed2.status = WorkStatus.FAILED
+        failed2.issue_id = None
+        failed2.context = None
 
         updated1 = MagicMock()
         updated1.work_id = "work_f1"
@@ -2009,6 +2032,8 @@ class TestFailedNodeRotation:
         mock_work.required_skills = []
         mock_work.work_type = "feature"
         mock_work.project_id = "project-1"
+        mock_work.issue_id = None
+        mock_work.context = None
 
         # Mock multiple compute instances so exclusion logic activates
         mock_sse_manager = MagicMock()
@@ -2018,6 +2043,7 @@ class TestFailedNodeRotation:
         ]
 
         with patch.object(orchestrator, "_select_skills_for_work", return_value=["code-writer"]), \
+             patch.object(orchestrator, "_resolve_model_for_skills", new_callable=AsyncMock, return_value=None), \
              patch.object(orchestrator, "_try_assign_via_sse", new_callable=AsyncMock, return_value=True) as mock_sse, \
              patch("services.sse_connection_manager.get_sse_connection_manager", return_value=mock_sse_manager):
             await orchestrator._spawn_for_work(mock_work)
@@ -2040,6 +2066,8 @@ class TestFailedNodeRotation:
         mock_work.required_skills = []
         mock_work.work_type = "feature"
         mock_work.project_id = "project-1"
+        mock_work.issue_id = None
+        mock_work.context = None
 
         # Mock single compute instance - exclusion should be skipped
         mock_sse_manager = MagicMock()
@@ -2048,6 +2076,7 @@ class TestFailedNodeRotation:
         ]
 
         with patch.object(orchestrator, "_select_skills_for_work", return_value=["code-writer"]), \
+             patch.object(orchestrator, "_resolve_model_for_skills", new_callable=AsyncMock, return_value=None), \
              patch.object(orchestrator, "_try_assign_via_sse", new_callable=AsyncMock, return_value=True) as mock_sse, \
              patch("services.sse_connection_manager.get_sse_connection_manager", return_value=mock_sse_manager):
             await orchestrator._spawn_for_work(mock_work)
@@ -2070,6 +2099,8 @@ class TestFailedNodeRotation:
         failed_item1.retry_count = 0
         failed_item1.status = WorkStatus.FAILED
         failed_item1.assigned_to = "compute-001"
+        failed_item1.issue_id = None
+        failed_item1.context = None
 
         updated1 = MagicMock()
         updated1.work_id = work_id
@@ -2095,6 +2126,8 @@ class TestFailedNodeRotation:
         failed_item2.retry_count = 1
         failed_item2.status = WorkStatus.FAILED
         failed_item2.assigned_to = "compute-002"
+        failed_item2.issue_id = None
+        failed_item2.context = None
 
         updated2 = MagicMock()
         updated2.work_id = work_id
@@ -2128,6 +2161,8 @@ class TestFailedNodeRotation:
         failed_item.retry_count = 2
         failed_item.status = WorkStatus.FAILED
         failed_item.assigned_to = "compute-003"
+        failed_item.issue_id = None
+        failed_item.context = None
 
         # Retries exhausted — stays FAILED
         still_failed = MagicMock()
@@ -2267,11 +2302,14 @@ class TestCharacterizationGate:
         work.required_skills = []
         work.work_type = "feature"
         work.tags = []
+        work.issue_id = None
+        work.context = None
 
         with patch("services.work_map_service.get_work_map_service") as mock_get_wms:
             mock_work_map = MagicMock()
             mock_work_map.list_work = AsyncMock(return_value=MagicMock(items=[work]))
             mock_work_map.get_ready_queue = AsyncMock(return_value=[])
+            mock_work_map.get_failed_work = AsyncMock(return_value=[])
             mock_work_map.get_dependencies_bulk = AsyncMock(return_value={"work-1": True})
             mock_get_wms.return_value = mock_work_map
 
@@ -2300,6 +2338,8 @@ class TestCharacterizationGate:
         work_gated.skill_ids = []
         work_gated.required_skills = []
         work_gated.work_type = "feature"
+        work_gated.issue_id = None
+        work_gated.context = None
 
         work_ready = MagicMock()
         work_ready.work_id = "work-ready"
@@ -2310,6 +2350,8 @@ class TestCharacterizationGate:
         work_ready.required_skills = []
         work_ready.work_type = "feature"
         work_ready.tags = []
+        work_ready.issue_id = None
+        work_ready.context = None
 
         with patch("services.work_map_service.get_work_map_service") as mock_get_wms:
             mock_work_map = MagicMock()
@@ -2317,6 +2359,7 @@ class TestCharacterizationGate:
                 return_value=MagicMock(items=[work_gated, work_ready])
             )
             mock_work_map.get_ready_queue = AsyncMock(return_value=[])
+            mock_work_map.get_failed_work = AsyncMock(return_value=[])
             mock_work_map.get_dependencies_bulk = AsyncMock(return_value={
                 "work-gated": True,
                 "work-ready": True,

--- a/serving/tests/unit/test_workmap_goals_issues.py
+++ b/serving/tests/unit/test_workmap_goals_issues.py
@@ -272,7 +272,13 @@ class TestIssueStatusFlow:
         assert updated.status == IssueStatus.IN_PROGRESS
         assert updated.started_at is not None
 
-        # in_progress → done
+        # in_progress → implemented (code done, pending merge)
+        updated = await service.update_issue_status(
+            issue.issue_id, IssueStatus.IMPLEMENTED
+        )
+        assert updated.status == IssueStatus.IMPLEMENTED
+
+        # implemented → done (after merge — sets completed_at)
         updated = await service.update_issue_status(
             issue.issue_id, IssueStatus.DONE
         )
@@ -328,7 +334,7 @@ class TestIssueStatusFlow:
             issue.issue_id, result
         )
 
-        assert completed.status == IssueStatus.DONE
+        assert completed.status == IssueStatus.IMPLEMENTED
         assert completed.result is not None
         assert completed.result.branch == "feat/issue-123"
         assert len(completed.result.commits) == 2
@@ -371,9 +377,10 @@ class TestDependencyResolution:
 
         assert dependent.status == IssueStatus.BACKLOG
 
-        # Complete the dependency
+        # Complete the dependency and finalize (merge → DONE + cascade)
         await service.update_issue_status(dep.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(dep.issue_id, IssueResult())
+        await service._issue_service.finalize_issue(dep.issue_id)
 
         # Check dependent is now ready
         dependent = await service.get_issue(dependent.issue_id)
@@ -397,17 +404,19 @@ class TestDependencyResolution:
             depends_on=[dep1.issue_id, dep2.issue_id]
         ))
 
-        # Complete first dep
+        # Complete and finalize first dep
         await service.update_issue_status(dep1.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(dep1.issue_id, IssueResult())
+        await service._issue_service.finalize_issue(dep1.issue_id)
 
-        # Dependent should still be backlog
+        # Dependent should still be backlog (dep2 not done)
         dependent = await service.get_issue(dependent.issue_id)
         assert dependent.status == IssueStatus.BACKLOG
 
-        # Complete second dep
+        # Complete and finalize second dep
         await service.update_issue_status(dep2.issue_id, IssueStatus.IN_PROGRESS)
         await service.complete_issue(dep2.issue_id, IssueResult())
+        await service._issue_service.finalize_issue(dep2.issue_id)
 
         # Now dependent should be ready
         dependent = await service.get_issue(dependent.issue_id)
@@ -628,11 +637,12 @@ class TestGoalCompletion:
         )
         response = await service.create_issues_batch(request)
 
-        # Complete all issues
+        # Complete and finalize all issues (finalize triggers goal completion check)
         for item in response.created_issues:
             issue_id = item["id"]
             await service.update_issue_status(issue_id, IssueStatus.IN_PROGRESS)
             await service.complete_issue(issue_id, IssueResult())
+            await service._issue_service.finalize_issue(issue_id)
 
         # Check goal is done
         goal = await service.get_goal(goal.goal_id)


### PR DESCRIPTION
## Summary
- Adds `IMPLEMENTED` intermediate status to `WorkStatus` and `IssueStatus` enums to distinguish "code done, pending merge" from "code merged to main"
- Two-phase completion: `complete_work()` → IMPLEMENTED, then `finalize_work()` → COMPLETED/DONE after merge succeeds
- Dependency cascade only triggers on DONE/COMPLETED (post-merge), preventing premature unblocking
- Frontend displays IMPLEMENTED as amber/warning badge with "Pending Merge" column in plan view

## Changes

### Backend (serving/)
- `models/work_map.py`: Add `IMPLEMENTED` to `WorkStatus` and `IssueStatus` enums
- `mcp/models.py`: Add `IMPLEMENTED` to `TaskStatus` enum
- `mcp/tools/complete.py`: Return "implemented" status instead of "completed"
- `mcp/tools/progress.py`: Map `TaskStatus.COMPLETED` → `WorkStatus.IMPLEMENTED`
- `services/assignment_service.py`: `complete_work()` sets IMPLEMENTED; updated valid transitions
- `services/issue_ops_service.py`: `complete_issue()` sets IMPLEMENTED; new `finalize_issue()` for DONE
- `services/work_map_service.py`: New `finalize_work()` method; cascade deferred to post-merge
- `services/work_orchestrator.py`: Handle IMPLEMENTED in orphan detection and retry logic
- `api/compute.py`: Call `finalize_work()` after successful merge in auto-merge flow
- `api/plan_summary.py`: Add `implemented_count` and `implemented_items` to plan summary

### Frontend (serving/frontend/)
- `Badge.jsx`: IMPLEMENTED renders as warning (amber), DONE as success (green)
- `IssueDetailModal.jsx`: New status option with valid transitions
- `WorkMapGraph.jsx/css`: Amber color for implemented nodes
- `IssueDependencyGraph.jsx`: Amber color for implemented nodes
- `DependencyGraphView.jsx`: Implemented status in directive aggregation
- `ActiveWorkView.jsx`: "Pending Merge" column for implemented items
- `Plan.css`: Implemented chip styling
- `useRecentActivity.js`: "implemented — pending merge" label

## Testing
- [x] 16 new unit tests for IMPLEMENTED status (`test_implemented_status.py`)
- [x] All existing unit tests updated and passing (354+ affected tests)
- [x] Full unit test suite green (excluding pre-existing failures)

## Follow-up
- [ ] Create issue for Tier 2 integration tests

## Issues
Closes #267