### PR TITLE
fix: Revert on conflict-resolution merge failure and harden revert path

### DIFF
--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -1124,8 +1124,17 @@ async def _handle_conflict_resolution_completed(event, work_map) -> None:
     # Re-trigger the PR merge pipeline with the original work item
     # finalize_work() inside _auto_create_and_merge_pr handles cascade
     branch_name = event.branch_name or work.branch_name
+    merge_ok = False
     if branch_name and work.project_id:
         merge_ok = await _auto_create_and_merge_pr(work, branch_name, event.compute_id)
+
+    if not merge_ok and branch_name and work.project_id:
+        # Merge or quality gates failed after conflict resolution — revert
+        logger.warning(
+            f"Reverting work {original_work_id} to IN_PROGRESS — "
+            f"PR merge did not succeed after conflict resolution"
+        )
+        await work_map.revert_completed_work(original_work_id)
 
 
 async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> bool:

--- a/serving/services/work_map_service.py
+++ b/serving/services/work_map_service.py
@@ -1183,8 +1183,8 @@ class WorkMapService:
             return False
 
         prev_status = work.status
-        # Revert work item to IN_PROGRESS
-        work.status = WorkStatus.IN_PROGRESS
+        # Revert work item to IN_PROGRESS via assignment service
+        await self._assignment_service.update_status(work_id, WorkStatus.IN_PROGRESS)
         work.result = None
         await self._save_to_redis(work)
         logger.info(f"Reverted work {work_id} from {prev_status.value} to IN_PROGRESS")
@@ -1193,24 +1193,27 @@ class WorkMapService:
         if work.issue_id:
             issue = await self._issue_service.get_issue(work.issue_id)
             if issue and issue.status in (IssueStatus.IMPLEMENTED, IssueStatus.DONE):
+                orig_status = issue.status
                 reason = "PR merge or quality gates failed — reverting to retry"
-                # Walk through valid transitions back to IN_PROGRESS
                 if issue.status == IssueStatus.DONE:
+                    # DONE → BACKLOG (auto-promotion may move to READY)
                     await self._issue_service.update_issue_status(
                         work.issue_id, IssueStatus.BACKLOG, reason=reason, trigger_cascade=False
                     )
-                    await self._issue_service.update_issue_status(
-                        work.issue_id, IssueStatus.READY, trigger_cascade=False
-                    )
+                    # Re-read: auto-promotion may have moved to READY already
+                    issue = await self._issue_service.get_issue(work.issue_id)
+                    if issue and issue.status == IssueStatus.BACKLOG:
+                        await self._issue_service.update_issue_status(
+                            work.issue_id, IssueStatus.READY, trigger_cascade=False
+                        )
+                if issue:
+                    issue = await self._issue_service.get_issue(work.issue_id)
+                if issue and issue.status != IssueStatus.IN_PROGRESS:
                     await self._issue_service.update_issue_status(
                         work.issue_id, IssueStatus.IN_PROGRESS, trigger_cascade=False
                     )
-                elif issue.status == IssueStatus.IMPLEMENTED:
-                    await self._issue_service.update_issue_status(
-                        work.issue_id, IssueStatus.IN_PROGRESS, reason=reason, trigger_cascade=False
-                    )
                 logger.info(
-                    f"Reverted issue {work.issue_id} from {issue.status.value} to IN_PROGRESS "
+                    f"Reverted issue {work.issue_id} from {orig_status.value} to IN_PROGRESS "
                     f"(work {work_id} merge failed)"
                 )
 

--- a/serving/tests/unit/test_conflict_resolution_dispatch.py
+++ b/serving/tests/unit/test_conflict_resolution_dispatch.py
@@ -155,9 +155,15 @@ class TestAutoCreateAndMergePr:
             return_value=AsyncMock(add_to_merge_queue=AsyncMock())
         )
 
+        mock_quality_gate = MagicMock()
+        mock_quality_gate.validate_branch = AsyncMock(
+            return_value=MagicMock(passed=True, gates=[])
+        )
+
         with patch("api.compute._resolve_git_project_name", return_value="proj-1_repo-abc"), \
              patch("git.pr_service.PRService", return_value=mock_pr_service), \
-             patch("api.compute._dispatch_conflict_resolution_work", new_callable=AsyncMock) as mock_dispatch:
+             patch("api.compute._dispatch_conflict_resolution_work", new_callable=AsyncMock) as mock_dispatch, \
+             patch("services.quality_gate_service.get_quality_gate_service", return_value=mock_quality_gate):
             await _auto_create_and_merge_pr(mock_work_item, "feat/my-branch", "compute-001")
 
         mock_pr_service.update_status.assert_awaited_once()
@@ -184,9 +190,15 @@ class TestAutoCreateAndMergePr:
         conflict_pr_after_merge = _make_pr("conflict", conflicting_files=["file.py"])
         mock_pr_service.get_pr = AsyncMock(return_value=conflict_pr_after_merge)
 
+        mock_quality_gate = MagicMock()
+        mock_quality_gate.validate_branch = AsyncMock(
+            return_value=MagicMock(passed=True, gates=[])
+        )
+
         with patch("api.compute._resolve_git_project_name", return_value="proj-1_repo-abc"), \
              patch("git.pr_service.PRService", return_value=mock_pr_service), \
-             patch("api.compute._dispatch_conflict_resolution_work", new_callable=AsyncMock) as mock_dispatch:
+             patch("api.compute._dispatch_conflict_resolution_work", new_callable=AsyncMock) as mock_dispatch, \
+             patch("services.quality_gate_service.get_quality_gate_service", return_value=mock_quality_gate):
             await _auto_create_and_merge_pr(mock_work_item, "feat/my-branch", "compute-001")
 
         # Should still have approved, but then detected conflict during merge


### PR DESCRIPTION
## Summary
- Fixes found during cross-review of PRs #271 (IMPLEMENTED status) and #275 (quality gates)
- Prevents work items from getting permanently stuck in IMPLEMENTED status when merge fails after conflict resolution
- Hardens the revert_completed_work path against auto-promotion race conditions

## Changes

### Critical fix
- serving/api/compute.py: Add revert_completed_work() call in _handle_conflict_resolution_completed when merge_ok is False

### Hardening
- serving/services/work_map_service.py: Use AssignmentService.update_status instead of direct mutation; re-read issue status between transitions to handle auto-promotion

### Test fixes
- test_conflict_resolution_dispatch.py: Add quality gate service mocks

## Testing
- [x] All 257 affected unit tests passing

## Issues
Follow-up to #271 and #275