### PR TITLE
feat: system integrity monitor, merge pipeline, and observability

### DIFF
--- a/marketplace/skills/system/lead-reviewer.yaml
+++ b/marketplace/skills/system/lead-reviewer.yaml
@@ -1,0 +1,109 @@
+id: lead-reviewer
+name: Lead Reviewer
+description: Reviews PRs for cross-module consistency, integration correctness, and architectural coherence before merge approval.
+version: "1.0.0"
+author: system
+preferred_model: opus
+
+instructions: |
+  # Lead Reviewer
+
+  ## Role
+  You are the lead reviewer for the project. You review every PR before merge to ensure
+  cross-module consistency, integration correctness, and adherence to project conventions.
+  Unlike the code-reviewer (which focuses on individual code quality), you focus on how
+  changes fit into the broader system.
+
+  ## Review Focus Areas
+
+  ### 1. Import and Dependency Correctness
+  - Are all imports valid and resolvable?
+  - Are there circular import risks?
+  - Are new dependencies properly declared in requirements/package files?
+  - Are version constraints appropriate?
+
+  ### 2. Configuration Completeness
+  - Are all environment variables referenced in code defined somewhere?
+  - Are config keys consistent across modules?
+  - Are defaults sensible for development and production?
+  - Are secrets handled securely (not hardcoded)?
+
+  ### 3. Cross-Module Consistency
+  - Do coding patterns match existing codebase conventions?
+  - Are naming conventions consistent (variable names, file names, API paths)?
+  - Are error handling patterns consistent?
+  - Are logging patterns consistent (log levels, message formats)?
+
+  ### 4. Missing Integration Pieces
+  - Are database migrations included for schema changes?
+  - Is seed data provided for new tables?
+  - Are initialization/startup hooks registered?
+  - Are cleanup/shutdown hooks registered?
+
+  ### 5. API Contract Alignment
+  - Do request/response schemas match between producer and consumer?
+  - Are API versioning conventions followed?
+  - Are error response formats consistent?
+  - Are WebSocket/SSE event formats documented?
+
+  ## Review Process
+
+  1. **Read the diff** — understand what changed and why
+  2. **Check imports** — verify all imports resolve correctly
+  3. **Check config** — ensure env vars and config keys are complete
+  4. **Check consistency** — compare patterns against existing code
+  5. **Check integration** — verify nothing is missing (migrations, hooks, etc.)
+  6. **Check contracts** — ensure APIs match between modules
+  7. **Submit review** — approve or request changes with structured feedback
+
+  ## Output Format
+
+  Submit your review using `claudevn_submit_review` with:
+  - **review_id**: The review_id from your assignment
+  - **approved**: `true` if the PR is ready to merge, `false` if changes are needed
+  - **summary**: 1-3 sentence summary of your findings
+  - **issues**: Array of objects, each with:
+    - `severity`: "error" (must fix) or "warning" (should fix)
+    - `file`: File path where the issue was found
+    - `message`: Clear description of the issue and how to fix it
+
+  ## Decision Criteria
+
+  **Approve** when:
+  - No errors found
+  - Warnings are minor and non-blocking
+  - Changes are consistent with the codebase
+
+  **Request changes** when:
+  - Missing imports or broken dependencies
+  - Missing config or environment variables
+  - Missing migrations for schema changes
+  - API contract mismatches between modules
+  - Security issues (hardcoded secrets, injection risks)
+
+  ## Composability
+  This skill can be composed with project-specific skills to provide
+  domain-specific review context. When composed, the project skill
+  provides knowledge of specific conventions, API contracts, and
+  architectural decisions.
+
+specialized_tools:
+  - claudevn_submit_review
+
+tags:
+  - lead-review
+  - integration-review
+  - consistency-check
+  - pr-review
+  - cross-module
+
+conflicts_with:
+  - code-reviewer  # Lead reviewer subsumes basic code review
+
+constraints:
+  - Do not modify code directly — only review and provide feedback
+  - Do not approve PRs with unresolved error-severity issues
+  - Do not block on minor style preferences — focus on integration concerns
+  - Always check for missing migrations when schema changes are present
+  - Always verify config completeness for new environment variables
+  - Be specific about what needs to change and where

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -970,6 +970,33 @@ def _resolve_git_project_name(project_id: str) -> str:
     return project_id
 
 
+async def _emit_merge_activity(
+    project_id: str, branch: str, event: str
+) -> None:
+    """Fire-and-forget activity event for merge lifecycle."""
+    try:
+        from services.project_service import get_project_service
+        from models.project import ActivityEventType
+
+        svc = get_project_service()
+        type_map = {
+            "merged": (ActivityEventType.PR_MERGED, f"Merged `{branch}` into main"),
+            "conflict": (ActivityEventType.PR_CONFLICT, f"Conflict on `{branch}` — needs rebase"),
+            "rebasing": (ActivityEventType.PR_REBASING, f"Dispatched rebase for `{branch}`"),
+        }
+        evt_type, description = type_map.get(
+            event, (ActivityEventType.BRANCH_MERGED, f"Merge event: {branch}")
+        )
+        await svc.record_activity_event(
+            project_id=project_id,
+            event_type=evt_type,
+            description=description,
+            metadata={"branch": branch, "merge_event": event},
+        )
+    except Exception as e:
+        logger.debug(f"Failed to emit merge activity event: {e}")
+
+
 async def _dispatch_conflict_resolution_work(
     work, branch_name: str, compute_id: str, pr
 ) -> None:
@@ -1347,31 +1374,74 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
         # Trigger merge queue processing
         results = await pr_service.process_merge_queue(git_project_name)
         for result in results:
-            if result.get("success"):
-                merged_branch = result.get("branch", branch_name)
-                logger.info(f"Auto-merged branch {merged_branch}")
+            result_branch = result.get("branch", "")
 
-                # Finalize work: IMPLEMENTED → COMPLETED + DONE + cascade
-                if merged_branch == branch_name:
-                    try:
-                        work_map = get_work_map_service()
+            if result.get("success"):
+                logger.info(f"Auto-merged branch {result_branch}")
+                await _emit_merge_activity(work.project_id, result_branch, "merged")
+
+                # Finalize the work item for this merged branch
+                try:
+                    work_map = get_work_map_service()
+                    if result_branch == branch_name:
                         await work_map.finalize_work(work.work_id)
-                    except Exception as fin_err:
-                        logger.warning(
-                            f"Failed to finalize work {work.work_id} after merge: {fin_err}"
+                    else:
+                        # Another branch merged in the same queue run —
+                        # look up its work item by PR task_id
+                        merged_pr = await pr_service.get_pr(
+                            git_project_name, result_branch
                         )
+                        if merged_pr and merged_pr.task_id:
+                            await work_map.finalize_work(merged_pr.task_id)
+                except Exception as fin_err:
+                    logger.warning(
+                        f"Failed to finalize work for {result_branch}: {fin_err}"
+                    )
 
             elif result.get("reason") == "conflict":
-                # Merge conflict — dispatch resolution to the branch's compute
-                conflict_branch = result.get("branch", branch_name)
-                conflict_pr = await pr_service.get_pr(git_project_name, conflict_branch)
-                if conflict_pr:
+                # Merge conflict — look up the CORRECT work item for this branch
+                conflict_pr = await pr_service.get_pr(
+                    git_project_name, result_branch
+                )
+                if not conflict_pr:
+                    continue
+
+                # Find the work item that owns this branch
+                conflict_work = None
+                if conflict_pr.task_id:
+                    try:
+                        work_map = get_work_map_service()
+                        conflict_work = await work_map.get_work(
+                            conflict_pr.task_id
+                        )
+                    except Exception:
+                        pass
+                if not conflict_work and result_branch == branch_name:
+                    conflict_work = work
+
+                if conflict_work:
                     dispatch_compute = conflict_pr.compute_id or compute_id
+                    await _emit_merge_activity(
+                        work.project_id, result_branch, "conflict"
+                    )
                     await _dispatch_conflict_resolution_work(
-                        work, conflict_branch, dispatch_compute, conflict_pr
+                        conflict_work, result_branch,
+                        dispatch_compute, conflict_pr
+                    )
+                    await _emit_merge_activity(
+                        work.project_id, result_branch, "rebasing"
+                    )
+                else:
+                    logger.warning(
+                        f"Cannot dispatch conflict resolution for "
+                        f"{result_branch}: no work item found "
+                        f"(task_id={conflict_pr.task_id})"
                     )
             else:
-                logger.warning(f"Auto-merge failed for {result.get('branch', branch_name)}: {result.get('error')}")
+                logger.warning(
+                    f"Auto-merge failed for {result_branch}: "
+                    f"{result.get('error')}"
+                )
 
         # Check if OUR branch was successfully merged
         our_merged = any(

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -725,6 +725,12 @@ async def _handle_work_status_update(event: ComputeEventRequest) -> None:
                 work.work_id, WorkStatus.IN_PROGRESS, event.compute_id
             )
             logger.info(f"Work {work.work_id} started (ASSIGNED -> IN_PROGRESS)")
+            if work.project_id:
+                await _emit_activity(
+                    work.project_id, "work_started",
+                    f"**{work.title}** started on {event.compute_id}",
+                    work_id=work.work_id, compute_id=event.compute_id,
+                )
         return
 
     # Determine if this is a success or failure event
@@ -797,6 +803,12 @@ async def _handle_work_status_update(event: ComputeEventRequest) -> None:
                     f"Work {work.work_id} completed (task {event.task_id}), "
                     "cascade deferred until after PR merge"
                 )
+                if work.project_id:
+                    await _emit_activity(
+                        work.project_id, "work_completed",
+                        f"**{work.title}** code complete — entering merge pipeline",
+                        work_id=work.work_id, compute_id=event.compute_id,
+                    )
         else:
             error = event.error or f"Exit code {event.exit_code}"
             await work_map.fail_work_and_update_issue(
@@ -807,6 +819,12 @@ async def _handle_work_status_update(event: ComputeEventRequest) -> None:
             logger.info(
                 f"Work {work.work_id} failed (task {event.task_id}): {error}"
             )
+            if work.project_id:
+                await _emit_activity(
+                    work.project_id, "work_failed",
+                    f"**{work.title}** failed: {error}",
+                    work_id=work.work_id, compute_id=event.compute_id,
+                )
 
     # Post-completion side effects run regardless of who set the terminal state,
     # since MCP progress doesn't handle PR creation or tracking (#829)
@@ -1014,31 +1032,28 @@ async def _release_compute_after_merge(compute_id: str) -> None:
         logger.debug(f"Could not release compute {compute_id}: {e}")
 
 
-async def _emit_merge_activity(
-    project_id: str, branch: str, event: str
+async def _emit_activity(
+    project_id: str, event_type: str, description: str,
+    work_id: str = None, compute_id: str = None,
+    metadata: dict = None
 ) -> None:
-    """Fire-and-forget activity event for merge lifecycle."""
+    """Fire-and-forget activity event for plan page observability."""
     try:
         from services.project_service import get_project_service
         from models.project import ActivityEventType
 
         svc = get_project_service()
-        type_map = {
-            "merged": (ActivityEventType.PR_MERGED, f"Merged `{branch}` into main"),
-            "conflict": (ActivityEventType.PR_CONFLICT, f"Conflict on `{branch}` — needs rebase"),
-            "rebasing": (ActivityEventType.PR_REBASING, f"Dispatched rebase for `{branch}`"),
-        }
-        evt_type, description = type_map.get(
-            event, (ActivityEventType.BRANCH_MERGED, f"Merge event: {branch}")
-        )
+        evt_type = ActivityEventType(event_type)
         await svc.record_activity_event(
             project_id=project_id,
             event_type=evt_type,
             description=description,
-            metadata={"branch": branch, "merge_event": event},
+            work_id=work_id,
+            compute_id=compute_id,
+            metadata=metadata or {},
         )
     except Exception as e:
-        logger.debug(f"Failed to emit merge activity event: {e}")
+        logger.debug(f"Failed to emit activity event: {e}")
 
 
 async def _dispatch_conflict_resolution_work(
@@ -1258,6 +1273,11 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                 title=work.title,
             )
             logger.info(f"Auto-created PR for branch {branch_name} (work {work.work_id})")
+            await _emit_activity(
+                work.project_id, "pr_created",
+                f"PR created for **{work.title}** (`{branch_name}`)",
+                work_id=work.work_id, compute_id=compute_id,
+            )
         except ValueError:
             # PR already exists — likely post-conflict-resolution re-entry.
             # Check if the existing PR had conflicts and they're now resolved.
@@ -1376,6 +1396,11 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                     )
             except Exception as e:
                 logger.debug(f"Could not emit quality gate notification: {e}")
+            await _emit_activity(
+                work.project_id, "pr_quality_failed",
+                f"Quality gates failed for **{work.title}** — will re-dispatch",
+                work_id=work.work_id, compute_id=compute_id,
+            )
             return "revert"
 
         logger.info(f"Quality gates passed for {branch_name}")
@@ -1432,7 +1457,7 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
 
             if result.get("success"):
                 logger.info(f"Auto-merged branch {result_branch}")
-                await _emit_merge_activity(work.project_id, result_branch, "merged")
+                await _emit_activity(work.project_id, "pr_merged", f"Merged `{result_branch}` into main")
 
                 # Finalize the work item for this merged branch and release its compute
                 try:
@@ -1440,6 +1465,11 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                     if result_branch == branch_name:
                         await work_map.finalize_work(work.work_id)
                         await _release_compute_after_merge(compute_id)
+                        await _emit_activity(
+                            work.project_id, "work_finalized",
+                            f"**{work.title}** merged and finalized",
+                            work_id=work.work_id, compute_id=compute_id,
+                        )
                     else:
                         # Another branch merged in the same queue run —
                         # look up its work item by PR task_id
@@ -1448,6 +1478,12 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                         )
                         if merged_pr and merged_pr.task_id:
                             await work_map.finalize_work(merged_pr.task_id)
+                            await _emit_activity(
+                                work.project_id, "work_finalized",
+                                f"Work `{merged_pr.task_id}` merged and finalized",
+                                work_id=merged_pr.task_id,
+                                compute_id=merged_pr.compute_id,
+                            )
                         if merged_pr and merged_pr.compute_id:
                             await _release_compute_after_merge(merged_pr.compute_id)
                 except Exception as fin_err:
@@ -1478,15 +1514,14 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
 
                 if conflict_work:
                     dispatch_compute = conflict_pr.compute_id or compute_id
-                    await _emit_merge_activity(
-                        work.project_id, result_branch, "conflict"
+                    await _emit_activity(
+                        work.project_id, "pr_conflict",
+                        f"Conflict on `{result_branch}` — dispatching rebase to {dispatch_compute}",
+                        work_id=conflict_work.work_id, compute_id=dispatch_compute,
                     )
                     await _dispatch_conflict_resolution_work(
                         conflict_work, result_branch,
                         dispatch_compute, conflict_pr
-                    )
-                    await _emit_merge_activity(
-                        work.project_id, result_branch, "rebasing"
                     )
                 else:
                     logger.warning(

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -1242,20 +1242,41 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                 },
             )
             # Post quality gate failure to project chat so users see it
+            failed_gates = [g.gate for g in validation.gates if g.status.value != "passed"]
+            failure_msg = (
+                f"Quality gates failed for **{work.title}** "
+                f"(branch `{branch_name}`): {', '.join(failed_gates)}. "
+                "Work reverted to in-progress."
+            )
             try:
                 from services.conversation_service import get_conversation_service
                 conv_service = get_conversation_service()
-                failed_gates = [g.gate for g in validation.gates if g.status.value != "passed"]
                 await conv_service.add_message(
                     project_id=work.project_id,
                     user_id="system",
                     display_name="System",
                     type="error",
-                    content=f"Quality gates failed for **{work.title}** (branch `{branch_name}`): {', '.join(failed_gates)}. Work reverted to in-progress.",
+                    content=failure_msg,
                     metadata={"work_id": work.work_id, "branch": branch_name, "event_type": "quality_gate_failed"},
                 )
             except Exception as e:
                 logger.warning(f"Failed to post quality gate failure to chat: {e}")
+            # Emit notification for the notification feed
+            try:
+                from services.notification_service import get_notification_service
+                from models.notification import NotificationLevel, NotificationCategory
+                notification_service = get_notification_service()
+                if notification_service:
+                    notification_service.emit(
+                        title=f"Quality gates failed: {work.title}",
+                        message=failure_msg,
+                        level=NotificationLevel.ERROR,
+                        category=NotificationCategory.WORK,
+                        project_id=work.project_id,
+                        entity_id=work.work_id,
+                    )
+            except Exception as e:
+                logger.debug(f"Could not emit quality gate notification: {e}")
             return False
 
         logger.info(f"Quality gates passed for {branch_name}")
@@ -2158,6 +2179,28 @@ async def register_instance(
                 metadata=request.metadata,
             )
             await registry.update_heartbeat(request.instance_id)
+
+            # Re-sync auth_status on reconnect (token may have been
+            # added/refreshed while compute was disconnected)
+            from services.claude_auth_service import get_claude_auth_service
+            from models.compute import ComputeAuthStatus
+
+            auth_svc = get_claude_auth_service()
+            if auth_svc:
+                token_info = auth_svc.get_token_info(request.instance_id)
+                if token_info and token_info.get("status") == "active":
+                    expires_at_str = token_info.get("expires_at")
+                    expires_at = (
+                        datetime.fromisoformat(expires_at_str)
+                        if expires_at_str
+                        else None
+                    )
+                    await registry.update_auth_status(
+                        request.instance_id,
+                        ComputeAuthStatus.AUTHORIZED,
+                        auth_expires_at=expires_at,
+                    )
+
             logger.info(
                 f"Compute {request.instance_id} re-registered — "
                 f"preserved {existing.status.value} status"
@@ -2189,6 +2232,32 @@ async def register_instance(
         )
 
         registered = await registry.add_instance(instance)
+
+        # Sync auth_status from existing tokens (fixes startup ordering:
+        # _sync_registry_auth_status runs before compute nodes register,
+        # so newly registered nodes default to UNAUTHORIZED even when
+        # active tokens exist in Redis)
+        from services.claude_auth_service import get_claude_auth_service
+        from models.compute import ComputeAuthStatus
+
+        auth_svc = get_claude_auth_service()
+        if auth_svc:
+            token_info = auth_svc.get_token_info(request.instance_id)
+            if token_info and token_info.get("status") == "active":
+                expires_at_str = token_info.get("expires_at")
+                expires_at = (
+                    datetime.fromisoformat(expires_at_str)
+                    if expires_at_str
+                    else None
+                )
+                await registry.update_auth_status(
+                    request.instance_id,
+                    ComputeAuthStatus.AUTHORIZED,
+                    auth_expires_at=expires_at,
+                )
+                logger.info(
+                    f"Synced auth_status to AUTHORIZED for newly registered {request.instance_id}"
+                )
 
         logger.info(
             f"Registered compute instance {request.instance_id} "

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -1260,12 +1260,44 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
 
         logger.info(f"Quality gates passed for {branch_name}")
 
+        # Lead compute review gate — dispatch review to a separate compute
+        # instance before auto-approving. If review is unavailable or times
+        # out, auto-approve to avoid blocking the pipeline.
+        reviewed_by = "auto-approved"
+        try:
+            from services.lead_compute_service import get_lead_compute_service
+            lead_service = get_lead_compute_service()
+            if lead_service.enabled:
+                review_result = await lead_service.review_pr(
+                    project=git_project_name,
+                    branch=branch_name,
+                    compute_id=compute_id,
+                    work_title=work.title,
+                    work_description=work.description or "",
+                    project_id=work.project_id,
+                )
+                reviewed_by = f"lead:{review_result.reviewer_id}"
+
+                if not review_result.approved:
+                    logger.warning(
+                        f"Lead review rejected {branch_name}: {review_result.summary}"
+                    )
+                    await pr_service.update_status(
+                        project=git_project_name,
+                        branch=branch_name,
+                        status=PRStatus.REJECTED,
+                        reviewed_by=reviewed_by,
+                    )
+                    return False
+        except Exception as e:
+            logger.debug(f"Lead review skipped for {branch_name}: {e}")
+
         # Auto-approve (work completed successfully, no conflicts, gates passed)
         await pr_service.update_status(
             project=git_project_name,
             branch=branch_name,
             status=PRStatus.APPROVED,
-            reviewed_by="auto-approved",
+            reviewed_by=reviewed_by,
         )
 
         # Add to merge queue (needed for post-resolution re-entry where the

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -615,36 +615,64 @@ async def receive_compute_event(
     if event.event.value != "claude_code_rejected":
         await _handle_work_status_update(event)
 
-    # Reset SSE connection to idle so compute can pick up new work.
-    # This MUST be here (not inside _handle_work_status_update) because
-    # characterization/decomposition tasks (char-*, decomp-*) are not work
-    # items — _handle_work_status_update returns early when get_work() is
-    # None, skipping the reset if it lived there.
+    # Reset SSE connection status after task completion.
+    #
+    # For WORK ITEMS that completed successfully with a branch: set to "merging"
+    # so the compute stays reserved for conflict resolution. It will be reset
+    # to "idle" after finalize_work (merge succeeded) or if merge permanently
+    # fails. The dispatcher skips non-idle computes, preventing double-assignment.
+    #
+    # For everything else (failures, char/decomp tasks, rejections): reset to
+    # "idle" immediately so the compute can pick up new work.
     if event.event.value in ("claude_code_completed", "claude_code_failed", "claude_code_rejected"):
+        is_work_success = (
+            event.event.value == "claude_code_completed"
+            and event.exit_code == 0
+            and not event.task_id.startswith("conflict-")
+            and not event.task_id.startswith("char-")
+            and not event.task_id.startswith("decomp-")
+        )
+        # Check if this work item has a branch (needs merge pipeline)
+        has_branch = False
+        if is_work_success:
+            try:
+                from services.work_map_service import get_work_map_service
+                w = await get_work_map_service().get_work(event.task_id)
+                has_branch = bool(w and (event.branch_name or w.branch_name) and w.project_id)
+            except Exception:
+                pass
+
         try:
             sse_manager = get_sse_connection_manager()
             connection = sse_manager.get_connection(event.compute_id)
             if connection:
-                connection.status = "idle"
-                connection.current_task_id = None
-                logger.info(f"Reset SSE connection {event.compute_id} to idle")
+                if is_work_success and has_branch:
+                    # Hold compute for merge pipeline — don't assign new work
+                    connection.status = "merging"
+                    logger.info(
+                        f"SSE connection {event.compute_id} set to 'merging' "
+                        f"(holding for PR pipeline)"
+                    )
+                else:
+                    connection.status = "idle"
+                    connection.current_task_id = None
+                    logger.info(f"Reset SSE connection {event.compute_id} to idle")
         except Exception as e:
             logger.warning(
-                f"Failed to reset SSE connection for {event.compute_id}: {e}"
+                f"Failed to update SSE connection for {event.compute_id}: {e}"
             )
 
-        # Fire the WorkDispatcher — compute is now idle, may have work waiting
-        # (characterization tasks, decomposition tasks, or execution work items).
-        # This replaces the 2-second polling loop with an immediate push signal.
-        try:
-            from services.work_dispatcher import get_work_dispatcher
-            get_work_dispatcher().trigger(
-                reason=f"compute_idle:{event.compute_id}"
-            )
-        except RuntimeError:
-            pass  # Dispatcher not initialized (e.g., test environment)
-        except Exception as e:
-            logger.debug(f"Could not fire dispatcher on compute idle: {e}")
+        # Fire the WorkDispatcher only when compute is actually idle
+        if not (is_work_success and has_branch):
+            try:
+                from services.work_dispatcher import get_work_dispatcher
+                get_work_dispatcher().trigger(
+                    reason=f"compute_idle:{event.compute_id}"
+                )
+            except RuntimeError:
+                pass
+            except Exception as e:
+                logger.debug(f"Could not fire dispatcher on compute idle: {e}")
 
     # On rejection, attempt to re-dispatch the task to another compute
     if event.event.value == "claude_code_rejected":
@@ -819,14 +847,14 @@ async def _handle_work_status_update(event: ComputeEventRequest) -> None:
                 f"Reverting work {work.work_id} to IN_PROGRESS — code needs changes"
             )
             await work_map.revert_completed_work(work.work_id)
+            await _release_compute_after_merge(event.compute_id)
         elif pr_result == "pending" and not already_terminal and branch_name and work.project_id:
-            # PR pipeline issue but code is done (IMPLEMENTED). Do NOT revert —
-            # that would burn retry budget re-doing already-complete work.
-            # The integrity monitor's stuck_pr / merged_not_finalized checks
-            # will handle the PR-level retry.
-            logger.warning(
-                f"PR pipeline pending for work {work.work_id} — keeping IMPLEMENTED "
-                f"(branch {branch_name} has code, PR will be retried)"
+            # PR pipeline pending — compute stays in "merging" status.
+            # Conflict resolution will dispatch back to this compute, or the
+            # integrity monitor safety net will catch it.
+            logger.info(
+                f"PR pipeline pending for work {work.work_id} — compute "
+                f"{event.compute_id} held in merging state"
             )
 
 
@@ -968,6 +996,22 @@ def _resolve_git_project_name(project_id: str) -> str:
 
     logger.warning(f"No repo found for project {project_id} in {repos_path}")
     return project_id
+
+
+async def _release_compute_after_merge(compute_id: str) -> None:
+    """Release a compute from 'merging' status back to idle after merge completes."""
+    try:
+        sse_manager = get_sse_connection_manager()
+        connection = sse_manager.get_connection(compute_id)
+        if connection and connection.status == "merging":
+            connection.status = "idle"
+            connection.current_task_id = None
+            logger.info(f"Released compute {compute_id} from merging to idle")
+
+            from services.work_dispatcher import get_work_dispatcher
+            get_work_dispatcher().trigger(reason=f"compute_idle:{compute_id}")
+    except Exception as e:
+        logger.debug(f"Could not release compute {compute_id}: {e}")
 
 
 async def _emit_merge_activity(
@@ -1390,11 +1434,12 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                 logger.info(f"Auto-merged branch {result_branch}")
                 await _emit_merge_activity(work.project_id, result_branch, "merged")
 
-                # Finalize the work item for this merged branch
+                # Finalize the work item for this merged branch and release its compute
                 try:
                     work_map = get_work_map_service()
                     if result_branch == branch_name:
                         await work_map.finalize_work(work.work_id)
+                        await _release_compute_after_merge(compute_id)
                     else:
                         # Another branch merged in the same queue run —
                         # look up its work item by PR task_id
@@ -1403,6 +1448,8 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                         )
                         if merged_pr and merged_pr.task_id:
                             await work_map.finalize_work(merged_pr.task_id)
+                        if merged_pr and merged_pr.compute_id:
+                            await _release_compute_after_merge(merged_pr.compute_id)
                 except Exception as fin_err:
                     logger.warning(
                         f"Failed to finalize work for {result_branch}: {fin_err}"

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -1345,6 +1345,25 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                         logger.warning(
                             f"Failed to finalize work {work.work_id} after merge: {fin_err}"
                         )
+
+                    # Post completion to project chat
+                    try:
+                        from services.conversation_service import get_conversation_service
+                        conv_service = get_conversation_service()
+                        await conv_service.add_message(
+                            project_id=work.project_id,
+                            user_id="system",
+                            display_name="System",
+                            type="assistant",
+                            content=f"**{work.title}** completed and merged successfully.",
+                            metadata={
+                                "work_id": work.work_id,
+                                "branch": branch_name,
+                                "event_type": "work_completed",
+                            },
+                        )
+                    except Exception as chat_err:
+                        logger.debug(f"Could not post completion to chat: {chat_err}")
             elif result.get("reason") == "conflict":
                 # Merge conflict — dispatch resolution to the branch's compute
                 conflict_branch = result.get("branch", branch_name)

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -808,18 +808,46 @@ async def _handle_work_status_update(event: ComputeEventRequest) -> None:
         # finalize_work() inside _auto_create_and_merge_pr handles
         # IMPLEMENTED → COMPLETED + DONE transitions and dependency cascade
         branch_name = event.branch_name or work.branch_name
-        merge_ok = False
+        pr_result = "pending"
         if branch_name and work.project_id:
-            merge_ok = await _auto_create_and_merge_pr(work, branch_name, event.compute_id)
+            pr_result = await _auto_create_and_merge_pr(work, branch_name, event.compute_id)
 
-        if not merge_ok and not already_terminal and branch_name and work.project_id:
-            # Merge or quality gates failed on the FIRST attempt — revert so they don't appear done.
-            # Skip revert when already_terminal: a duplicate event finding a PR mid-review
-            # should not undo the prior event's IMPLEMENTED status.
+        if pr_result == "revert" and not already_terminal:
+            # Code needs changes (quality gates failed, review rejected) — revert
+            # so the work can be re-dispatched with corrective instructions.
             logger.warning(
-                f"Reverting work {work.work_id} to IN_PROGRESS — PR merge did not succeed"
+                f"Reverting work {work.work_id} to IN_PROGRESS — code needs changes"
             )
             await work_map.revert_completed_work(work.work_id)
+        elif pr_result == "pending" and not already_terminal and branch_name and work.project_id:
+            # PR pipeline issue but code is done (IMPLEMENTED). Do NOT revert —
+            # that would burn retry budget re-doing already-complete work.
+            # The integrity monitor's stuck_pr / merged_not_finalized checks
+            # will handle the PR-level retry.
+            logger.warning(
+                f"PR pipeline pending for work {work.work_id} — keeping IMPLEMENTED "
+                f"(branch {branch_name} has code, PR will be retried)"
+            )
+            try:
+                from services.conversation_service import get_conversation_service
+                conv_service = get_conversation_service()
+                await conv_service.add_message(
+                    project_id=work.project_id,
+                    user_id="system",
+                    display_name="System",
+                    type="assistant",
+                    content=(
+                        f"**{work.title}** code is complete but PR merge pending. "
+                        f"Branch `{branch_name}` will be retried automatically."
+                    ),
+                    metadata={
+                        "work_id": work.work_id,
+                        "branch": branch_name,
+                        "event_type": "pr_merge_pending",
+                    },
+                )
+            except Exception:
+                pass
 
 
 async def _handle_rejection_redispatch(event: ComputeEventRequest) -> None:
@@ -1126,20 +1154,25 @@ async def _handle_conflict_resolution_completed(event, work_map) -> None:
     # Re-trigger the PR merge pipeline with the original work item
     # finalize_work() inside _auto_create_and_merge_pr handles cascade
     branch_name = event.branch_name or work.branch_name
-    merge_ok = False
+    pr_result = "pending"
     if branch_name and work.project_id:
-        merge_ok = await _auto_create_and_merge_pr(work, branch_name, event.compute_id)
+        pr_result = await _auto_create_and_merge_pr(work, branch_name, event.compute_id)
 
-    if not merge_ok and branch_name and work.project_id:
-        # Merge or quality gates failed after conflict resolution — revert
+    if pr_result == "revert" and branch_name and work.project_id:
+        # Quality gates / review rejected after conflict resolution — revert
         logger.warning(
             f"Reverting work {original_work_id} to IN_PROGRESS — "
-            f"PR merge did not succeed after conflict resolution"
+            f"code needs changes after conflict resolution"
         )
         await work_map.revert_completed_work(original_work_id)
+    elif pr_result == "pending":
+        logger.info(
+            f"PR pipeline pending for {original_work_id} after conflict resolution — "
+            f"integrity monitor will retry"
+        )
 
 
-async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> bool:
+async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> str:
     """Auto-create a PR and trigger merge queue processing after work completion.
 
     Handles both fresh PRs and post-conflict-resolution re-entry (where
@@ -1151,7 +1184,9 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
         compute_id: Compute instance that completed the work
 
     Returns:
-        True if the PR was merged successfully, False otherwise.
+        "merged"  — PR was merged successfully
+        "pending" — PR pipeline issue, code is fine, keep IMPLEMENTED
+        "revert"  — Code needs changes (quality gates failed, review rejected)
     """
     from git.pr_service import PRService, PRStatus
     from services.work_map_service import get_work_map_service
@@ -1194,14 +1229,14 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                     await _dispatch_conflict_resolution_work(
                         work, branch_name, compute_id, existing_pr
                     )
-                    return False
+                    return "pending"
             else:
                 # PR exists in a non-conflict state — nothing to do
                 logger.info(
                     f"PR already exists for {branch_name} "
                     f"(status: {existing_pr.status.value if existing_pr else 'unknown'})"
                 )
-                return False
+                return "pending"
 
         # If the PR has conflicts on creation (not post-resolution), dispatch resolution.
         if not conflict_resolved and pr.status == PRStatus.CONFLICT:
@@ -1209,7 +1244,7 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                 f"PR has conflicts on creation, dispatching conflict resolution for {branch_name}"
             )
             await _dispatch_conflict_resolution_work(work, branch_name, compute_id, pr)
-            return False
+            return "pending"
 
         # Run quality gates before auto-approve
         from services.quality_gate_service import get_quality_gate_service
@@ -1249,7 +1284,7 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
             failure_msg = (
                 f"Quality gates failed for **{work.title}** "
                 f"(branch `{branch_name}`): {', '.join(failed_gates)}. "
-                "Work reverted to in-progress."
+                "Work will be re-dispatched."
             )
             try:
                 from services.conversation_service import get_conversation_service
@@ -1280,7 +1315,7 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                     )
             except Exception as e:
                 logger.debug(f"Could not emit quality gate notification: {e}")
-            return False
+            return "revert"
 
         logger.info(f"Quality gates passed for {branch_name}")
 
@@ -1312,7 +1347,7 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                         status=PRStatus.REJECTED,
                         reviewed_by=reviewed_by,
                     )
-                    return False
+                    return "revert"
         except Exception as e:
             logger.debug(f"Lead review skipped for {branch_name}: {e}")
 
@@ -1381,11 +1416,11 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
             r.get("success") and r.get("branch", "") == branch_name
             for r in results
         )
-        return our_merged
+        return "merged" if our_merged else "pending"
 
     except Exception as e:
         logger.warning(f"Auto PR/merge failed for {branch_name}: {e}")
-        return False
+        return "pending"
 
 
 # =============================================================================

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -1216,15 +1216,25 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
             logger.info(f"Auto-created PR for branch {branch_name} (work {work.work_id})")
         except ValueError:
             # PR already exists — likely post-conflict-resolution re-entry.
-            # Check if the existing PR was in CONFLICT status and conflicts
-            # are now resolved after the compute rebased and pushed.
+            # Check if the existing PR had conflicts and they're now resolved.
             existing_pr = await pr_service.get_pr(git_project_name, branch_name)
-            if existing_pr and existing_pr.status == PRStatus.CONFLICT:
+            if not existing_pr:
+                return "pending"
+
+            # PRs that had conflicts may be in CONFLICT or PENDING status
+            # (PENDING when the integrity monitor or a stale update reset it).
+            had_conflicts = (
+                existing_pr.status == PRStatus.CONFLICT
+                or (existing_pr.status == PRStatus.PENDING
+                    and getattr(existing_pr, 'conflicting_files', None))
+            )
+
+            if had_conflicts:
                 # Verify conflicts are resolved by running dry-run merge
                 dry_run = await pr_service.dry_run_merge(git_project_name, branch_name)
                 if dry_run.get("can_merge"):
                     logger.info(
-                        f"Conflicts resolved for {branch_name}, re-approving PR"
+                        f"Conflicts resolved for {branch_name}, proceeding to merge"
                     )
                     pr = existing_pr
                     conflict_resolved = True
@@ -1241,7 +1251,7 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                 # PR exists in a non-conflict state — nothing to do
                 logger.info(
                     f"PR already exists for {branch_name} "
-                    f"(status: {existing_pr.status.value if existing_pr else 'unknown'})"
+                    f"(status: {existing_pr.status.value})"
                 )
                 return "pending"
 

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -828,26 +828,6 @@ async def _handle_work_status_update(event: ComputeEventRequest) -> None:
                 f"PR pipeline pending for work {work.work_id} — keeping IMPLEMENTED "
                 f"(branch {branch_name} has code, PR will be retried)"
             )
-            try:
-                from services.conversation_service import get_conversation_service
-                conv_service = get_conversation_service()
-                await conv_service.add_message(
-                    project_id=work.project_id,
-                    user_id="system",
-                    display_name="System",
-                    type="assistant",
-                    content=(
-                        f"**{work.title}** code is complete but PR merge pending. "
-                        f"Branch `{branch_name}` will be retried automatically."
-                    ),
-                    metadata={
-                        "work_id": work.work_id,
-                        "branch": branch_name,
-                        "event_type": "pr_merge_pending",
-                    },
-                )
-            except Exception:
-                pass
 
 
 async def _handle_rejection_redispatch(event: ComputeEventRequest) -> None:
@@ -1381,24 +1361,6 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
                             f"Failed to finalize work {work.work_id} after merge: {fin_err}"
                         )
 
-                    # Post completion to project chat
-                    try:
-                        from services.conversation_service import get_conversation_service
-                        conv_service = get_conversation_service()
-                        await conv_service.add_message(
-                            project_id=work.project_id,
-                            user_id="system",
-                            display_name="System",
-                            type="assistant",
-                            content=f"**{work.title}** completed and merged successfully.",
-                            metadata={
-                                "work_id": work.work_id,
-                                "branch": branch_name,
-                                "event_type": "work_completed",
-                            },
-                        )
-                    except Exception as chat_err:
-                        logger.debug(f"Could not post completion to chat: {chat_err}")
             elif result.get("reason") == "conflict":
                 # Merge conflict — dispatch resolution to the branch's compute
                 conflict_branch = result.get("branch", branch_name)

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -812,8 +812,10 @@ async def _handle_work_status_update(event: ComputeEventRequest) -> None:
         if branch_name and work.project_id:
             merge_ok = await _auto_create_and_merge_pr(work, branch_name, event.compute_id)
 
-        if not merge_ok and branch_name and work.project_id:
-            # Merge or quality gates failed — revert work/issue so they don't appear done
+        if not merge_ok and not already_terminal and branch_name and work.project_id:
+            # Merge or quality gates failed on the FIRST attempt — revert so they don't appear done.
+            # Skip revert when already_terminal: a duplicate event finding a PR mid-review
+            # should not undo the prior event's IMPLEMENTED status.
             logger.warning(
                 f"Reverting work {work.work_id} to IN_PROGRESS — PR merge did not succeed"
             )

--- a/serving/api/compute.py
+++ b/serving/api/compute.py
@@ -1152,6 +1152,7 @@ async def _auto_create_and_merge_pr(work, branch_name: str, compute_id: str) -> 
         True if the PR was merged successfully, False otherwise.
     """
     from git.pr_service import PRService, PRStatus
+    from services.work_map_service import get_work_map_service
 
     try:
         pr_service = PRService()

--- a/serving/api/plan_summary.py
+++ b/serving/api/plan_summary.py
@@ -67,6 +67,9 @@ class PlanSummaryResponse(BaseModel):
     recent_traces: List[dict] = Field(default_factory=list)  # last 10 traces
     trace_count: int = 0
 
+    # Activity events (merge lifecycle, work status changes)
+    activity_events: List[dict] = Field(default_factory=list)
+
 
 def _serialize_issue(issue) -> dict:
     """Serialize an issue for the plan summary response."""
@@ -204,5 +207,22 @@ async def get_plan_summary(
         logger.warning(f"Decision trace service unavailable: {e}")
     except Exception as e:
         logger.warning(f"Error fetching decision traces: {e}")
+
+    # Fetch recent activity events
+    try:
+        from services.project_service import get_project_service
+        project_service = get_project_service()
+        events = await project_service.get_recent_activity(project_id, limit=20)
+        response.activity_events = [
+            {
+                "event_id": e.event_id,
+                "event_type": e.event_type.value if hasattr(e.event_type, 'value') else e.event_type,
+                "description": e.description,
+                "timestamp": e.timestamp.isoformat() if hasattr(e.timestamp, 'isoformat') else str(e.timestamp),
+            }
+            for e in events
+        ]
+    except Exception as e:
+        logger.debug(f"Activity events unavailable: {e}")
 
     return response

--- a/serving/api/slim_claude_code.py
+++ b/serving/api/slim_claude_code.py
@@ -213,6 +213,37 @@ async def _set_processing_status(
 
     await redis.setex(key, PROCESSING_STATUS_TTL_SECONDS, json.dumps(data))
 
+    # Push stage change to WebSocket subscribers in real-time
+    try:
+        from services.observability_event_bus import get_event_bus
+        from models.observability import GoalProcessingStageEvent
+        import uuid as _uuid
+
+        event_bus = get_event_bus()
+        if event_bus:
+            previous_stage = existing_data.get("stage") if existing else None
+            # Look up project_id from goal for frontend filtering
+            project_id = None
+            try:
+                goal_key = f"claudevn:workmap:goal:{goal_id}"
+                goal_data = await redis.hget(goal_key, "project_id")
+                if goal_data:
+                    project_id = goal_data
+            except Exception:
+                pass
+
+            event = GoalProcessingStageEvent(
+                event_id=f"gps_{_uuid.uuid4().hex[:12]}",
+                goal_id=goal_id,
+                project_id=project_id,
+                stage=stage.value,
+                previous_stage=previous_stage,
+                error=error,
+            )
+            await event_bus.emit_event(event)
+    except Exception as e:
+        logger.debug(f"Could not emit processing stage event: {e}")
+
 
 async def _get_processing_status(goal_id: str) -> Optional[ProcessingStatusResponse]:
     """Retrieve processing status for a goal from Redis."""

--- a/serving/app.py
+++ b/serving/app.py
@@ -983,7 +983,7 @@ async def lifespan(app: FastAPI):
     # =========================================================================
     try:
         integrity_enabled = os.getenv('INTEGRITY_MONITOR_ENABLED', 'true').lower() == 'true'
-        integrity_interval = int(os.getenv('INTEGRITY_MONITOR_INTERVAL_SECONDS', '60'))
+        integrity_interval = int(os.getenv('INTEGRITY_MONITOR_INTERVAL_SECONDS', '600'))
         if integrity_enabled:
             await start_system_integrity_monitor(check_interval=integrity_interval)
             logger.info(

--- a/serving/app.py
+++ b/serving/app.py
@@ -31,8 +31,8 @@ from services.work_orchestrator import (
     start_work_orchestration, stop_work_orchestration, get_work_orchestrator
 )
 from services.work_dispatcher import start_work_dispatcher, stop_work_dispatcher
-from services.reconciliation_manager import (
-    start_reconciliation_manager, stop_reconciliation_manager
+from services.system_integrity_monitor import (
+    start_system_integrity_monitor, stop_system_integrity_monitor
 )
 from api import compute
 from api import compute_approval
@@ -975,22 +975,24 @@ async def lifespan(app: FastAPI):
         logger.warning(f"Failed to start work dispatcher: {e}. Falling back to polling-only dispatch.")
 
     # =========================================================================
-    # OPTIONAL: Reconciliation Manager
-    # Periodic safety net (45s) that catches stuck items, orphaned tasks,
-    # and consistency issues missed by the event-driven dispatch path.
+    # OPTIONAL: System Integrity Monitor
+    # Active agent (60s sweep) that detects cross-cutting state machine
+    # inconsistencies (merged but un-finalized work, stuck issues/goals,
+    # orphaned work, pipeline stalls) and attempts remediation.
+    # Replaces the former ReconciliationManager with broader coverage.
     # =========================================================================
     try:
-        reconcile_enabled = os.getenv('RECONCILIATION_ENABLED', 'true').lower() == 'true'
-        reconcile_interval = int(os.getenv('RECONCILIATION_INTERVAL_SECONDS', '45'))
-        if reconcile_enabled:
-            await start_reconciliation_manager(check_interval=reconcile_interval)
+        integrity_enabled = os.getenv('INTEGRITY_MONITOR_ENABLED', 'true').lower() == 'true'
+        integrity_interval = int(os.getenv('INTEGRITY_MONITOR_INTERVAL_SECONDS', '60'))
+        if integrity_enabled:
+            await start_system_integrity_monitor(check_interval=integrity_interval)
             logger.info(
-                f"Reconciliation manager started (interval={reconcile_interval}s)"
+                f"System integrity monitor started (interval={integrity_interval}s)"
             )
         else:
-            logger.info("Reconciliation manager disabled via RECONCILIATION_ENABLED=false")
+            logger.info("System integrity monitor disabled via INTEGRITY_MONITOR_ENABLED=false")
     except Exception as e:
-        logger.warning(f"Failed to start reconciliation manager: {e}")
+        logger.warning(f"Failed to start system integrity monitor: {e}")
 
     # =========================================================================
     # OPTIONAL: Work Orchestrator
@@ -1080,12 +1082,12 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.debug(f"Auto-drain lifecycle service cleanup: {e}")
 
-    # Stop reconciliation manager
+    # Stop system integrity monitor
     try:
-        await stop_reconciliation_manager()
-        logger.info("Reconciliation manager stopped")
+        await stop_system_integrity_monitor()
+        logger.info("System integrity monitor stopped")
     except Exception as e:
-        logger.debug(f"Reconciliation manager cleanup: {e}")
+        logger.debug(f"System integrity monitor cleanup: {e}")
 
     # Stop work dispatcher
     try:

--- a/serving/app.py
+++ b/serving/app.py
@@ -983,7 +983,7 @@ async def lifespan(app: FastAPI):
     # =========================================================================
     try:
         integrity_enabled = os.getenv('INTEGRITY_MONITOR_ENABLED', 'true').lower() == 'true'
-        integrity_interval = int(os.getenv('INTEGRITY_MONITOR_INTERVAL_SECONDS', '600'))
+        integrity_interval = int(os.getenv('INTEGRITY_MONITOR_INTERVAL_SECONDS', '60'))
         if integrity_enabled:
             await start_system_integrity_monitor(check_interval=integrity_interval)
             logger.info(

--- a/serving/frontend/src/api/orchestrator.js
+++ b/serving/frontend/src/api/orchestrator.js
@@ -1,0 +1,13 @@
+import { request } from './index'
+
+export async function getOrchestratorStatus() {
+  return request('/orchestrator/status')
+}
+
+export async function pauseOrchestrator() {
+  return request('/orchestrator/pause', { method: 'POST' })
+}
+
+export async function resumeOrchestrator() {
+  return request('/orchestrator/resume', { method: 'POST' })
+}

--- a/serving/frontend/src/components/directives/Conversation.css
+++ b/serving/frontend/src/components/directives/Conversation.css
@@ -601,30 +601,12 @@
   background: rgba(34, 197, 94, 0.03);
 }
 
-.conv-complete-issues {
-  margin-top: 4px;
+.conv-issues-summary {
+  margin: 8px 0 0;
   padding-top: 8px;
   border-top: 1px solid var(--border);
-}
-
-.conv-issues-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.conv-issue-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 0;
   font-size: 13px;
-  color: var(--text);
-  border-bottom: 1px solid var(--border);
-}
-
-.conv-issue-item:last-child {
-  border-bottom: none;
+  color: var(--text-secondary);
 }
 
 .conv-reasoning {

--- a/serving/frontend/src/components/directives/ConversationTimeline.jsx
+++ b/serving/frontend/src/components/directives/ConversationTimeline.jsx
@@ -168,7 +168,7 @@ function GoalProcessingMessage({ msg, onRetry }) {
             <span className="conv-msg-label">Processing Timed Out</span>
           </div>
           <p className="conv-timeout-text">
-            Processing has not completed after 5 minutes. The operation may still be running on the server.
+            The current stage has not progressed for 5 minutes. The operation may still be running on the server.
           </p>
           {onRetry && (
             <div className="conv-timeout-actions">
@@ -220,7 +220,7 @@ function GoalProcessingMessage({ msg, onRetry }) {
 
 function GoalCompleteMessage({ msg }) {
   const result = msg.result
-  const issues = result?.issues_created || result?.issues || []
+  const issues = result?.issues_created || result?.created_issues || result?.issues || []
 
   return (
     <GoalCompletionCard

--- a/serving/frontend/src/components/directives/ConversationTimeline.jsx
+++ b/serving/frontend/src/components/directives/ConversationTimeline.jsx
@@ -470,14 +470,16 @@ function StatusGroup({ msgs }) {
 // Group consecutive compact messages, interleave with full-card messages
 // ---------------------------------------------------------------------------
 
+const MAX_STATUS_PER_GROUP = 20
+
 function buildRenderGroups(messages) {
   const groups = []
   let compactBuf = []
 
   const flushCompact = () => {
-    if (compactBuf.length > 0) {
-      groups.push({ kind: 'compact', msgs: compactBuf })
-      compactBuf = []
+    // Split into chunks of MAX_STATUS_PER_GROUP
+    while (compactBuf.length > 0) {
+      groups.push({ kind: 'compact', msgs: compactBuf.splice(0, MAX_STATUS_PER_GROUP) })
     }
   }
 

--- a/serving/frontend/src/components/directives/GoalCompletionCard.jsx
+++ b/serving/frontend/src/components/directives/GoalCompletionCard.jsx
@@ -1,4 +1,4 @@
-import { Check, FileText } from 'lucide-react'
+import { Check } from 'lucide-react'
 
 const STAGE_LABELS = {
   queued: 'Queuing work',
@@ -50,15 +50,7 @@ export default function GoalCompletionCard({ issues = [], reasoning, startedAt, 
           ))}
         </div>
         {issues.length > 0 && (
-          <ul className="conv-issues-list conv-complete-issues">
-            {issues.map((issue, i) => (
-              <li key={issue.issue_id || i} className="conv-issue-item">
-                <FileText size={12} />
-                <span>{issue.title}</span>
-                {issue.priority && <span className="conv-tag conv-tag-priority">{issue.priority}</span>}
-              </li>
-            ))}
-          </ul>
+          <p className="conv-issues-summary">{issues.length} issue{issues.length !== 1 ? 's' : ''} created</p>
         )}
         {reasoning && (
           <p className="conv-reasoning">{reasoning}</p>

--- a/serving/frontend/src/components/plan/ActiveWorkView.jsx
+++ b/serving/frontend/src/components/plan/ActiveWorkView.jsx
@@ -121,7 +121,7 @@ function ActiveWorkView({ data, loading, onItemClick, onItemTracesClick, itemBuc
         )}
         {done_items.length > 0 && (
           <WorkColumn
-            title="Merged"
+            title="Done"
             icon={CheckCircle2}
             iconClass="done"
             items={done_items}

--- a/serving/frontend/src/components/plan/WhyThisOrder.jsx
+++ b/serving/frontend/src/components/plan/WhyThisOrder.jsx
@@ -43,9 +43,9 @@ function formatTimeAgo(isoString) {
   return `${diffDays}d ago`
 }
 
-function WhyThisOrder({ buckets = [], traces = [], traceCount = 0, onTraceChainClick }) {
+function WhyThisOrder({ buckets = [], traces = [], traceCount = 0, activityEvents = [], onTraceChainClick }) {
   const [orderingExpanded, setOrderingExpanded] = useState(true)
-  const [otherExpanded, setOtherExpanded] = useState(false)
+  const [otherExpanded, setOtherExpanded] = useState(true)
   const hasBuckets = buckets.length > 0
 
   // Split traces into ordering-relevant and other
@@ -63,9 +63,9 @@ function WhyThisOrder({ buckets = [], traces = [], traceCount = 0, onTraceChainC
   }, [traces])
 
   const hasOrderingTraces = orderingTraces.length > 0
-  const hasOtherTraces = otherTraces.length > 0
+  const hasActivity = activityEvents.length > 0 || otherTraces.length > 0
 
-  if (!hasBuckets && !hasOrderingTraces && !hasOtherTraces) return null
+  if (!hasBuckets && !hasOrderingTraces && !hasActivity) return null
 
   const sortedBuckets = hasBuckets
     ? buckets.slice().sort((a, b) => a.rank - b.rank)
@@ -141,20 +141,23 @@ function WhyThisOrder({ buckets = [], traces = [], traceCount = 0, onTraceChainC
         </>
       )}
 
-      {hasOtherTraces && (
+      {hasActivity && (
         <>
           <button
             className="plan-why-header plan-why-header--secondary"
             onClick={() => setOtherExpanded(!otherExpanded)}
           >
             {otherExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-            <span className="plan-why-title">Other Activity</span>
+            <span className="plan-why-title">Activity Log</span>
             <span className="plan-why-count">
-              {otherTraces.length}
+              {activityEvents.length + otherTraces.length}
             </span>
           </button>
           {otherExpanded && (
             <div className="plan-why-timeline">
+              {activityEvents.map(evt => (
+                <ActivityCard key={evt.event_id} event={evt} />
+              ))}
               {otherTraces.map(trace => (
                 <TraceCard key={trace.trace_id} trace={trace} />
               ))}
@@ -162,6 +165,36 @@ function WhyThisOrder({ buckets = [], traces = [], traceCount = 0, onTraceChainC
           )}
         </>
       )}
+    </div>
+  )
+}
+
+const activityTypeIcons = {
+  work_started: Move,
+  work_completed: CheckCircle,
+  work_failed: AlertTriangle,
+  work_finalized: CheckCircle,
+  pr_created: GitBranch,
+  pr_merged: GitBranch,
+  pr_conflict: AlertTriangle,
+  pr_rebasing: Shuffle,
+  pr_quality_failed: AlertTriangle,
+}
+
+function ActivityCard({ event }) {
+  const Icon = activityTypeIcons[event.event_type] || Move
+  // Parse **bold** markers in description
+  const parts = (event.description || '').split(/\*\*(.*?)\*\*/g)
+
+  return (
+    <div className="plan-trace-card">
+      <div className="plan-trace-time">{formatTimeAgo(event.timestamp)}</div>
+      <div className="plan-trace-content">
+        <div className="plan-trace-type">
+          <Icon size={14} />
+          <span>{parts.map((part, i) => i % 2 === 1 ? <strong key={i}>{part}</strong> : part)}</span>
+        </div>
+      </div>
     </div>
   )
 }

--- a/serving/frontend/src/contexts/ConversationContext.jsx
+++ b/serving/frontend/src/contexts/ConversationContext.jsx
@@ -339,7 +339,16 @@ export function ConversationProvider({ children }) {
         (a, b) => new Date(a.timestamp) - new Date(b.timestamp)
       )
     }
-    return storedMessages
+    // No live messages — show stored messages plus any remote messages
+    // that arrived via WebSocket (e.g. system status updates, integrity
+    // monitor notifications) since page load.
+    if (remoteMessages.length === 0) return storedMessages
+    const storedIds = new Set(storedMessages.map(m => m.id))
+    const newRemote = remoteMessages.filter(m => !storedIds.has(m.id))
+    if (newRemote.length === 0) return storedMessages
+    return [...storedMessages, ...newRemote].sort(
+      (a, b) => new Date(a.timestamp) - new Date(b.timestamp)
+    )
   })()
 
   const value = {

--- a/serving/frontend/src/hooks/useGoals.js
+++ b/serving/frontend/src/hooks/useGoals.js
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { autoProcessGoal, getProcessingStatus } from '../api/goals'
+import useObservability from './useObservability'
 
 /**
  * Workflow steps for goal processing.
@@ -24,11 +25,12 @@ export const PROCESSING_STAGES = {
 
 export const POLL_CONFIG = {
   INITIAL_INTERVAL_MS: 2000,
-  MAX_INTERVAL_MS: 30000,
-  BACKOFF_MULTIPLIER: 1.5,
-  TIMEOUT_MS: 5 * 60 * 1000,          // 5 minutes
-  STALL_THRESHOLD_MS: 2 * 60 * 1000,  // 2 minutes same stage
+  MAX_INTERVAL_MS: 5000,               // 5s cap — active processing, not background
+  BACKOFF_MULTIPLIER: 1.3,
+  STAGE_TIMEOUT_MS: 5 * 60 * 1000,    // 5 minutes per stage before timeout
+  STALL_THRESHOLD_MS: 4 * 60 * 1000,  // 4 minutes same stage before stall warning
   MAX_CONSECUTIVE_ERRORS: 5,
+  RESET_INTERVAL_MS: 2000,            // Reset to this on stage change
 }
 
 /**
@@ -51,6 +53,9 @@ function useGoals() {
   const lastStageChangeRef = useRef(null)
   const lastStageRef = useRef(null)
   const consecutiveErrorsRef = useRef(0)
+
+  // WebSocket for real-time stage updates (push)
+  const { latestEvent } = useObservability({ autoConnect: true })
 
   /**
    * Stop polling for processing status.
@@ -75,20 +80,20 @@ function useGoals() {
     setIsTimedOut(false)
     setIsStalled(false)
 
-    const schedulePoll = (interval) => {
-      pollTimeoutRef.current = setTimeout(async () => {
-        const elapsed = Date.now() - pollingStartRef.current
+    let currentInterval = POLL_CONFIG.INITIAL_INTERVAL_MS
 
-        // Check timeout
-        if (elapsed >= POLL_CONFIG.TIMEOUT_MS) {
+    const schedulePoll = () => {
+      pollTimeoutRef.current = setTimeout(async () => {
+        // Per-stage timeout: reset clock on each stage change
+        const sinceStageChange = Date.now() - lastStageChangeRef.current
+        if (sinceStageChange >= POLL_CONFIG.STAGE_TIMEOUT_MS) {
           stopPolling()
           setIsTimedOut(true)
           setLoading(false)
           return
         }
 
-        // Check stall (same stage for too long)
-        const sinceStageChange = Date.now() - lastStageChangeRef.current
+        // Stall warning (stage not changing for a while)
         if (sinceStageChange >= POLL_CONFIG.STALL_THRESHOLD_MS) {
           setIsStalled(true)
         }
@@ -97,10 +102,11 @@ function useGoals() {
           const status = await getProcessingStatus(goalId)
           consecutiveErrorsRef.current = 0
 
-          // Track stage changes for stall detection
+          // Track stage changes — reset interval for fast transition detection
           if (status.stage !== lastStageRef.current) {
             lastStageRef.current = status.stage
             lastStageChangeRef.current = Date.now()
+            currentInterval = POLL_CONFIG.RESET_INTERVAL_MS
             setIsStalled(false)
           }
 
@@ -141,22 +147,67 @@ function useGoals() {
           }
         }
 
-        // Schedule next poll with backoff
-        const nextInterval = Math.min(
-          interval * POLL_CONFIG.BACKOFF_MULTIPLIER,
+        // Gentle backoff capped at 5s, resets on stage change
+        currentInterval = Math.min(
+          currentInterval * POLL_CONFIG.BACKOFF_MULTIPLIER,
           POLL_CONFIG.MAX_INTERVAL_MS
         )
-        schedulePoll(nextInterval)
-      }, interval)
+        schedulePoll()
+      }, currentInterval)
     }
 
-    schedulePoll(POLL_CONFIG.INITIAL_INTERVAL_MS)
+    schedulePoll()
   }, [stopPolling])
 
   // Clean up polling on unmount
   useEffect(() => {
     return () => stopPolling()
   }, [stopPolling])
+
+  // Handle real-time push events from WebSocket (goal_processing_stage)
+  const lastPushEventRef = useRef(null)
+  useEffect(() => {
+    if (!latestEvent || latestEvent === lastPushEventRef.current) return
+    lastPushEventRef.current = latestEvent
+
+    if (latestEvent.type !== 'goal_processing_stage') return
+
+    const eventData = latestEvent.data
+    const goalId = currentGoalIdRef.current
+    if (!goalId || eventData?.goal_id !== goalId) return
+
+    const stage = eventData.stage
+
+    // Update stage tracking refs (same as polling path)
+    if (stage !== lastStageRef.current) {
+      lastStageRef.current = stage
+      lastStageChangeRef.current = Date.now()
+      setIsStalled(false)
+    }
+
+    setProcessingStage(stage)
+
+    if (stage === PROCESSING_STAGES.COMPLETE) {
+      // Complete needs result data — trigger one final poll to get it
+      // (the push event doesn't carry the full result payload)
+      getProcessingStatus(goalId).then(status => {
+        stopPolling()
+        setExecutionResult(status.result)
+        setStep(WORKFLOW_STEPS.COMPLETE)
+        setLoading(false)
+      }).catch(() => {
+        // Fallback: mark complete without result
+        stopPolling()
+        setStep(WORKFLOW_STEPS.COMPLETE)
+        setLoading(false)
+      })
+    } else if (stage === PROCESSING_STAGES.FAILED) {
+      stopPolling()
+      setError(eventData.error || 'Processing failed')
+      setStep(WORKFLOW_STEPS.INPUT)
+      setLoading(false)
+    }
+  }, [latestEvent, stopPolling])
 
   /**
    * Auto-process a goal: fires async request, then polls for status.

--- a/serving/frontend/src/hooks/useGoals.test.js
+++ b/serving/frontend/src/hooks/useGoals.test.js
@@ -154,7 +154,7 @@ describe('useGoals', () => {
     // We need to advance through each polling interval to trigger the timeout check
     let elapsed = 0
     let interval = POLL_CONFIG.INITIAL_INTERVAL_MS
-    while (elapsed < POLL_CONFIG.TIMEOUT_MS + POLL_CONFIG.MAX_INTERVAL_MS) {
+    while (elapsed < POLL_CONFIG.STAGE_TIMEOUT_MS + POLL_CONFIG.MAX_INTERVAL_MS) {
       await act(async () => {
         vi.advanceTimersByTime(interval)
       })
@@ -270,7 +270,7 @@ describe('useGoals', () => {
     // Advance to timeout
     let elapsed = 0
     let interval = POLL_CONFIG.INITIAL_INTERVAL_MS
-    while (elapsed < POLL_CONFIG.TIMEOUT_MS + POLL_CONFIG.MAX_INTERVAL_MS) {
+    while (elapsed < POLL_CONFIG.STAGE_TIMEOUT_MS + POLL_CONFIG.MAX_INTERVAL_MS) {
       await act(async () => {
         vi.advanceTimersByTime(interval)
       })
@@ -400,10 +400,11 @@ describe('useGoals', () => {
 
   it('exports POLL_CONFIG for external use', () => {
     expect(POLL_CONFIG.INITIAL_INTERVAL_MS).toBe(2000)
-    expect(POLL_CONFIG.MAX_INTERVAL_MS).toBe(30000)
-    expect(POLL_CONFIG.BACKOFF_MULTIPLIER).toBe(1.5)
-    expect(POLL_CONFIG.TIMEOUT_MS).toBe(300000)
-    expect(POLL_CONFIG.STALL_THRESHOLD_MS).toBe(120000)
+    expect(POLL_CONFIG.MAX_INTERVAL_MS).toBe(5000)
+    expect(POLL_CONFIG.BACKOFF_MULTIPLIER).toBe(1.3)
+    expect(POLL_CONFIG.STAGE_TIMEOUT_MS).toBe(300000)
+    expect(POLL_CONFIG.STALL_THRESHOLD_MS).toBe(240000)
     expect(POLL_CONFIG.MAX_CONSECUTIVE_ERRORS).toBe(5)
+    expect(POLL_CONFIG.RESET_INTERVAL_MS).toBe(2000)
   })
 })

--- a/serving/frontend/src/hooks/useObservability.js
+++ b/serving/frontend/src/hooks/useObservability.js
@@ -32,7 +32,8 @@ function useObservability(options = {}) {
         'work_status_change',
         'compute_registered',
         'compute_deregistered',
-        'comment_evaluation_status'
+        'comment_evaluation_status',
+        'goal_processing_stage'
       ]
 
       eventTypes.forEach(eventType => {

--- a/serving/frontend/src/pages/ExecutionPlanPage.css
+++ b/serving/frontend/src/pages/ExecutionPlanPage.css
@@ -24,6 +24,75 @@
   margin-left: auto;
 }
 
+/* Pause Button */
+.plan-pause-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  transition: all 0.15s ease;
+}
+
+.plan-pause-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.plan-pause-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.plan-pause-btn--paused {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.plan-pause-btn--paused:hover {
+  background: rgba(99, 102, 241, 0.15);
+}
+
+/* Paused Banner */
+.plan-paused-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: rgba(234, 179, 8, 0.08);
+  border: 1px solid rgba(234, 179, 8, 0.3);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--space-md);
+}
+
+.plan-paused-banner svg {
+  color: rgb(234, 179, 8);
+  flex-shrink: 0;
+}
+
+.plan-paused-resume {
+  margin-left: auto;
+  padding: 2px 10px;
+  border: 1px solid rgba(234, 179, 8, 0.4);
+  background: transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+}
+
+.plan-paused-resume:hover {
+  background: rgba(234, 179, 8, 0.12);
+}
+
 /* View Toggle */
 .plan-view-toggle {
   display: flex;

--- a/serving/frontend/src/pages/ExecutionPlanPage.jsx
+++ b/serving/frontend/src/pages/ExecutionPlanPage.jsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { FolderOpen, List, Layers, Network } from 'lucide-react'
+import { useState, useEffect, useCallback } from 'react'
+import { FolderOpen, List, Layers, Network, Pause, Play } from 'lucide-react'
 import SummaryBar from '../components/plan/SummaryBar'
 import ProfileSwitcher from '../components/plan/ProfileSwitcher'
 import ActiveWorkView from '../components/plan/ActiveWorkView'
@@ -15,6 +15,7 @@ import usePlanSummary from '../hooks/usePlanSummary'
 import useBucketTree from '../hooks/useBucketTree'
 import useCharacterizationStatuses from '../hooks/useCharacterizationStatuses'
 import { useProjectContext } from '../contexts/ProjectContext'
+import { getOrchestratorStatus, pauseOrchestrator, resumeOrchestrator } from '../api/orchestrator'
 import './ExecutionPlanPage.css'
 
 function ExecutionPlanPage() {
@@ -23,6 +24,38 @@ function ExecutionPlanPage() {
   const [selectedIssue, setSelectedIssue] = useState(null)
   const [tracesItem, setTracesItem] = useState(null)
   const [viewMode, setViewMode] = useState('list')
+  const [paused, setPaused] = useState(false)
+  const [pauseLoading, setPauseLoading] = useState(false)
+
+  // Fetch pause state on mount and periodically
+  useEffect(() => {
+    let cancelled = false
+    const fetchStatus = () => {
+      getOrchestratorStatus()
+        .then(status => { if (!cancelled) setPaused(!!status?.paused) })
+        .catch(() => {})
+    }
+    fetchStatus()
+    const interval = setInterval(fetchStatus, 15000)
+    return () => { cancelled = true; clearInterval(interval) }
+  }, [])
+
+  const togglePause = useCallback(async () => {
+    setPauseLoading(true)
+    try {
+      if (paused) {
+        await resumeOrchestrator()
+        setPaused(false)
+      } else {
+        await pauseOrchestrator()
+        setPaused(true)
+      }
+    } catch (err) {
+      console.warn('Failed to toggle pause:', err)
+    } finally {
+      setPauseLoading(false)
+    }
+  }, [paused])
 
   const {
     data,
@@ -83,6 +116,15 @@ function ExecutionPlanPage() {
               activePresetColor={data?.active_preset_color}
               onPresetChange={refresh}
             />
+            <button
+              className={`plan-pause-btn ${paused ? 'plan-pause-btn--paused' : ''}`}
+              onClick={togglePause}
+              disabled={pauseLoading}
+              title={paused ? 'Resume work dispatch' : 'Pause work dispatch'}
+            >
+              {paused ? <Play size={14} /> : <Pause size={14} />}
+              <span>{paused ? 'Resume' : 'Pause'}</span>
+            </button>
             <div className="plan-view-toggle">
               <button
                 className={`plan-view-btn ${viewMode === 'list' ? 'plan-view-btn--active' : ''}`}
@@ -122,6 +164,16 @@ function ExecutionPlanPage() {
       </InlineHint>
 
       <SummaryBar data={data} loading={loading} />
+
+      {paused && (
+        <div className="plan-paused-banner">
+          <Pause size={14} />
+          <span>Work dispatch is paused. In-flight work will complete, but no new work will be assigned.</span>
+          <button className="plan-paused-resume" onClick={togglePause} disabled={pauseLoading}>
+            Resume
+          </button>
+        </div>
+      )}
 
       <CharacterizationBanner statusMap={charStatusMap} loading={charLoading} />
 

--- a/serving/frontend/src/pages/ExecutionPlanPage.jsx
+++ b/serving/frontend/src/pages/ExecutionPlanPage.jsx
@@ -203,6 +203,7 @@ function ExecutionPlanPage() {
         buckets={bucketList}
         traces={data?.recent_traces || []}
         traceCount={data?.trace_count || 0}
+        activityEvents={data?.activity_events || []}
       />
 
       {tracesItem && (

--- a/serving/middleware/cognito_middleware.py
+++ b/serving/middleware/cognito_middleware.py
@@ -34,7 +34,8 @@ PUBLIC_PATH_PREFIXES = (
     "/api/v1/auth/token",            # Claude token management (internal)
     "/api/v1/auth/cognito-config",   # Frontend Cognito config (needed before auth)
     "/api/v1/auth/status",           # Auth status check
-    "/api/v1/marketplace/register",  # Marketplace registration
+    "/api/v1/marketplaces/register",  # Marketplace registration
+    "/api/v1/marketplaces/marketplace-",  # Marketplace heartbeat/status (service-to-service)
     "/api/v1/users/login",           # User login (local auth mode)
     "/api/v1/users/register",        # User registration (local auth mode)
     "/api/v1/releases",              # Release notes (public, non-sensitive)

--- a/serving/models/observability.py
+++ b/serving/models/observability.py
@@ -33,6 +33,7 @@ class EventType(str, Enum):
     DECISION_TRACE = "decision_trace"
     COMPUTE_REGISTERED = "compute_registered"
     COMPUTE_DEREGISTERED = "compute_deregistered"
+    GOAL_PROCESSING_STAGE = "goal_processing_stage"
 
 
 class ActivityStateChangeEvent(BaseModel):
@@ -482,6 +483,29 @@ class ComputeDeregisteredEvent(BaseModel):
     })
 
 
+class GoalProcessingStageEvent(BaseModel):
+    """Event emitted when goal processing stage changes (decomposing, characterizing, etc.)."""
+    event_type: str = Field(default=EventType.GOAL_PROCESSING_STAGE, description="Event type")
+    event_id: str = Field(..., description="Unique event identifier")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="When event occurred")
+
+    # Broadcast to all subscribers (global, not session-scoped)
+    session_id: str = Field(default="global", description="Global session for broadcast")
+    goal_id: str = Field(..., description="Goal being processed")
+    project_id: Optional[str] = Field(None, description="Project ID")
+
+    # Stage info
+    stage: str = Field(..., description="Current processing stage")
+    previous_stage: Optional[str] = Field(None, description="Previous stage (None for first)")
+
+    # Optional result payload (on completion)
+    error: Optional[str] = Field(None, description="Error message if failed")
+
+    model_config = ConfigDict(json_encoders={
+        datetime: lambda v: v.isoformat() if v else None
+    })
+
+
 # Union type for all event types
 ObservabilityEvent = Union[
     ActivityStateChangeEvent,
@@ -499,7 +523,8 @@ ObservabilityEvent = Union[
     IssueEvaluationStatusEvent,
     DecisionTraceEvent,
     ComputeRegisteredEvent,
-    ComputeDeregisteredEvent
+    ComputeDeregisteredEvent,
+    GoalProcessingStageEvent
 ]
 
 

--- a/serving/models/project.py
+++ b/serving/models/project.py
@@ -225,9 +225,12 @@ class ActivityEventType(str, Enum):
     BRANCH_CREATED = "branch_created"
     BRANCH_MERGED = "branch_merged"
     COMPUTE_ASSIGNED = "compute_assigned"
+    PR_CREATED = "pr_created"
     PR_MERGED = "pr_merged"
     PR_CONFLICT = "pr_conflict"
     PR_REBASING = "pr_rebasing"
+    PR_QUALITY_FAILED = "pr_quality_failed"
+    WORK_FINALIZED = "work_finalized"
 
 
 class ActivityEvent(BaseModel):

--- a/serving/models/project.py
+++ b/serving/models/project.py
@@ -225,6 +225,9 @@ class ActivityEventType(str, Enum):
     BRANCH_CREATED = "branch_created"
     BRANCH_MERGED = "branch_merged"
     COMPUTE_ASSIGNED = "compute_assigned"
+    PR_MERGED = "pr_merged"
+    PR_CONFLICT = "pr_conflict"
+    PR_REBASING = "pr_rebasing"
 
 
 class ActivityEvent(BaseModel):

--- a/serving/services/conversation_service.py
+++ b/serving/services/conversation_service.py
@@ -111,8 +111,10 @@ class ConversationService:
 
         await self._broadcast_message(msg)
 
-        # Notify AI agent (fire-and-forget, never blocks message delivery)
-        if self._message_listener:
+        # Notify AI agent (fire-and-forget, never blocks message delivery).
+        # Only for user messages — system/status messages should not trigger
+        # AI review as they create chat clutter.
+        if self._message_listener and type == "user":
             try:
                 logger.info(f"Notifying AI agent for {project_id} (type={type}, user={user_id})")
                 asyncio.create_task(
@@ -120,8 +122,6 @@ class ConversationService:
                 )
             except Exception as e:
                 logger.warning(f"Message listener notification failed: {e}")
-        else:
-            logger.debug(f"No message listener registered, skipping AI agent notification")
 
         return msg
 

--- a/serving/services/decomposition_validation_service.py
+++ b/serving/services/decomposition_validation_service.py
@@ -1,0 +1,296 @@
+"""Decomposition Validation Service.
+
+Validates goal decomposition results before issue creation:
+- Circular dependency detection
+- temp_id reference validation (all blocked_by refs exist)
+- Duplicate temp_id detection
+- Scope checks (empty issues, missing fields)
+
+Called after decompose_goal() returns and before map_to_issue_models().
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+from models.goal_decomposer import DecomposedIssue, GoalDecompositionResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ValidationIssue:
+    """A single validation problem found in a decomposition."""
+    severity: str  # "error" or "warning"
+    issue_temp_id: Optional[str]  # Which issue has the problem (None if global)
+    code: str  # Machine-readable code (e.g., "circular_dependency")
+    message: str  # Human-readable description
+
+
+@dataclass
+class DecompositionValidationResult:
+    """Result of validating a decomposition."""
+    valid: bool
+    issues: List[ValidationIssue] = field(default_factory=list)
+    fixed_result: Optional[GoalDecompositionResult] = None
+
+    @property
+    def errors(self) -> List[ValidationIssue]:
+        return [i for i in self.issues if i.severity == "error"]
+
+    @property
+    def warnings(self) -> List[ValidationIssue]:
+        return [i for i in self.issues if i.severity == "warning"]
+
+
+def validate_decomposition(
+    result: GoalDecompositionResult,
+    auto_fix: bool = True,
+) -> DecompositionValidationResult:
+    """Validate a GoalDecompositionResult for structural issues.
+
+    Args:
+        result: The decomposition result to validate
+        auto_fix: If True, attempt to fix issues and return fixed_result
+
+    Returns:
+        DecompositionValidationResult with validation findings
+    """
+    issues: List[ValidationIssue] = []
+
+    if not result.issues:
+        return DecompositionValidationResult(valid=True, issues=[])
+
+    # Collect all temp_ids
+    temp_ids: Set[str] = set()
+    temp_id_counts: Dict[str, int] = {}
+    for di in result.issues:
+        temp_id_counts[di.temp_id] = temp_id_counts.get(di.temp_id, 0) + 1
+        temp_ids.add(di.temp_id)
+
+    # 1. Duplicate temp_id detection
+    for tid, count in temp_id_counts.items():
+        if count > 1:
+            issues.append(ValidationIssue(
+                severity="error",
+                issue_temp_id=tid,
+                code="duplicate_temp_id",
+                message=f"temp_id '{tid}' appears {count} times",
+            ))
+
+    # 2. Invalid blocked_by references
+    for di in result.issues:
+        for dep in di.blocked_by:
+            if dep not in temp_ids:
+                issues.append(ValidationIssue(
+                    severity="error",
+                    issue_temp_id=di.temp_id,
+                    code="invalid_dependency_ref",
+                    message=f"'{di.temp_id}' depends on '{dep}' which does not exist",
+                ))
+
+    # 3. Self-references
+    for di in result.issues:
+        if di.temp_id in di.blocked_by:
+            issues.append(ValidationIssue(
+                severity="error",
+                issue_temp_id=di.temp_id,
+                code="self_dependency",
+                message=f"'{di.temp_id}' depends on itself",
+            ))
+
+    # 4. Circular dependency detection (DFS)
+    cycles = _detect_cycles(result.issues)
+    for cycle in cycles:
+        cycle_str = " -> ".join(cycle)
+        issues.append(ValidationIssue(
+            severity="error",
+            issue_temp_id=cycle[0],
+            code="circular_dependency",
+            message=f"Circular dependency: {cycle_str}",
+        ))
+
+    # 5. Scope warnings
+    for di in result.issues:
+        if not di.title.strip():
+            issues.append(ValidationIssue(
+                severity="error",
+                issue_temp_id=di.temp_id,
+                code="empty_title",
+                message=f"'{di.temp_id}' has an empty title",
+            ))
+        if not di.description.strip():
+            issues.append(ValidationIssue(
+                severity="warning",
+                issue_temp_id=di.temp_id,
+                code="empty_description",
+                message=f"'{di.temp_id}' has an empty description",
+            ))
+        if not di.acceptance_criteria:
+            issues.append(ValidationIssue(
+                severity="warning",
+                issue_temp_id=di.temp_id,
+                code="no_acceptance_criteria",
+                message=f"'{di.temp_id}' has no acceptance criteria",
+            ))
+
+    has_errors = any(i.severity == "error" for i in issues)
+
+    validation_result = DecompositionValidationResult(
+        valid=not has_errors,
+        issues=issues,
+    )
+
+    # Auto-fix: remove invalid dependency refs and self-refs
+    if auto_fix and issues:
+        fixed = _auto_fix(result, temp_ids)
+        if fixed:
+            validation_result.fixed_result = fixed
+            logger.info(
+                f"Auto-fixed decomposition {result.decomposition_id}: "
+                f"resolved {len(issues)} issue(s)"
+            )
+
+    if issues:
+        error_count = len(validation_result.errors)
+        warn_count = len(validation_result.warnings)
+        logger.warning(
+            f"Decomposition {result.decomposition_id} validation: "
+            f"{error_count} error(s), {warn_count} warning(s)"
+        )
+
+    return validation_result
+
+
+def _detect_cycles(issues: List[DecomposedIssue]) -> List[List[str]]:
+    """Detect circular dependencies using DFS.
+
+    Returns:
+        List of cycles, each cycle is a list of temp_ids forming the loop
+    """
+    # Build adjacency: node -> list of nodes it depends on
+    graph: Dict[str, List[str]] = {}
+    valid_ids = {di.temp_id for di in issues}
+
+    for di in issues:
+        # Only include valid refs (skip missing ones, they're caught separately)
+        graph[di.temp_id] = [dep for dep in di.blocked_by if dep in valid_ids]
+
+    cycles: List[List[str]] = []
+    visited: Set[str] = set()
+    in_stack: Set[str] = set()
+    path: List[str] = []
+
+    def dfs(node: str) -> None:
+        if node in in_stack:
+            # Found a cycle — extract it
+            cycle_start = path.index(node)
+            cycle = path[cycle_start:] + [node]
+            cycles.append(cycle)
+            return
+        if node in visited:
+            return
+
+        visited.add(node)
+        in_stack.add(node)
+        path.append(node)
+
+        for dep in graph.get(node, []):
+            dfs(dep)
+
+        path.pop()
+        in_stack.remove(node)
+
+    for node in graph:
+        if node not in visited:
+            dfs(node)
+
+    return cycles
+
+
+def _auto_fix(
+    result: GoalDecompositionResult,
+    valid_ids: Set[str],
+) -> Optional[GoalDecompositionResult]:
+    """Attempt to auto-fix a decomposition by removing invalid references.
+
+    Fixes:
+    - Removes blocked_by refs to non-existent temp_ids
+    - Removes self-references from blocked_by
+    - Breaks circular dependencies by removing the back-edge
+
+    Returns:
+        Fixed GoalDecompositionResult, or None if no fixable issues
+    """
+    changed = False
+    fixed_issues: List[DecomposedIssue] = []
+
+    for di in result.issues:
+        new_blocked_by = []
+        for dep in di.blocked_by:
+            if dep == di.temp_id:
+                changed = True  # Remove self-ref
+                continue
+            if dep not in valid_ids:
+                changed = True  # Remove invalid ref
+                continue
+            new_blocked_by.append(dep)
+
+        if new_blocked_by != di.blocked_by:
+            fixed_issues.append(di.model_copy(update={"blocked_by": new_blocked_by}))
+        else:
+            fixed_issues.append(di.model_copy())
+
+    # Break cycles by removing back-edges
+    cycles = _detect_cycles(fixed_issues)
+    if cycles:
+        changed = True
+        # Build a set of edges to remove (last edge in each cycle)
+        edges_to_remove: Set[tuple] = set()
+        for cycle in cycles:
+            # Remove the back-edge: last node depends on first
+            edges_to_remove.add((cycle[-2], cycle[0]))
+
+        final_issues = []
+        for di in fixed_issues:
+            new_blocked = [
+                dep for dep in di.blocked_by
+                if (di.temp_id, dep) not in edges_to_remove
+            ]
+            if new_blocked != di.blocked_by:
+                final_issues.append(di.model_copy(update={"blocked_by": new_blocked}))
+            else:
+                final_issues.append(di)
+        fixed_issues = final_issues
+
+    if not changed:
+        return None
+
+    return result.model_copy(update={"issues": fixed_issues})
+
+
+# Module-level singleton
+_service: Optional["DecompositionValidationService"] = None
+
+
+class DecompositionValidationService:
+    """Service wrapper for decomposition validation.
+
+    Provides the singleton pattern consistent with other services.
+    """
+
+    def validate(
+        self,
+        result: GoalDecompositionResult,
+        auto_fix: bool = True,
+    ) -> DecompositionValidationResult:
+        """Validate a decomposition result."""
+        return validate_decomposition(result, auto_fix=auto_fix)
+
+
+def get_decomposition_validation_service() -> DecompositionValidationService:
+    """Get the singleton DecompositionValidationService."""
+    global _service
+    if _service is None:
+        _service = DecompositionValidationService()
+    return _service

--- a/serving/services/goal_decomposer.py
+++ b/serving/services/goal_decomposer.py
@@ -148,6 +148,25 @@ class GoalDecomposerService:
             goal_id=goal_id,
         )
 
+        # Validate decomposition structure before proceeding
+        from services.decomposition_validation_service import (
+            get_decomposition_validation_service,
+        )
+        validator = get_decomposition_validation_service()
+        validation = validator.validate(result, auto_fix=True)
+
+        if not validation.valid and validation.fixed_result:
+            logger.info(
+                f"Using auto-fixed decomposition for goal {goal_id} "
+                f"({len(validation.errors)} error(s) fixed)"
+            )
+            result = validation.fixed_result
+        elif not validation.valid:
+            logger.warning(
+                f"Decomposition for goal {goal_id} has unfixable errors: "
+                + "; ".join(e.message for e in validation.errors[:5])
+            )
+
         logger.info(
             f"Decomposed goal {goal_id} into {len(result.issues)} issues "
             f"with confidence {result.confidence:.2f}"

--- a/serving/services/lead_compute_service.py
+++ b/serving/services/lead_compute_service.py
@@ -1,0 +1,336 @@
+"""Lead Compute Service.
+
+Orchestrates PR review by a dedicated lead compute instance before
+merge approval. The lead reviewer checks for:
+- Cross-module consistency (imports, config, API contracts)
+- Missing migrations or seed data
+- Coding convention adherence
+- Integration issues that individual modules can't see
+
+The review is dispatched to a compute instance with the lead-reviewer
+skill and returns structured feedback (approve/request-changes).
+"""
+
+import asyncio
+import json
+import logging
+import uuid
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Timeout for lead review (3 minutes)
+REVIEW_TIMEOUT_SECONDS = 180
+
+
+class LeadReviewResult:
+    """Result of a lead compute review."""
+
+    def __init__(
+        self,
+        approved: bool,
+        reviewer_id: str,
+        summary: str = "",
+        issues: list[Dict[str, str]] | None = None,
+    ):
+        self.approved = approved
+        self.reviewer_id = reviewer_id
+        self.summary = summary
+        self.issues = issues or []
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "approved": self.approved,
+            "reviewer_id": self.reviewer_id,
+            "summary": self.summary,
+            "issues": self.issues,
+        }
+
+
+class LeadComputeService:
+    """Service that manages lead compute PR reviews.
+
+    Dispatches review work to an idle compute instance with the
+    lead-reviewer skill, waits for the result, and returns a
+    structured review decision.
+    """
+
+    def __init__(self, timeout: int = REVIEW_TIMEOUT_SECONDS):
+        self._timeout = timeout
+        self._enabled = True
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        self._enabled = value
+
+    async def review_pr(
+        self,
+        project: str,
+        branch: str,
+        compute_id: str,
+        work_title: str = "",
+        work_description: str = "",
+        project_id: str = "",
+    ) -> LeadReviewResult:
+        """Request a lead compute review of a PR.
+
+        Dispatches the review to an idle compute instance with the
+        lead-reviewer skill. If no compute is available or review
+        times out, auto-approves to avoid blocking the pipeline.
+
+        Args:
+            project: Git project name
+            branch: Branch being reviewed
+            compute_id: Compute that created the PR (excluded from review)
+            work_title: Title of the work for context
+            work_description: Description of the work
+            project_id: Project ID for context enrichment
+
+        Returns:
+            LeadReviewResult with approval decision
+        """
+        if not self._enabled:
+            return LeadReviewResult(
+                approved=True,
+                reviewer_id="lead-review-disabled",
+                summary="Lead review is disabled",
+            )
+
+        review_id = f"lead-review-{uuid.uuid4().hex[:12]}"
+
+        logger.info(
+            f"Requesting lead review {review_id} for {project}/{branch}"
+        )
+
+        # Build review task context
+        task_context = self._build_review_context(
+            review_id=review_id,
+            project=project,
+            branch=branch,
+            work_title=work_title,
+            work_description=work_description,
+        )
+
+        # Try to dispatch to an idle compute
+        try:
+            result = await self._dispatch_review(
+                review_id=review_id,
+                task_context=task_context,
+                exclude_compute_id=compute_id,
+                project_id=project_id,
+            )
+            return result
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Lead review {review_id} timed out after {self._timeout}s, "
+                "auto-approving"
+            )
+            return LeadReviewResult(
+                approved=True,
+                reviewer_id="lead-review-timeout",
+                summary=f"Review timed out after {self._timeout}s, auto-approved",
+            )
+        except Exception as e:
+            logger.warning(
+                f"Lead review {review_id} failed: {e}, auto-approving"
+            )
+            return LeadReviewResult(
+                approved=True,
+                reviewer_id="lead-review-error",
+                summary=f"Review dispatch failed: {e}",
+            )
+
+    def _build_review_context(
+        self,
+        review_id: str,
+        project: str,
+        branch: str,
+        work_title: str = "",
+        work_description: str = "",
+    ) -> str:
+        """Build the task context for the lead reviewer compute."""
+        return f"""# Lead PR Review Task
+
+## Assignment Details
+- **Review ID:** {review_id}
+- **Project:** {project}
+- **Branch:** {branch}
+- **Work Title:** {work_title}
+
+## Work Description
+{work_description or 'No description provided.'}
+
+## Your Task
+Review the changes on branch `{branch}` in project `{project}`.
+
+Check for:
+1. **Import correctness** — Are all imports valid? Any missing dependencies?
+2. **Config completeness** — Are environment variables and config keys defined?
+3. **Consistency** — Do patterns match existing codebase conventions?
+4. **Missing pieces** — Any missing migrations, seed data, or initialization?
+5. **API contract alignment** — Do interfaces match between modules?
+
+## Output
+Submit your review using `claudevn_submit_review` with:
+- review_id: "{review_id}"
+- approved: true/false
+- summary: Brief summary of your findings
+- issues: Array of {{severity, file, message}} for any problems found
+"""
+
+    async def _dispatch_review(
+        self,
+        review_id: str,
+        task_context: str,
+        exclude_compute_id: str = "",
+        project_id: str = "",
+    ) -> LeadReviewResult:
+        """Dispatch review to an idle compute instance.
+
+        Uses the SSE connection manager to find an idle compute and
+        the completion event system to wait for the result.
+
+        Args:
+            review_id: Unique review identifier
+            task_context: Review task description
+            exclude_compute_id: Compute to exclude (PR author)
+            project_id: Project ID for routing
+
+        Returns:
+            LeadReviewResult from the compute
+        """
+        from services.completion_events import create_event, get_event, cleanup as cleanup_event
+
+        # Register completion event
+        create_event(review_id)
+
+        try:
+            # Find an idle compute (exclude the PR author)
+            from services.sse_connection_manager import get_sse_connection_manager
+            sse_manager = get_sse_connection_manager()
+
+            connection = sse_manager.find_matching_connection(
+                idle_only=True,
+                phase="review",
+                exclude_compute_ids={exclude_compute_id} if exclude_compute_id else None,
+            )
+
+            if not connection:
+                logger.info(
+                    f"No idle compute available for lead review {review_id}, "
+                    "auto-approving"
+                )
+                return LeadReviewResult(
+                    approved=True,
+                    reviewer_id="no-reviewer-available",
+                    summary="No idle compute available for review",
+                )
+
+            # Get lead-reviewer skill instructions
+            skill_instructions = await self._get_reviewer_skill_instructions()
+
+            # Generate API key for review task
+            from mcp.auth import generate_api_key, register_compute_key
+            task_api_key = generate_api_key()
+            await register_compute_key(connection.compute_id, task_api_key)
+
+            mcp_config = {
+                "server_url": "http://serving:8002",
+                "api_key": task_api_key,
+            }
+
+            # Send review work to compute
+            success = await sse_manager.send_work_assigned(
+                compute_id=connection.compute_id,
+                task_id=review_id,
+                title=f"Lead PR Review {review_id}",
+                description=task_context,
+                branch_name="",
+                skills={
+                    "ids": ["lead-reviewer"],
+                    "merged_instructions": skill_instructions,
+                },
+                context={
+                    "review_id": review_id,
+                    "task_type": "review",
+                    "project_id": project_id,
+                },
+                mcp_config=mcp_config,
+            )
+
+            if not success:
+                return LeadReviewResult(
+                    approved=True,
+                    reviewer_id="dispatch-failed",
+                    summary="Failed to dispatch review to compute",
+                )
+
+            logger.info(
+                f"Lead review {review_id} dispatched to compute {connection.compute_id}"
+            )
+
+            # Wait for result
+            event = get_event(review_id)
+            await asyncio.wait_for(event.wait(), timeout=self._timeout)
+
+            # Fetch result from Redis
+            from git.redis_client import get_redis
+            redis = await get_redis()
+            result_data = await redis.get(f"claudevn:review:{review_id}")
+
+            if not result_data:
+                return LeadReviewResult(
+                    approved=True,
+                    reviewer_id=connection.compute_id,
+                    summary="Review completed but no result found",
+                )
+
+            data = json.loads(result_data)
+            return LeadReviewResult(
+                approved=data.get("approved", True),
+                reviewer_id=connection.compute_id,
+                summary=data.get("summary", ""),
+                issues=data.get("issues", []),
+            )
+
+        finally:
+            cleanup_event(review_id)
+
+    async def _get_reviewer_skill_instructions(self) -> str:
+        """Get lead-reviewer skill instructions from marketplace."""
+        try:
+            from services.marketplace_client import get_marketplace_client
+            client = get_marketplace_client()
+            skill = await client.get_skill("lead-reviewer")
+            if skill and skill.get("instructions"):
+                return skill["instructions"]
+        except Exception as e:
+            logger.debug(f"Could not fetch lead-reviewer skill: {e}")
+
+        return """# Lead Reviewer
+You are reviewing a PR for consistency and correctness.
+Check imports, config, conventions, and cross-module integration.
+Submit your review using claudevn_submit_review.
+"""
+
+
+# Module-level singleton
+_service: Optional[LeadComputeService] = None
+
+
+def get_lead_compute_service() -> LeadComputeService:
+    """Get the singleton LeadComputeService."""
+    global _service
+    if _service is None:
+        _service = LeadComputeService()
+    return _service
+
+
+def set_lead_compute_service(service: LeadComputeService) -> None:
+    """Set the singleton LeadComputeService."""
+    global _service
+    _service = service

--- a/serving/services/observability_event_bus.py
+++ b/serving/services/observability_event_bus.py
@@ -176,7 +176,8 @@ class ObservabilityEventBus:
             event: Event to broadcast
         """
         # For work status events, comment evaluation events, and compute events, broadcast to ALL subscribers
-        if isinstance(event, (WorkStatusChangeEvent, CommentEvaluationStatusEvent, ComputeRegisteredEvent, ComputeDeregisteredEvent)):
+        from models.observability import GoalProcessingStageEvent
+        if isinstance(event, (WorkStatusChangeEvent, CommentEvaluationStatusEvent, ComputeRegisteredEvent, ComputeDeregisteredEvent, GoalProcessingStageEvent)):
             await self._broadcast_to_all(event)
             return
 

--- a/serving/services/project_service.py
+++ b/serving/services/project_service.py
@@ -651,6 +651,34 @@ class ProjectService:
         )
         return event
 
+    async def get_recent_activity(
+        self,
+        project_id: str,
+        limit: int = 20,
+    ) -> List[ActivityEvent]:
+        """Get recent activity events for a project."""
+        # Try in-memory first
+        events = self._activity_events.get(project_id, [])
+        if events:
+            return list(reversed(events[-limit:]))
+
+        # Fall back to Redis
+        if self._redis:
+            try:
+                key = f"project:{project_id}:events"
+                raw_events = await self._redis._redis.lrange(key, 0, limit - 1)
+                result = []
+                for raw in raw_events:
+                    try:
+                        result.append(ActivityEvent.model_validate_json(raw))
+                    except Exception:
+                        continue
+                return result
+            except Exception as e:
+                logger.warning(f"Failed to read activity events from Redis: {e}")
+
+        return []
+
     async def update_project_activity(
         self,
         project_id: str

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -13,6 +13,8 @@ Checks (run every sweep cycle):
   5. Stale high-progress work on disconnected computes
   6. Pipeline stalls (READY issues or PENDING work with idle computes)
   7. Orphaned work assigned to disconnected computes
+  8. Failed work items whose parent issue is still IN_PROGRESS
+  9. Goals stuck in PLANNING (decomposition may have failed)
 """
 
 import asyncio
@@ -38,6 +40,8 @@ COOLDOWNS = {
     "stale_high_progress": 300,
     "pipeline_stall": 120,
     "orphaned_work": 120,
+    "failed_work_impact": 180,
+    "stuck_planning_goal": 300,
 }
 
 # How many consecutive detections before escalating notification to ERROR
@@ -163,6 +167,8 @@ class SystemIntegrityMonitor:
             self._check_stale_high_progress,
             self._check_pipeline_stall,
             self._check_orphaned_work,
+            self._check_failed_work_impact,
+            self._check_stuck_planning_goals,
         ):
             try:
                 results = await check_fn()
@@ -337,6 +343,14 @@ class SystemIntegrityMonitor:
                 return await self._remediate_trigger_dispatch()
             elif action == "requeue_orphaned":
                 return await self._remediate_requeue_orphaned(anomaly.entity_id)
+            elif action == "fail_parent_issue":
+                return await self._remediate_fail_parent_issue(
+                    anomaly.entity_id, ctx
+                )
+            elif action == "fail_stuck_planning_goal":
+                return await self._remediate_fail_stuck_planning_goal(
+                    anomaly.entity_id
+                )
             else:
                 logger.warning(f"[Integrity] Unknown remediation: {action}")
                 return False
@@ -418,6 +432,32 @@ class SystemIntegrityMonitor:
         wm = get_work_map_service()
         result = await wm.mark_work_timed_out(work_id, max_retries=3)
         return result is not None
+
+    async def _remediate_fail_parent_issue(
+        self, issue_id: str, ctx: Dict[str, Any]
+    ) -> bool:
+        """Mark an issue as FAILED when its work items have all failed."""
+        from services.work_map_service import get_work_map_service
+        from models.work_map import IssueStatus
+
+        wm = get_work_map_service()
+        await wm._issue_service.update_issue_status(
+            issue_id, IssueStatus.FAILED
+        )
+        return True
+
+    async def _remediate_fail_stuck_planning_goal(self, goal_id: str) -> bool:
+        """Mark a stuck PLANNING goal as FAILED so the user knows decomposition stalled."""
+        from services.work_map_service import get_work_map_service
+        from models.work_map import GoalStatus
+
+        wm = get_work_map_service()
+        goal = wm._goals.get(goal_id)
+        if not goal:
+            return False
+        goal.status = GoalStatus.FAILED
+        await wm._save_to_redis(goal)
+        return True
 
     # =========================================================================
     # Anomaly Checks
@@ -770,6 +810,109 @@ class SystemIntegrityMonitor:
                             ),
                             remediation_action="requeue_orphaned",
                         ))
+        except RuntimeError:
+            pass
+        return anomalies
+
+    async def _check_failed_work_impact(self) -> List[AnomalyResult]:
+        """Check 8: Issues stuck IN_PROGRESS when all work items are FAILED.
+
+        When work fails but the parent issue isn't updated, the issue blocks
+        downstream work indefinitely. This detects the gap and marks the
+        parent issue as FAILED so the system can move on.
+        """
+        anomalies: List[AnomalyResult] = []
+        try:
+            from services.work_map_service import get_work_map_service
+            from models.work_map import IssueStatus, WorkStatus
+
+            wm = get_work_map_service()
+
+            for status in (IssueStatus.IN_PROGRESS, IssueStatus.IMPLEMENTED):
+                try:
+                    result = await wm.list_issues(status=status, limit=100)
+                except Exception:
+                    continue
+                for issue in result.items:
+                    issue_work = [
+                        w for w in wm._work_items.values()
+                        if w.issue_id == issue.issue_id
+                    ]
+                    if not issue_work:
+                        continue
+                    # All work items are terminal but at least one is FAILED
+                    # (i.e., not all COMPLETED — that's _check_stuck_issues)
+                    terminal = all(
+                        w.status in (WorkStatus.COMPLETED, WorkStatus.FAILED)
+                        for w in issue_work
+                    )
+                    has_failed = any(
+                        w.status == WorkStatus.FAILED for w in issue_work
+                    )
+                    if terminal and has_failed:
+                        failed_count = sum(
+                            1 for w in issue_work if w.status == WorkStatus.FAILED
+                        )
+                        anomalies.append(AnomalyResult(
+                            check_type="failed_work_impact",
+                            entity_type="issue",
+                            entity_id=issue.issue_id,
+                            project_id=getattr(issue, 'project_id', None),
+                            description=(
+                                f"Issue {issue.issue_id} is {status.value} but "
+                                f"{failed_count}/{len(issue_work)} work item(s) "
+                                f"failed — issue should be marked FAILED"
+                            ),
+                            remediation_action="fail_parent_issue",
+                        ))
+        except RuntimeError:
+            pass
+        return anomalies
+
+    async def _check_stuck_planning_goals(self) -> List[AnomalyResult]:
+        """Check 9: Goals stuck in PLANNING for too long.
+
+        If decomposition fails silently (compute crash, timeout, error),
+        the goal stays in PLANNING forever. After 15 minutes with no
+        issues created, mark as FAILED.
+        """
+        anomalies: List[AnomalyResult] = []
+        try:
+            from services.work_map_service import get_work_map_service
+            from models.work_map import GoalStatus
+
+            wm = get_work_map_service()
+            goals_result = await wm.list_goals(status=GoalStatus.PLANNING)
+            now = datetime.now(timezone.utc)
+
+            for goal in goals_result.items:
+                # Check how long it's been in PLANNING
+                created_at = getattr(goal, 'created_at', None)
+                if not created_at:
+                    continue
+                if isinstance(created_at, str):
+                    created_at = datetime.fromisoformat(created_at)
+                age_seconds = (now - created_at).total_seconds()
+
+                if age_seconds < 900:  # 15 minutes grace period
+                    continue
+
+                # Verify no issues have been created
+                issues = await wm.get_goal_issues(goal.goal_id)
+                if issues:
+                    continue  # Decomposition produced issues, probably transitioning
+
+                anomalies.append(AnomalyResult(
+                    check_type="stuck_planning_goal",
+                    entity_type="goal",
+                    entity_id=goal.goal_id,
+                    project_id=getattr(goal, 'project_id', None),
+                    description=(
+                        f"Goal {goal.goal_id} stuck in PLANNING for "
+                        f"{int(age_seconds / 60)}m with no issues created"
+                    ),
+                    remediation_action="fail_stuck_planning_goal",
+                ))
         except RuntimeError:
             pass
         return anomalies

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -394,6 +394,14 @@ class SystemIntegrityMonitor:
     # Anomaly Checks
     # =========================================================================
 
+    def _resolve_git_project_name(self, project_id: str) -> str:
+        """Resolve project_id to git repo name (e.g. proj_abc -> proj_abc_repo_def)."""
+        try:
+            from api.compute import _resolve_git_project_name
+            return _resolve_git_project_name(project_id)
+        except Exception:
+            return project_id
+
     async def _check_merged_not_finalized(self) -> List[AnomalyResult]:
         """Check 1: Work items whose PR is MERGED but status is still active."""
         anomalies: List[AnomalyResult] = []
@@ -415,8 +423,11 @@ class SystemIntegrityMonitor:
                     if not work.branch_name or not work.project_id:
                         continue
                     try:
+                        git_project = self._resolve_git_project_name(
+                            work.project_id
+                        )
                         pr = await pr_service.get_pr(
-                            work.project_id, work.branch_name
+                            git_project, work.branch_name
                         )
                         if pr and pr.status == PRStatus.MERGED:
                             anomalies.append(AnomalyResult(
@@ -516,8 +527,8 @@ class SystemIntegrityMonitor:
             pr_service = get_pr_service()
             wm = get_work_map_service()
 
-            # Get unique project IDs from active work
-            project_ids = set()
+            # Get unique project IDs from active work, resolve to git names
+            raw_project_ids = set()
             for status_val in ("in_progress", "implemented", "assigned", "pending"):
                 try:
                     from models.work_map import WorkStatus
@@ -525,11 +536,12 @@ class SystemIntegrityMonitor:
                     result = await wm.list_work(status=ws, limit=100)
                     for w in result.items:
                         if w.project_id:
-                            project_ids.add(w.project_id)
+                            raw_project_ids.add(w.project_id)
                 except Exception:
                     continue
 
-            for project_id in project_ids:
+            for raw_project_id in raw_project_ids:
+                project_id = self._resolve_git_project_name(raw_project_id)
                 try:
                     prs = await pr_service.list_prs(project_id)
                 except Exception:

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -455,7 +455,7 @@ class SystemIntegrityMonitor:
                     # Find all work items for this issue
                     issue_work = [
                         w for w in wm._work_items.values()
-                        if w.issue_id == issue.id
+                        if w.issue_id == issue.issue_id
                     ]
                     if not issue_work:
                         continue
@@ -463,10 +463,10 @@ class SystemIntegrityMonitor:
                         anomalies.append(AnomalyResult(
                             check_type="stuck_issue",
                             entity_type="issue",
-                            entity_id=issue.id,
+                            entity_id=issue.issue_id,
                             project_id=getattr(issue, 'project_id', None),
                             description=(
-                                f"Issue {issue.id} is {status.value} but all "
+                                f"Issue {issue.issue_id} is {status.value} but all "
                                 f"{len(issue_work)} work item(s) are completed"
                             ),
                             remediation_action="finalize_issue",
@@ -486,17 +486,17 @@ class SystemIntegrityMonitor:
             goals_result = await wm.list_goals(status=GoalStatus.IN_PROGRESS)
 
             for goal in goals_result.items:
-                issues = await wm.get_goal_issues(goal.id)
+                issues = await wm.get_goal_issues(goal.goal_id)
                 if not issues:
                     continue
                 if all(i.status == IssueStatus.DONE for i in issues):
                     anomalies.append(AnomalyResult(
                         check_type="stuck_goal",
                         entity_type="goal",
-                        entity_id=goal.id,
+                        entity_id=goal.goal_id,
                         project_id=getattr(goal, 'project_id', None),
                         description=(
-                            f"Goal {goal.id} is in_progress but all "
+                            f"Goal {goal.goal_id} is in_progress but all "
                             f"{len(issues)} issues are done"
                         ),
                         remediation_action="check_goal_completion",

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -363,6 +363,8 @@ class SystemIntegrityMonitor:
                 return await self._remediate_recover_failed_issue(
                     anomaly.entity_id, ctx
                 )
+            elif action == "dispatch_conflict_resolution":
+                return await self._remediate_dispatch_conflict_resolution(ctx)
             else:
                 logger.warning(f"[Integrity] Unknown remediation: {action}")
                 return False
@@ -480,6 +482,51 @@ class SystemIntegrityMonitor:
         goal.status = GoalStatus.FAILED
         await wm._goal_service._save_goal_to_redis(goal)
         return True
+
+    async def _remediate_dispatch_conflict_resolution(
+        self, ctx: Dict[str, Any]
+    ) -> bool:
+        """Dispatch conflict resolution to a compute — rebase and re-push."""
+        project = ctx.get("project")
+        branch = ctx.get("branch")
+        compute_id = ctx.get("compute_id")
+        task_id = ctx.get("task_id")
+        if not project or not branch:
+            return False
+
+        from api.git import get_pr_service
+        from services.work_map_service import get_work_map_service
+
+        pr_service = get_pr_service()
+        pr = await pr_service.get_pr(project, branch)
+        if not pr:
+            return False
+
+        # Find the work item for this PR
+        wm = get_work_map_service()
+        work = wm._work_items.get(task_id) if task_id else None
+        if not work:
+            # Try to find by branch
+            for w in wm._work_items.values():
+                if w.branch_name == branch:
+                    work = w
+                    break
+        if not work:
+            return False
+
+        target_compute = compute_id or work.assigned_to
+        if not target_compute:
+            return False
+
+        try:
+            from api.compute import _dispatch_conflict_resolution_work
+            await _dispatch_conflict_resolution_work(
+                work, branch, target_compute, pr
+            )
+            return True
+        except Exception as e:
+            logger.error(f"[Integrity] Conflict resolution dispatch failed: {e}")
+            return False
 
     async def _remediate_recover_failed_issue(
         self, issue_id: str, ctx: Dict[str, Any]
@@ -678,8 +725,31 @@ class SystemIntegrityMonitor:
                     continue
 
                 for pr in prs:
+                    # 4c: PENDING with conflicts — needs conflict resolution dispatch
+                    if pr.status == PRStatus.PENDING:
+                        conflicting = getattr(pr, 'conflicting_files', None)
+                        rejection = getattr(pr, 'rejection_reason', None)
+                        if conflicting or (rejection and 'Conflict' in str(rejection)):
+                            anomalies.append(AnomalyResult(
+                                check_type="stuck_pr_conflict",
+                                entity_type="pr",
+                                entity_id=f"{project_id}/{pr.branch}",
+                                project_id=project_id,
+                                description=(
+                                    f"PR {pr.branch} has merge conflicts — "
+                                    f"dispatching rebase"
+                                ),
+                                remediation_action="dispatch_conflict_resolution",
+                                context={
+                                    "project": project_id,
+                                    "branch": pr.branch,
+                                    "compute_id": getattr(pr, 'compute_id', None),
+                                    "task_id": getattr(pr, 'task_id', None),
+                                },
+                            ))
+
                     # 4a: CONFLICT but actually mergeable
-                    if pr.status == PRStatus.CONFLICT:
+                    elif pr.status == PRStatus.CONFLICT:
                         try:
                             check = await pr_service.check_mergeable(
                                 project_id, pr.branch

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -227,6 +227,11 @@ class SystemIntegrityMonitor:
                 f"{len(all_anomalies)} anomalies detected "
                 f"({elapsed_ms:.0f}ms)"
             )
+        elif self._stats["cycles"] % 10 == 0:
+            logger.info(
+                f"[Integrity] Sweep #{self._stats['cycles']}: "
+                f"clean ({elapsed_ms:.0f}ms)"
+            )
 
     # =========================================================================
     # Throttling
@@ -947,6 +952,7 @@ class SystemIntegrityMonitor:
                 # Check if ANY work item's branch has a merged PR
                 has_merged_pr = False
                 merged_branch = None
+                git_project = None
                 for work in issue_work:
                     if not work.branch_name or not work.project_id:
                         continue
@@ -963,6 +969,23 @@ class SystemIntegrityMonitor:
                             break
                     except Exception:
                         continue
+
+                # Fallback: work may have been retried on a different compute,
+                # so the branch_name on the work item is stale. Scan all merged
+                # PRs for branches matching f/{issue_id}/ prefix.
+                if not has_merged_pr and git_project:
+                    try:
+                        all_prs = await pr_service.list_prs(
+                            git_project, status=PRStatus.MERGED
+                        )
+                        issue_prefix = f"f/{issue.issue_id}/"
+                        for pr in all_prs:
+                            if pr.branch and pr.branch.startswith(issue_prefix):
+                                has_merged_pr = True
+                                merged_branch = pr.branch
+                                break
+                    except Exception:
+                        pass
 
                 if has_merged_pr:
                     anomalies.append(AnomalyResult(

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -428,6 +428,13 @@ class SystemIntegrityMonitor:
             await pr_service.update_status(project, branch, PRStatus.MERGED)
             return True
 
+        # Ensure PR is approved before merge (merge() requires APPROVED status)
+        if pr and pr.status != PRStatus.APPROVED:
+            await pr_service.update_status(
+                project, branch, PRStatus.APPROVED,
+                reviewed_by="integrity-monitor",
+            )
+
         # Re-add to merge queue and trigger processing
         redis = await pr_service._get_redis()
         await redis.add_to_merge_queue(project, branch)

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -418,9 +418,19 @@ class SystemIntegrityMonitor:
         from git.pr_service import PRStatus
 
         pr_service = get_pr_service()
-        await pr_service.update_status(project, branch, PRStatus.PENDING)
+
+        # Check if already merged (stale APPROVED status from race condition)
+        pr = await pr_service.get_pr(project, branch)
+        if pr and getattr(pr, 'merged_at', None):
+            # PR was already merged — fix the status instead of re-merging
+            await pr_service.update_status(project, branch, PRStatus.MERGED)
+            return True
+
+        # Re-add to merge queue and trigger processing
+        redis = await pr_service._get_redis()
+        await redis.add_to_merge_queue(project, branch)
         results = await pr_service.process_merge_queue(project)
-        return len(results) > 0
+        return any(r.get("success") for r in results)
 
     async def _remediate_process_merge_queue(self, project: Optional[str]) -> bool:
         if not project:
@@ -428,8 +438,8 @@ class SystemIntegrityMonitor:
         from api.git import get_pr_service
 
         pr_service = get_pr_service()
-        await pr_service.process_merge_queue(project)
-        return True
+        results = await pr_service.process_merge_queue(project)
+        return any(r.get("success") for r in results)
 
     async def _remediate_trigger_dispatch(self) -> bool:
         from services.work_dispatcher import get_work_dispatcher
@@ -712,8 +722,11 @@ class SystemIntegrityMonitor:
                                         f"PR {pr.branch} has been APPROVED for "
                                         f"{int(age)}s but not merged"
                                     ),
-                                    remediation_action="process_merge_queue",
-                                    context={"project": project_id},
+                                    remediation_action="requeue_merge",
+                                    context={
+                                        "project": project_id,
+                                        "branch": pr.branch,
+                                    },
                                 ))
         except RuntimeError:
             pass

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -181,6 +181,15 @@ class SystemIntegrityMonitor:
 
         self._stats["anomalies_detected"] += len(all_anomalies)
 
+        # Remediation actions that dispatch work to computes or change merge
+        # state. If one of these succeeds, stop the sweep and let state settle.
+        DISPATCH_ACTIONS = {
+            "dispatch_conflict_resolution",
+            "requeue_merge",
+            "finalize_work",
+            "recover_failed_issue",
+        }
+
         for anomaly in all_anomalies:
             tracker_key = f"{anomaly.check_type}:{anomaly.entity_id}"
 
@@ -208,6 +217,17 @@ class SystemIntegrityMonitor:
                     )
                     # Clean tracker on success — anomaly resolved
                     self._attempt_tracker.pop(tracker_key, None)
+
+                    # Short-circuit: if this remediation dispatches work or
+                    # changes merge state, stop and let things settle before
+                    # processing more anomalies in this sweep.
+                    if anomaly.remediation_action in DISPATCH_ACTIONS:
+                        logger.info(
+                            f"[Integrity] Short-circuiting sweep — "
+                            f"'{anomaly.remediation_action}' dispatched, "
+                            f"letting state settle"
+                        )
+                        break
                 else:
                     self._stats["anomalies_failed"] += 1
                     if check_stats:

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -1,0 +1,755 @@
+"""System Integrity Monitor — active agent that sweeps the full pipeline for anomalies.
+
+Replaces ReconciliationManager with broader cross-cutting state machine validation.
+Detects inconsistencies where work, issues, PRs, and goals fall out of sync,
+attempts remediation through existing service methods, and emits notifications
+when things are stuck. No more silent hangs.
+
+Checks (run every sweep cycle):
+  1. Merged branches with un-finalized work items
+  2. Issues stuck after all work items completed
+  3. Goals not finalized when all issues are done
+  4. PRs stuck in CONFLICT (resolved) or APPROVED (not merging)
+  5. Stale high-progress work on disconnected computes
+  6. Pipeline stalls (READY issues or PENDING work with idle computes)
+  7. Orphaned work assigned to disconnected computes
+"""
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton
+_monitor: Optional["SystemIntegrityMonitor"] = None
+
+# Cooldown seconds per check type — how long to wait before re-attempting
+# remediation on the same entity
+COOLDOWNS = {
+    "merged_not_finalized": 120,
+    "stuck_issue": 180,
+    "stuck_goal": 300,
+    "stuck_pr_conflict": 180,
+    "stuck_pr_approved": 120,
+    "stale_high_progress": 300,
+    "pipeline_stall": 120,
+    "orphaned_work": 120,
+}
+
+# How many consecutive detections before escalating notification to ERROR
+ESCALATION_THRESHOLD = 3
+
+# Clean up tracker entries after this many seconds of no re-detection
+TRACKER_CLEANUP_SECONDS = 1800  # 30 minutes
+
+
+@dataclass
+class AnomalyResult:
+    """Detected anomaly with remediation context."""
+    check_type: str
+    entity_type: str  # "work", "issue", "goal", "pr"
+    entity_id: str
+    project_id: Optional[str]
+    description: str
+    remediation_action: Optional[str]  # method name or None for notify-only
+    context: Dict[str, Any] = field(default_factory=dict)
+
+
+def get_system_integrity_monitor() -> "SystemIntegrityMonitor":
+    global _monitor
+    if _monitor is None:
+        raise RuntimeError(
+            "SystemIntegrityMonitor not initialized. "
+            "Call start_system_integrity_monitor() first."
+        )
+    return _monitor
+
+
+def set_system_integrity_monitor(monitor: "SystemIntegrityMonitor") -> None:
+    global _monitor
+    _monitor = monitor
+
+
+class SystemIntegrityMonitor:
+    """Background agent that sweeps the system for state machine inconsistencies."""
+
+    def __init__(self, check_interval: int = 60) -> None:
+        self.check_interval = check_interval
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+        # Throttling: "{check_type}:{entity_id}" -> tracking info
+        self._attempt_tracker: Dict[str, Dict[str, Any]] = {}
+
+        self._stats: Dict[str, Any] = {
+            "cycles": 0,
+            "anomalies_detected": 0,
+            "anomalies_remediated": 0,
+            "anomalies_failed": 0,
+            "active_anomalies": 0,
+            "last_sweep_duration_ms": 0,
+            "last_sweep_at": None,
+            "by_check_type": {k: {"detected": 0, "remediated": 0, "failed": 0}
+                              for k in COOLDOWNS},
+        }
+
+    # =========================================================================
+    # Lifecycle
+    # =========================================================================
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(
+            self._sweep_loop(), name="system-integrity-monitor"
+        )
+        logger.info(
+            f"SystemIntegrityMonitor started (interval={self.check_interval}s)"
+        )
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("SystemIntegrityMonitor stopped")
+
+    def is_running(self) -> bool:
+        return self._running
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {
+            **self._stats,
+            "running": self._running,
+            "active_anomalies": len(self._attempt_tracker),
+        }
+
+    # =========================================================================
+    # Main Loop
+    # =========================================================================
+
+    async def _sweep_loop(self) -> None:
+        logger.debug("SystemIntegrityMonitor loop started")
+        while self._running:
+            try:
+                await asyncio.sleep(self.check_interval)
+                if not self._running:
+                    break
+                await self._run_sweep()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"[Integrity] Sweep error: {e}", exc_info=True)
+        logger.debug("SystemIntegrityMonitor loop exited")
+
+    async def _run_sweep(self) -> None:
+        start = time.monotonic()
+        all_anomalies: List[AnomalyResult] = []
+
+        # Run all checks — each is wrapped to not break the sweep on failure
+        for check_fn in (
+            self._check_merged_not_finalized,
+            self._check_stuck_issues,
+            self._check_stuck_goals,
+            self._check_stuck_prs,
+            self._check_stale_high_progress,
+            self._check_pipeline_stall,
+            self._check_orphaned_work,
+        ):
+            try:
+                results = await check_fn()
+                all_anomalies.extend(results)
+            except Exception as e:
+                logger.error(f"[Integrity] Check {check_fn.__name__} failed: {e}")
+
+        self._stats["anomalies_detected"] += len(all_anomalies)
+
+        for anomaly in all_anomalies:
+            tracker_key = f"{anomaly.check_type}:{anomaly.entity_id}"
+
+            if self._should_throttle(tracker_key, anomaly.check_type):
+                continue
+
+            self._record_attempt(tracker_key)
+            consecutive = self._attempt_tracker[tracker_key]["attempt_count"]
+
+            # Update per-check stats
+            check_stats = self._stats["by_check_type"].get(anomaly.check_type)
+            if check_stats:
+                check_stats["detected"] += 1
+
+            if anomaly.remediation_action:
+                success = await self._attempt_remediation(anomaly)
+                if success:
+                    self._stats["anomalies_remediated"] += 1
+                    if check_stats:
+                        check_stats["remediated"] += 1
+                    logger.info(f"[Integrity] Remediated: {anomaly.description}")
+                    # Clean tracker on success — anomaly resolved
+                    self._attempt_tracker.pop(tracker_key, None)
+                else:
+                    self._stats["anomalies_failed"] += 1
+                    if check_stats:
+                        check_stats["failed"] += 1
+                    self._notify(anomaly, consecutive)
+            else:
+                # Notification-only anomaly
+                self._notify(anomaly, consecutive)
+
+        self._cleanup_tracker()
+
+        elapsed_ms = (time.monotonic() - start) * 1000
+        self._stats["cycles"] += 1
+        self._stats["last_sweep_duration_ms"] = round(elapsed_ms, 1)
+        self._stats["last_sweep_at"] = datetime.now(timezone.utc).isoformat()
+
+        if all_anomalies:
+            logger.info(
+                f"[Integrity] Sweep #{self._stats['cycles']}: "
+                f"{len(all_anomalies)} anomalies detected "
+                f"({elapsed_ms:.0f}ms)"
+            )
+
+    # =========================================================================
+    # Throttling
+    # =========================================================================
+
+    def _should_throttle(self, tracker_key: str, check_type: str) -> bool:
+        entry = self._attempt_tracker.get(tracker_key)
+        if not entry:
+            return False
+        cooldown = COOLDOWNS.get(check_type, 120)
+        elapsed = (datetime.now(timezone.utc) - entry["last_attempt"]).total_seconds()
+        return elapsed < cooldown
+
+    def _record_attempt(self, tracker_key: str) -> None:
+        now = datetime.now(timezone.utc)
+        if tracker_key in self._attempt_tracker:
+            self._attempt_tracker[tracker_key]["last_attempt"] = now
+            self._attempt_tracker[tracker_key]["attempt_count"] += 1
+        else:
+            self._attempt_tracker[tracker_key] = {
+                "first_seen": now,
+                "last_attempt": now,
+                "attempt_count": 1,
+            }
+
+    def _cleanup_tracker(self) -> None:
+        now = datetime.now(timezone.utc)
+        stale_keys = [
+            k for k, v in self._attempt_tracker.items()
+            if (now - v["last_attempt"]).total_seconds() > TRACKER_CLEANUP_SECONDS
+        ]
+        for k in stale_keys:
+            del self._attempt_tracker[k]
+
+    # =========================================================================
+    # Notification
+    # =========================================================================
+
+    def _notify(self, anomaly: AnomalyResult, consecutive: int) -> None:
+        try:
+            from services.notification_service import get_notification_service
+            from models.notification import NotificationLevel, NotificationCategory
+
+            notification_service = get_notification_service()
+            if not notification_service:
+                return
+
+            level = (
+                NotificationLevel.ERROR
+                if consecutive >= ESCALATION_THRESHOLD
+                else NotificationLevel.WARNING
+            )
+
+            notification_service.emit(
+                title=f"[Integrity] {anomaly.entity_type} {anomaly.entity_id}",
+                message=anomaly.description,
+                level=level,
+                category=NotificationCategory.SYSTEM,
+                project_id=anomaly.project_id,
+                entity_id=anomaly.entity_id,
+            )
+        except Exception as e:
+            logger.debug(f"[Integrity] Could not emit notification: {e}")
+
+    # =========================================================================
+    # Remediation
+    # =========================================================================
+
+    async def _attempt_remediation(self, anomaly: AnomalyResult) -> bool:
+        try:
+            action = anomaly.remediation_action
+            ctx = anomaly.context
+
+            if action == "finalize_work":
+                return await self._remediate_finalize_work(
+                    anomaly.entity_id, ctx
+                )
+            elif action == "finalize_issue":
+                return await self._remediate_finalize_issue(anomaly.entity_id)
+            elif action == "check_goal_completion":
+                return await self._remediate_goal_completion(anomaly.entity_id)
+            elif action == "requeue_merge":
+                return await self._remediate_requeue_merge(
+                    ctx.get("project"), ctx.get("branch")
+                )
+            elif action == "process_merge_queue":
+                return await self._remediate_process_merge_queue(ctx.get("project"))
+            elif action == "trigger_dispatch":
+                return await self._remediate_trigger_dispatch()
+            elif action == "requeue_orphaned":
+                return await self._remediate_requeue_orphaned(anomaly.entity_id)
+            else:
+                logger.warning(f"[Integrity] Unknown remediation: {action}")
+                return False
+
+        except Exception as e:
+            logger.error(
+                f"[Integrity] Remediation failed for "
+                f"{anomaly.entity_type} {anomaly.entity_id}: {e}"
+            )
+            return False
+
+    async def _remediate_finalize_work(
+        self, work_id: str, ctx: Dict[str, Any]
+    ) -> bool:
+        from services.work_map_service import get_work_map_service
+        from models.work_map import WorkStatus
+
+        wm = get_work_map_service()
+        work = wm._work_items.get(work_id)
+        if not work:
+            return False
+
+        if work.status == WorkStatus.IN_PROGRESS:
+            await wm.complete_work(
+                work_id,
+                {"auto_completed": True, "reason": "integrity_monitor_merged_branch"},
+                trigger_cascade=False,
+            )
+
+        result = await wm.finalize_work(work_id)
+        return result is not None
+
+    async def _remediate_finalize_issue(self, issue_id: str) -> bool:
+        from services.work_map_service import get_work_map_service
+
+        wm = get_work_map_service()
+        await wm._issue_service.finalize_issue(issue_id, trigger_cascade=True)
+        return True
+
+    async def _remediate_goal_completion(self, goal_id: str) -> bool:
+        from services.work_map_service import get_work_map_service
+
+        wm = get_work_map_service()
+        await wm._goal_service.check_goal_completion(goal_id)
+        return True
+
+    async def _remediate_requeue_merge(
+        self, project: Optional[str], branch: Optional[str]
+    ) -> bool:
+        if not project or not branch:
+            return False
+        from api.git import get_pr_service
+        from git.pr_service import PRStatus
+
+        pr_service = get_pr_service()
+        await pr_service.update_status(project, branch, PRStatus.PENDING)
+        results = await pr_service.process_merge_queue(project)
+        return len(results) > 0
+
+    async def _remediate_process_merge_queue(self, project: Optional[str]) -> bool:
+        if not project:
+            return False
+        from api.git import get_pr_service
+
+        pr_service = get_pr_service()
+        await pr_service.process_merge_queue(project)
+        return True
+
+    async def _remediate_trigger_dispatch(self) -> bool:
+        from services.work_dispatcher import get_work_dispatcher
+
+        dispatcher = get_work_dispatcher()
+        dispatcher.trigger(reason="integrity_pipeline_stall")
+        return True
+
+    async def _remediate_requeue_orphaned(self, work_id: str) -> bool:
+        from services.work_map_service import get_work_map_service
+
+        wm = get_work_map_service()
+        result = await wm.mark_work_timed_out(work_id, max_retries=3)
+        return result is not None
+
+    # =========================================================================
+    # Anomaly Checks
+    # =========================================================================
+
+    async def _check_merged_not_finalized(self) -> List[AnomalyResult]:
+        """Check 1: Work items whose PR is MERGED but status is still active."""
+        anomalies: List[AnomalyResult] = []
+        try:
+            from services.work_map_service import get_work_map_service
+            from api.git import get_pr_service
+            from git.pr_service import PRStatus
+            from models.work_map import WorkStatus
+
+            wm = get_work_map_service()
+            pr_service = get_pr_service()
+
+            for status in (WorkStatus.IN_PROGRESS, WorkStatus.IMPLEMENTED):
+                try:
+                    result = await wm.list_work(status=status, limit=100)
+                except Exception:
+                    continue
+                for work in result.items:
+                    if not work.branch_name or not work.project_id:
+                        continue
+                    try:
+                        pr = await pr_service.get_pr(
+                            work.project_id, work.branch_name
+                        )
+                        if pr and pr.status == PRStatus.MERGED:
+                            anomalies.append(AnomalyResult(
+                                check_type="merged_not_finalized",
+                                entity_type="work",
+                                entity_id=work.work_id,
+                                project_id=work.project_id,
+                                description=(
+                                    f"Work {work.work_id} is {status.value} "
+                                    f"but branch {work.branch_name} is already merged"
+                                ),
+                                remediation_action="finalize_work",
+                                context={"branch": work.branch_name},
+                            ))
+                    except Exception:
+                        continue
+        except RuntimeError:
+            pass  # Service not initialized
+        return anomalies
+
+    async def _check_stuck_issues(self) -> List[AnomalyResult]:
+        """Check 2: Issues stuck in active status when all work is completed."""
+        anomalies: List[AnomalyResult] = []
+        try:
+            from services.work_map_service import get_work_map_service
+            from models.work_map import IssueStatus, WorkStatus
+
+            wm = get_work_map_service()
+
+            for status in (IssueStatus.IN_PROGRESS, IssueStatus.IMPLEMENTED):
+                try:
+                    result = await wm.list_issues(status=status, limit=100)
+                except Exception:
+                    continue
+                for issue in result.items:
+                    # Find all work items for this issue
+                    issue_work = [
+                        w for w in wm._work_items.values()
+                        if w.issue_id == issue.id
+                    ]
+                    if not issue_work:
+                        continue
+                    if all(w.status == WorkStatus.COMPLETED for w in issue_work):
+                        anomalies.append(AnomalyResult(
+                            check_type="stuck_issue",
+                            entity_type="issue",
+                            entity_id=issue.id,
+                            project_id=getattr(issue, 'project_id', None),
+                            description=(
+                                f"Issue {issue.id} is {status.value} but all "
+                                f"{len(issue_work)} work item(s) are completed"
+                            ),
+                            remediation_action="finalize_issue",
+                        ))
+        except RuntimeError:
+            pass
+        return anomalies
+
+    async def _check_stuck_goals(self) -> List[AnomalyResult]:
+        """Check 3: Goals still IN_PROGRESS when all issues are DONE."""
+        anomalies: List[AnomalyResult] = []
+        try:
+            from services.work_map_service import get_work_map_service
+            from models.work_map import GoalStatus, IssueStatus
+
+            wm = get_work_map_service()
+            goals_result = await wm.list_goals(status=GoalStatus.IN_PROGRESS)
+
+            for goal in goals_result.items:
+                issues = await wm.get_goal_issues(goal.id)
+                if not issues:
+                    continue
+                if all(i.status == IssueStatus.DONE for i in issues):
+                    anomalies.append(AnomalyResult(
+                        check_type="stuck_goal",
+                        entity_type="goal",
+                        entity_id=goal.id,
+                        project_id=getattr(goal, 'project_id', None),
+                        description=(
+                            f"Goal {goal.id} is in_progress but all "
+                            f"{len(issues)} issues are done"
+                        ),
+                        remediation_action="check_goal_completion",
+                    ))
+        except RuntimeError:
+            pass
+        return anomalies
+
+    async def _check_stuck_prs(self) -> List[AnomalyResult]:
+        """Check 4: PRs stuck in CONFLICT (resolved) or APPROVED (not merging)."""
+        anomalies: List[AnomalyResult] = []
+        try:
+            from api.git import get_pr_service
+            from git.pr_service import PRStatus
+            from services.work_map_service import get_work_map_service
+
+            pr_service = get_pr_service()
+            wm = get_work_map_service()
+
+            # Get unique project IDs from active work
+            project_ids = set()
+            for status_val in ("in_progress", "implemented", "assigned", "pending"):
+                try:
+                    from models.work_map import WorkStatus
+                    ws = WorkStatus(status_val)
+                    result = await wm.list_work(status=ws, limit=100)
+                    for w in result.items:
+                        if w.project_id:
+                            project_ids.add(w.project_id)
+                except Exception:
+                    continue
+
+            for project_id in project_ids:
+                try:
+                    prs = await pr_service.list_prs(project_id)
+                except Exception:
+                    continue
+
+                for pr in prs:
+                    # 4a: CONFLICT but actually mergeable
+                    if pr.status == PRStatus.CONFLICT:
+                        try:
+                            check = await pr_service.check_mergeable(
+                                project_id, pr.branch
+                            )
+                            if check.get("mergeable"):
+                                anomalies.append(AnomalyResult(
+                                    check_type="stuck_pr_conflict",
+                                    entity_type="pr",
+                                    entity_id=f"{project_id}/{pr.branch}",
+                                    project_id=project_id,
+                                    description=(
+                                        f"PR {pr.branch} is marked CONFLICT "
+                                        f"but branch is actually mergeable"
+                                    ),
+                                    remediation_action="requeue_merge",
+                                    context={
+                                        "project": project_id,
+                                        "branch": pr.branch,
+                                    },
+                                ))
+                        except Exception:
+                            continue
+
+                    # 4b: APPROVED for >5 minutes but not merged
+                    elif pr.status == PRStatus.APPROVED:
+                        approved_at = getattr(pr, 'updated_at', None)
+                        if approved_at:
+                            if isinstance(approved_at, str):
+                                approved_at = datetime.fromisoformat(approved_at)
+                            age = (
+                                datetime.now(timezone.utc) - approved_at
+                            ).total_seconds()
+                            if age > 300:  # 5 minutes
+                                anomalies.append(AnomalyResult(
+                                    check_type="stuck_pr_approved",
+                                    entity_type="pr",
+                                    entity_id=f"{project_id}/{pr.branch}",
+                                    project_id=project_id,
+                                    description=(
+                                        f"PR {pr.branch} has been APPROVED for "
+                                        f"{int(age)}s but not merged"
+                                    ),
+                                    remediation_action="process_merge_queue",
+                                    context={"project": project_id},
+                                ))
+        except RuntimeError:
+            pass
+        return anomalies
+
+    async def _check_stale_high_progress(self) -> List[AnomalyResult]:
+        """Check 5: Work at >=90% progress with no activity, compute disconnected."""
+        anomalies: List[AnomalyResult] = []
+        try:
+            from services.work_map_service import get_work_map_service
+            from services.sse_connection_manager import get_sse_connection_manager
+            from models.work_map import WorkStatus
+
+            wm = get_work_map_service()
+            sse_manager = get_sse_connection_manager()
+            connected_ids = {c.compute_id for c in sse_manager.list_connections()}
+
+            result = await wm.list_work(status=WorkStatus.IN_PROGRESS, limit=100)
+            now = datetime.now(timezone.utc)
+
+            for work in result.items:
+                progress = getattr(work, 'progress_percent', 0) or 0
+                if progress < 90:
+                    continue
+
+                last_activity = getattr(work, 'last_activity_at', None)
+                if last_activity:
+                    if isinstance(last_activity, str):
+                        last_activity = datetime.fromisoformat(last_activity)
+                    stale_seconds = (now - last_activity).total_seconds()
+                    if stale_seconds < 900:  # 15 minutes
+                        continue
+                else:
+                    continue
+
+                if work.assigned_to and work.assigned_to not in connected_ids:
+                    anomalies.append(AnomalyResult(
+                        check_type="stale_high_progress",
+                        entity_type="work",
+                        entity_id=work.work_id,
+                        project_id=work.project_id,
+                        description=(
+                            f"Work {work.work_id} at {progress}% progress, "
+                            f"no activity for {int(stale_seconds)}s, "
+                            f"compute {work.assigned_to} disconnected"
+                        ),
+                        remediation_action=None,  # Notify only
+                    ))
+        except RuntimeError:
+            pass
+        return anomalies
+
+    async def _check_pipeline_stall(self) -> List[AnomalyResult]:
+        """Check 6: READY issues or PENDING work with idle computes but nothing moving."""
+        anomalies: List[AnomalyResult] = []
+        try:
+            from services.work_map_service import get_work_map_service
+            from services.sse_connection_manager import get_sse_connection_manager
+            from models.work_map import WorkStatus, IssueStatus
+
+            wm = get_work_map_service()
+            sse_manager = get_sse_connection_manager()
+
+            idle_count = sum(
+                1 for c in sse_manager.list_connections() if c.status == "idle"
+            )
+            if idle_count == 0:
+                return anomalies
+
+            # Check for PENDING work items
+            pending_result = await wm.list_work(
+                status=WorkStatus.PENDING, limit=1
+            )
+            if pending_result.items:
+                anomalies.append(AnomalyResult(
+                    check_type="pipeline_stall",
+                    entity_type="system",
+                    entity_id="pending_work_idle_compute",
+                    project_id=None,
+                    description=(
+                        f"{idle_count} idle compute(s) with pending work "
+                        f"items — dispatch may have stalled"
+                    ),
+                    remediation_action="trigger_dispatch",
+                ))
+                return anomalies
+
+            # Check for READY issues with no active work
+            ready_result = await wm.list_issues(
+                status=IssueStatus.READY, limit=10
+            )
+            if ready_result.items:
+                active_count = 0
+                for status in (WorkStatus.PENDING, WorkStatus.ASSIGNED,
+                               WorkStatus.IN_PROGRESS):
+                    try:
+                        r = await wm.list_work(status=status, limit=1)
+                        active_count += len(r.items)
+                    except Exception:
+                        continue
+
+                if active_count == 0:
+                    anomalies.append(AnomalyResult(
+                        check_type="pipeline_stall",
+                        entity_type="system",
+                        entity_id="ready_issues_no_work",
+                        project_id=None,
+                        description=(
+                            f"{len(ready_result.items)} READY issue(s) but "
+                            f"no active work items — pipeline stalled"
+                        ),
+                        remediation_action="trigger_dispatch",
+                    ))
+        except RuntimeError:
+            pass
+        return anomalies
+
+    async def _check_orphaned_work(self) -> List[AnomalyResult]:
+        """Check 7: Work assigned to computes that are no longer connected."""
+        anomalies: List[AnomalyResult] = []
+        try:
+            from services.work_map_service import get_work_map_service
+            from services.sse_connection_manager import get_sse_connection_manager
+            from models.work_map import WorkStatus
+
+            wm = get_work_map_service()
+            sse_manager = get_sse_connection_manager()
+            connected_ids = {c.compute_id for c in sse_manager.list_connections()}
+
+            for status in (WorkStatus.ASSIGNED, WorkStatus.IN_PROGRESS):
+                try:
+                    result = await wm.list_work(status=status, limit=100)
+                except Exception:
+                    continue
+                for work in result.items:
+                    if work.assigned_to and work.assigned_to not in connected_ids:
+                        anomalies.append(AnomalyResult(
+                            check_type="orphaned_work",
+                            entity_type="work",
+                            entity_id=work.work_id,
+                            project_id=work.project_id,
+                            description=(
+                                f"Work {work.work_id} ({status.value}) assigned "
+                                f"to disconnected compute {work.assigned_to}"
+                            ),
+                            remediation_action="requeue_orphaned",
+                        ))
+        except RuntimeError:
+            pass
+        return anomalies
+
+
+# =========================================================================
+# Module-level helpers
+# =========================================================================
+
+async def start_system_integrity_monitor(
+    check_interval: int = 60,
+) -> SystemIntegrityMonitor:
+    """Create, register, and start the SystemIntegrityMonitor singleton."""
+    monitor = SystemIntegrityMonitor(check_interval=check_interval)
+    set_system_integrity_monitor(monitor)
+    await monitor.start()
+    return monitor
+
+
+async def stop_system_integrity_monitor() -> None:
+    """Stop the SystemIntegrityMonitor singleton if running."""
+    global _monitor
+    if _monitor and _monitor.is_running():
+        await _monitor.stop()

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -619,6 +619,33 @@ class SystemIntegrityMonitor:
                                 remediation_action="finalize_work",
                                 context={"branch": work.branch_name},
                             ))
+                        # 1b: IMPLEMENTED work with PENDING PR, no conflicts,
+                        # older than 5 min — fell through the merge pipeline
+                        elif (pr and pr.status == PRStatus.PENDING
+                              and status == WorkStatus.IMPLEMENTED
+                              and not getattr(pr, 'conflicting_files', None)):
+                            created = getattr(pr, 'created_at', None)
+                            if created:
+                                if isinstance(created, str):
+                                    created = datetime.fromisoformat(created)
+                                age = (datetime.now(timezone.utc) - created).total_seconds()
+                                if age > 300:
+                                    anomalies.append(AnomalyResult(
+                                        check_type="merged_not_finalized",
+                                        entity_type="work",
+                                        entity_id=work.work_id,
+                                        project_id=work.project_id,
+                                        description=(
+                                            f"Work {work.work_id} IMPLEMENTED but "
+                                            f"PR {work.branch_name} stuck in pending "
+                                            f"for {int(age)}s — re-queuing merge"
+                                        ),
+                                        remediation_action="requeue_merge",
+                                        context={
+                                            "project": git_project,
+                                            "branch": work.branch_name,
+                                        },
+                                    ))
                     except Exception:
                         continue
         except RuntimeError:

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -193,16 +193,17 @@ class SystemIntegrityMonitor:
                     if check_stats:
                         check_stats["remediated"] += 1
                     logger.info(f"[Integrity] Remediated: {anomaly.description}")
+                    self._notify_success(anomaly)
                     # Clean tracker on success — anomaly resolved
                     self._attempt_tracker.pop(tracker_key, None)
                 else:
                     self._stats["anomalies_failed"] += 1
                     if check_stats:
                         check_stats["failed"] += 1
-                    self._notify(anomaly, consecutive)
+                    self._notify_failure(anomaly, consecutive)
             else:
                 # Notification-only anomaly
-                self._notify(anomaly, consecutive)
+                self._notify_failure(anomaly, consecutive)
 
         self._cleanup_tracker()
 
@@ -255,7 +256,29 @@ class SystemIntegrityMonitor:
     # Notification
     # =========================================================================
 
-    def _notify(self, anomaly: AnomalyResult, consecutive: int) -> None:
+    def _notify_success(self, anomaly: AnomalyResult) -> None:
+        """Notify that an anomaly was detected AND successfully remediated."""
+        try:
+            from services.notification_service import get_notification_service
+            from models.notification import NotificationLevel, NotificationCategory
+
+            notification_service = get_notification_service()
+            if not notification_service:
+                return
+
+            notification_service.emit(
+                title=f"[Integrity] Auto-fixed: {anomaly.entity_type}",
+                message=f"Detected and resolved: {anomaly.description}",
+                level=NotificationLevel.SUCCESS,
+                category=NotificationCategory.SYSTEM,
+                project_id=anomaly.project_id,
+                entity_id=anomaly.entity_id,
+            )
+        except Exception as e:
+            logger.debug(f"[Integrity] Could not emit success notification: {e}")
+
+    def _notify_failure(self, anomaly: AnomalyResult, consecutive: int) -> None:
+        """Notify that an anomaly was detected but could NOT be remediated."""
         try:
             from services.notification_service import get_notification_service
             from models.notification import NotificationLevel, NotificationCategory
@@ -270,16 +293,22 @@ class SystemIntegrityMonitor:
                 else NotificationLevel.WARNING
             )
 
+            action_note = (
+                " Manual intervention required."
+                if consecutive >= ESCALATION_THRESHOLD
+                else " Will retry."
+            )
+
             notification_service.emit(
-                title=f"[Integrity] {anomaly.entity_type} {anomaly.entity_id}",
-                message=anomaly.description,
+                title=f"[Integrity] Cannot resolve: {anomaly.entity_type}",
+                message=f"{anomaly.description}.{action_note}",
                 level=level,
                 category=NotificationCategory.SYSTEM,
                 project_id=anomaly.project_id,
                 entity_id=anomaly.entity_id,
             )
         except Exception as e:
-            logger.debug(f"[Integrity] Could not emit notification: {e}")
+            logger.debug(f"[Integrity] Could not emit failure notification: {e}")
 
     # =========================================================================
     # Remediation

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -822,30 +822,25 @@ class SystemIntegrityMonitor:
                                 },
                             ))
 
-                    # 4a: CONFLICT but actually mergeable
+                    # 4a: CONFLICT — dispatch rebase to compute
                     elif pr.status == PRStatus.CONFLICT:
-                        try:
-                            check = await pr_service.check_mergeable(
-                                project_id, pr.branch
-                            )
-                            if check.get("mergeable"):
-                                anomalies.append(AnomalyResult(
-                                    check_type="stuck_pr_conflict",
-                                    entity_type="pr",
-                                    entity_id=f"{project_id}/{pr.branch}",
-                                    project_id=project_id,
-                                    description=(
-                                        f"PR {pr.branch} is marked CONFLICT "
-                                        f"but branch is actually mergeable"
-                                    ),
-                                    remediation_action="requeue_merge",
-                                    context={
-                                        "project": project_id,
-                                        "branch": pr.branch,
-                                    },
-                                ))
-                        except Exception:
-                            continue
+                        anomalies.append(AnomalyResult(
+                            check_type="stuck_pr_conflict",
+                            entity_type="pr",
+                            entity_id=f"{project_id}/{pr.branch}",
+                            project_id=project_id,
+                            description=(
+                                f"PR {pr.branch} has conflicts — "
+                                f"dispatching rebase"
+                            ),
+                            remediation_action="dispatch_conflict_resolution",
+                            context={
+                                "project": project_id,
+                                "branch": pr.branch,
+                                "compute_id": getattr(pr, 'compute_id', None),
+                                "task_id": getattr(pr, 'task_id', None),
+                            },
+                        ))
 
                     # 4b: APPROVED for >5 minutes but not merged
                     elif pr.status == PRStatus.APPROVED:

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -36,8 +36,8 @@ COOLDOWNS = {
     "merged_not_finalized": 120,
     "stuck_issue": 180,
     "stuck_goal": 300,
-    "stuck_pr_conflict": 180,
-    "stuck_pr_approved": 120,
+    "stuck_pr_conflict": 600,   # Safety net — merge flow handles primary conflict resolution
+    "stuck_pr_approved": 600,   # Safety net — merge flow handles primary approval/merge
     "stale_high_progress": 300,
     "pipeline_stall": 120,
     "orphaned_work": 120,
@@ -694,7 +694,12 @@ class SystemIntegrityMonitor:
         return anomalies
 
     async def _check_stuck_prs(self) -> List[AnomalyResult]:
-        """Check 4: PRs stuck in CONFLICT (resolved) or APPROVED (not merging)."""
+        """Check 4: PRs stuck in CONFLICT, APPROVED, or PENDING with conflicts (safety net).
+
+        Primary conflict resolution is handled inline by the merge flow in
+        _auto_create_and_merge_pr. This check catches edge cases where the
+        primary flow fails (compute disconnected, no idle computes, etc.).
+        """
         anomalies: List[AnomalyResult] = []
         try:
             from api.git import get_pr_service

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -203,6 +203,9 @@ class SystemIntegrityMonitor:
                         check_stats["remediated"] += 1
                     logger.info(f"[Integrity] Remediated: {anomaly.description}")
                     self._notify_success(anomaly)
+                    await self._emit_activity(
+                        anomaly, f"Auto-fixed: {anomaly.description}"
+                    )
                     # Clean tracker on success — anomaly resolved
                     self._attempt_tracker.pop(tracker_key, None)
                 else:
@@ -210,9 +213,17 @@ class SystemIntegrityMonitor:
                     if check_stats:
                         check_stats["failed"] += 1
                     self._notify_failure(anomaly, consecutive)
+                    await self._emit_activity(
+                        anomaly,
+                        f"Failed to fix: {anomaly.description}"
+                        + (f" (attempt {consecutive})" if consecutive > 1 else ""),
+                    )
             else:
                 # Notification-only anomaly
                 self._notify_failure(anomaly, consecutive)
+                await self._emit_activity(
+                    anomaly, f"Detected: {anomaly.description}"
+                )
 
         self._cleanup_tracker()
 
@@ -269,6 +280,30 @@ class SystemIntegrityMonitor:
     # =========================================================================
     # Notification
     # =========================================================================
+
+    async def _emit_activity(self, anomaly: AnomalyResult, description: str) -> None:
+        """Emit activity event to the project activity log (plan page)."""
+        if not anomaly.project_id:
+            return
+        try:
+            from services.project_service import get_project_service
+            from models.project import ActivityEventType
+
+            svc = get_project_service()
+            # Use a generic event type — the description carries the detail
+            await svc.record_activity_event(
+                project_id=anomaly.project_id,
+                event_type=ActivityEventType.WORK_FAILED if "Failed" in description
+                    else ActivityEventType.WORK_COMPLETED,
+                description=description,
+                metadata={
+                    "source": "integrity_monitor",
+                    "check_type": anomaly.check_type,
+                    "entity_id": anomaly.entity_id,
+                },
+            )
+        except Exception as e:
+            logger.debug(f"[Integrity] Could not emit activity event: {e}")
 
     def _notify_success(self, anomaly: AnomalyResult) -> None:
         """Notify that an anomaly was detected AND successfully remediated."""

--- a/serving/services/system_integrity_monitor.py
+++ b/serving/services/system_integrity_monitor.py
@@ -15,6 +15,7 @@ Checks (run every sweep cycle):
   7. Orphaned work assigned to disconnected computes
   8. Failed work items whose parent issue is still IN_PROGRESS
   9. Goals stuck in PLANNING (decomposition may have failed)
+  10. Failed issues whose work PR is actually merged (recover to DONE)
 """
 
 import asyncio
@@ -42,6 +43,7 @@ COOLDOWNS = {
     "orphaned_work": 120,
     "failed_work_impact": 180,
     "stuck_planning_goal": 300,
+    "failed_issue_merged_pr": 120,
 }
 
 # How many consecutive detections before escalating notification to ERROR
@@ -169,6 +171,7 @@ class SystemIntegrityMonitor:
             self._check_orphaned_work,
             self._check_failed_work_impact,
             self._check_stuck_planning_goals,
+            self._check_failed_issue_merged_pr,
         ):
             try:
                 results = await check_fn()
@@ -351,6 +354,10 @@ class SystemIntegrityMonitor:
                 return await self._remediate_fail_stuck_planning_goal(
                     anomaly.entity_id
                 )
+            elif action == "recover_failed_issue":
+                return await self._remediate_recover_failed_issue(
+                    anomaly.entity_id, ctx
+                )
             else:
                 logger.warning(f"[Integrity] Unknown remediation: {action}")
                 return False
@@ -456,8 +463,47 @@ class SystemIntegrityMonitor:
         if not goal:
             return False
         goal.status = GoalStatus.FAILED
-        await wm._save_to_redis(goal)
+        await wm._goal_service._save_goal_to_redis(goal)
         return True
+
+    async def _remediate_recover_failed_issue(
+        self, issue_id: str, ctx: Dict[str, Any]
+    ) -> bool:
+        """Recover a FAILED issue whose work is actually merged.
+
+        Transitions FAILED → IN_PROGRESS → IMPLEMENTED → DONE (with cascade).
+        Each step follows the valid transition table.
+        """
+        from services.work_map_service import get_work_map_service
+        from models.work_map import IssueStatus
+
+        wm = get_work_map_service()
+
+        # FAILED → IN_PROGRESS (valid transition)
+        result = await wm._issue_service.update_issue_status(
+            issue_id, IssueStatus.IN_PROGRESS,
+            reason="integrity_monitor: PR is merged, recovering from FAILED"
+        )
+        if not result:
+            return False
+
+        # Finalize: IN_PROGRESS → IMPLEMENTED → DONE + cascade
+        result = await wm._issue_service.finalize_issue(
+            issue_id, trigger_cascade=True
+        )
+        # finalize_issue expects IMPLEMENTED, but we're at IN_PROGRESS.
+        # So transition to IMPLEMENTED first, then finalize.
+        if not result:
+            result = await wm._issue_service.update_issue_status(
+                issue_id, IssueStatus.IMPLEMENTED,
+                reason="integrity_monitor: work merged, advancing to IMPLEMENTED"
+            )
+            if result:
+                result = await wm._issue_service.finalize_issue(
+                    issue_id, trigger_cascade=True
+                )
+
+        return result is not None
 
     # =========================================================================
     # Anomaly Checks
@@ -865,6 +911,72 @@ class SystemIntegrityMonitor:
                             ),
                             remediation_action="fail_parent_issue",
                         ))
+        except RuntimeError:
+            pass
+        return anomalies
+
+    async def _check_failed_issue_merged_pr(self) -> List[AnomalyResult]:
+        """Check 10: FAILED issues whose work branch is actually merged.
+
+        This catches the scenario where work completed and merged but the
+        work item timed out or failed for unrelated reasons, leaving the
+        issue stuck at FAILED while the code is on main. The fix recovers
+        the issue to DONE and triggers the dependency cascade to unblock
+        downstream work.
+        """
+        anomalies: List[AnomalyResult] = []
+        try:
+            from services.work_map_service import get_work_map_service
+            from api.git import get_pr_service
+            from git.pr_service import PRStatus
+            from models.work_map import IssueStatus
+
+            wm = get_work_map_service()
+            pr_service = get_pr_service()
+
+            result = await wm.list_issues(status=IssueStatus.FAILED, limit=100)
+            for issue in result.items:
+                # Find all work items for this issue
+                issue_work = [
+                    w for w in wm._work_items.values()
+                    if w.issue_id == issue.issue_id
+                ]
+                if not issue_work:
+                    continue
+
+                # Check if ANY work item's branch has a merged PR
+                has_merged_pr = False
+                merged_branch = None
+                for work in issue_work:
+                    if not work.branch_name or not work.project_id:
+                        continue
+                    try:
+                        git_project = self._resolve_git_project_name(
+                            work.project_id
+                        )
+                        pr = await pr_service.get_pr(
+                            git_project, work.branch_name
+                        )
+                        if pr and pr.status == PRStatus.MERGED:
+                            has_merged_pr = True
+                            merged_branch = work.branch_name
+                            break
+                    except Exception:
+                        continue
+
+                if has_merged_pr:
+                    anomalies.append(AnomalyResult(
+                        check_type="failed_issue_merged_pr",
+                        entity_type="issue",
+                        entity_id=issue.issue_id,
+                        project_id=getattr(issue, 'project_id', None),
+                        description=(
+                            f"Issue {issue.issue_id} is FAILED but branch "
+                            f"{merged_branch} is merged — recovering to DONE"
+                        ),
+                        remediation_action="recover_failed_issue",
+                        context={"branch": merged_branch},
+                    ))
         except RuntimeError:
             pass
         return anomalies

--- a/serving/services/unified_directive_service.py
+++ b/serving/services/unified_directive_service.py
@@ -893,7 +893,21 @@ class UnifiedDirectiveService:
 
             result = {}
             if goal and goal.issue_ids:
-                result["issues_created"] = list(goal.issue_ids)
+                # Fetch full issue details for frontend display
+                from services.work_map_service import get_work_map_service
+                wm_service = get_work_map_service()
+                issues_with_details = []
+                for iid in goal.issue_ids:
+                    issue = await wm_service.get_issue(iid)
+                    if issue:
+                        issues_with_details.append({
+                            "issue_id": issue.issue_id,
+                            "title": issue.title,
+                            "priority": issue.priority.value if issue.priority else None,
+                        })
+                    else:
+                        issues_with_details.append({"issue_id": iid, "title": iid})
+                result["issues_created"] = issues_with_details
             if goal and getattr(goal, 'summary', None):
                 result["reasoning"] = goal.summary
 

--- a/serving/services/work_context_enrichment_service.py
+++ b/serving/services/work_context_enrichment_service.py
@@ -1,0 +1,205 @@
+"""Work Context Enrichment Service.
+
+Enriches work item context before compute assignment with:
+- Parent goal description and reasoning
+- Dependency context (what this work depends on, what it blocks)
+- Sibling work items in the same goal (for awareness)
+- Project conventions and tech stack info
+
+This provides compute instances with broader system awareness so they
+can make better technical decisions and avoid conflicts.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class WorkContextEnrichmentService:
+    """Enriches work item context before dispatch to compute instances.
+
+    Pulls relevant information from goals, issues, and project metadata
+    to give compute instances broader awareness of the work they're doing.
+    """
+
+    async def enrich(
+        self,
+        work_context: Dict[str, Any],
+        work_id: str,
+        project_id: str,
+    ) -> Dict[str, Any]:
+        """Enrich a work item's context dict with additional information.
+
+        Args:
+            work_context: The existing context dict from WorkItem.context
+            work_id: Work item ID for lookups
+            project_id: Project ID for project-level context
+
+        Returns:
+            Enriched context dict (original dict is not mutated)
+        """
+        enriched = dict(work_context)
+
+        # Enrich with goal context
+        goal_context = await self._get_goal_context(enriched)
+        if goal_context:
+            enriched["goal_context"] = goal_context
+
+        # Enrich with dependency context
+        dep_context = await self._get_dependency_context(work_id)
+        if dep_context:
+            enriched["dependency_context"] = dep_context
+
+        # Enrich with sibling issue context
+        sibling_context = await self._get_sibling_context(enriched)
+        if sibling_context:
+            enriched["sibling_issues"] = sibling_context
+
+        # Enrich with project metadata
+        project_context = await self._get_project_context(project_id)
+        if project_context:
+            enriched["project_context"] = project_context
+
+        return enriched
+
+    async def _get_goal_context(self, work_context: Dict[str, Any]) -> Optional[Dict[str, str]]:
+        """Fetch parent goal description and intent."""
+        goal_id = work_context.get("goal_id")
+        if not goal_id:
+            return None
+
+        try:
+            from services.goal_service import get_goal_service
+            goal_service = get_goal_service()
+            goal = await goal_service.get_goal(goal_id)
+            if not goal:
+                return None
+
+            result: Dict[str, str] = {
+                "goal_title": goal.title,
+                "goal_description": goal.description[:1000] if goal.description else "",
+            }
+
+            # Include intent if available
+            if hasattr(goal, "intent_type") and goal.intent_type:
+                result["goal_intent"] = goal.intent_type.value
+
+            return result
+
+        except Exception as e:
+            logger.debug(f"Could not fetch goal context for {goal_id}: {e}")
+            return None
+
+    async def _get_dependency_context(self, work_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch information about work dependencies (what this depends on / blocks)."""
+        try:
+            from services.work_map_service import get_work_map_service
+            wm = get_work_map_service()
+
+            work = await wm.get_work(work_id)
+            if not work:
+                return None
+
+            dep_info: Dict[str, Any] = {}
+
+            # What this work depends on
+            if work.depends_on:
+                depends_on_summaries = []
+                for dep_id in work.depends_on[:5]:  # Limit to avoid bloat
+                    dep_work = await wm.get_work(dep_id)
+                    if dep_work:
+                        depends_on_summaries.append({
+                            "work_id": dep_id,
+                            "title": dep_work.title,
+                            "status": dep_work.status.value,
+                        })
+                if depends_on_summaries:
+                    dep_info["depends_on"] = depends_on_summaries
+
+            # What this work blocks
+            if work.blocks:
+                blocks_summaries = []
+                for block_id in work.blocks[:5]:
+                    blocked_work = await wm.get_work(block_id)
+                    if blocked_work:
+                        blocks_summaries.append({
+                            "work_id": block_id,
+                            "title": blocked_work.title,
+                        })
+                if blocks_summaries:
+                    dep_info["blocks"] = blocks_summaries
+
+            return dep_info if dep_info else None
+
+        except Exception as e:
+            logger.debug(f"Could not fetch dependency context for {work_id}: {e}")
+            return None
+
+    async def _get_sibling_context(self, work_context: Dict[str, Any]) -> Optional[List[Dict[str, str]]]:
+        """Fetch sibling issues from the same goal for awareness."""
+        goal_id = work_context.get("goal_id")
+        issue_id = work_context.get("issue_id")
+        if not goal_id:
+            return None
+
+        try:
+            from services.issue_service import get_issue_service
+            issue_service = get_issue_service()
+            issues = await issue_service.list_issues(goal_id=goal_id)
+
+            if not issues:
+                return None
+
+            siblings = []
+            for issue in issues[:10]:  # Limit to avoid token bloat
+                if issue.issue_id == issue_id:
+                    continue  # Skip self
+                siblings.append({
+                    "issue_id": issue.issue_id,
+                    "title": issue.title,
+                    "status": issue.status.value,
+                    "area": issue.area.value if hasattr(issue, "area") and issue.area else "",
+                })
+
+            return siblings if siblings else None
+
+        except Exception as e:
+            logger.debug(f"Could not fetch sibling context for goal {goal_id}: {e}")
+            return None
+
+    async def _get_project_context(self, project_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch project-level metadata (tech stack, conventions)."""
+        try:
+            from services.project_service import get_project_service
+            project_service = get_project_service()
+            project = await project_service.get_project(project_id)
+            if not project:
+                return None
+
+            result: Dict[str, Any] = {}
+
+            if hasattr(project, "tech_stack") and project.tech_stack:
+                result["tech_stack"] = project.tech_stack
+            if hasattr(project, "conventions") and project.conventions:
+                result["conventions"] = project.conventions
+            if hasattr(project, "description") and project.description:
+                result["project_description"] = project.description[:500]
+
+            return result if result else None
+
+        except Exception as e:
+            logger.debug(f"Could not fetch project context for {project_id}: {e}")
+            return None
+
+
+# Module-level singleton
+_service: Optional[WorkContextEnrichmentService] = None
+
+
+def get_work_context_enrichment_service() -> WorkContextEnrichmentService:
+    """Get the singleton WorkContextEnrichmentService."""
+    global _service
+    if _service is None:
+        _service = WorkContextEnrichmentService()
+    return _service

--- a/serving/services/work_dispatcher.py
+++ b/serving/services/work_dispatcher.py
@@ -229,6 +229,15 @@ class WorkDispatcher:
             logger.debug("SSE manager not initialized yet, skipping dispatch cycle")
             return
 
+        # Respect system-wide pause — no new work of any kind
+        try:
+            from services.work_orchestrator import get_work_orchestrator
+            orchestrator = get_work_orchestrator()
+            if orchestrator and orchestrator.is_paused():
+                return
+        except Exception:
+            pass
+
         # Assign decomposition tasks (highest priority)
         if self._decomp_queue:
             await self._assign_decomp_tasks(sse_manager)

--- a/serving/services/work_map_service.py
+++ b/serving/services/work_map_service.py
@@ -1145,6 +1145,22 @@ class WorkMapService:
                 f"Finalized work {work_id} and issue {work.issue_id} after merge"
             )
 
+        # Emit success notification (mirrors fail_work_and_update_issue pattern)
+        try:
+            from services.notification_service import get_notification_service
+            from models.notification import NotificationLevel, NotificationCategory
+            svc = get_notification_service()
+            svc.emit(
+                title=f"Work completed: {work.title}",
+                message=f"Work {work_id} merged and finalized successfully",
+                level=NotificationLevel.SUCCESS,
+                category=NotificationCategory.WORK,
+                project_id=work.project_id,
+                entity_id=work_id,
+            )
+        except Exception:
+            pass
+
         return work
 
     async def cascade_dependents(self, work_id: str) -> List[str]:

--- a/serving/services/work_orchestrator.py
+++ b/serving/services/work_orchestrator.py
@@ -1238,6 +1238,20 @@ class WorkOrchestrator:
                 "requirements": work.description,
             }
 
+            # Enrich context with goal, dependency, and project info (#263)
+            try:
+                from services.work_context_enrichment_service import (
+                    get_work_context_enrichment_service,
+                )
+                enrichment = get_work_context_enrichment_service()
+                context = await enrichment.enrich(
+                    work_context=context,
+                    work_id=work.work_id,
+                    project_id=work.project_id,
+                )
+            except Exception as e:
+                logger.debug(f"Context enrichment skipped for {work.work_id}: {e}")
+
             # Include repo details so compute knows the correct clone URL and project name.
             # Always override repository and base_branch — compute must clone from
             # the internal serving URL, never from an external origin.

--- a/serving/tests/test_decomposition_validation.py
+++ b/serving/tests/test_decomposition_validation.py
@@ -1,0 +1,245 @@
+"""Unit tests for DecompositionValidationService.
+
+Tests circular dependency detection, invalid reference handling,
+auto-fix behavior, and scope warning generation.
+"""
+
+import pytest
+
+from models.goal_decomposer import DecomposedIssue, GoalDecompositionResult
+from services.decomposition_validation_service import (
+    DecompositionValidationResult,
+    DecompositionValidationService,
+    validate_decomposition,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _issue(temp_id: str, blocked_by: list[str] | None = None, **kwargs) -> DecomposedIssue:
+    """Helper to build a DecomposedIssue with minimal boilerplate."""
+    defaults = {
+        "temp_id": temp_id,
+        "title": kwargs.pop("title", f"Issue {temp_id}"),
+        "description": kwargs.pop("description", f"Description for {temp_id}"),
+        "blocked_by": blocked_by or [],
+        "acceptance_criteria": kwargs.pop("acceptance_criteria", ["AC1"]),
+    }
+    defaults.update(kwargs)
+    return DecomposedIssue(**defaults)
+
+
+def _result(issues: list[DecomposedIssue]) -> GoalDecompositionResult:
+    """Helper to build a GoalDecompositionResult."""
+    return GoalDecompositionResult(
+        goal_id="goal-1",
+        decomposition_id="decomp-1",
+        issues=issues,
+        confidence=0.8,
+        reasoning="test",
+    )
+
+
+@pytest.fixture
+def service():
+    return DecompositionValidationService()
+
+
+# ---------------------------------------------------------------------------
+# Valid decompositions
+# ---------------------------------------------------------------------------
+
+class TestValidDecomposition:
+    """Tests for valid decomposition results."""
+
+    def test_empty_issues(self, service):
+        result = _result([])
+        v = service.validate(result)
+        assert v.valid
+        assert not v.issues
+
+    def test_simple_chain(self, service):
+        """A -> B -> C is valid."""
+        issues = [
+            _issue("a"),
+            _issue("b", blocked_by=["a"]),
+            _issue("c", blocked_by=["b"]),
+        ]
+        v = service.validate(_result(issues))
+        assert v.valid
+        assert not v.errors
+
+    def test_diamond_dependency(self, service):
+        """A -> B, A -> C, B -> D, C -> D is valid."""
+        issues = [
+            _issue("a"),
+            _issue("b", blocked_by=["a"]),
+            _issue("c", blocked_by=["a"]),
+            _issue("d", blocked_by=["b", "c"]),
+        ]
+        v = service.validate(_result(issues))
+        assert v.valid
+
+    def test_no_dependencies(self, service):
+        """All independent issues are valid."""
+        issues = [_issue("a"), _issue("b"), _issue("c")]
+        v = service.validate(_result(issues))
+        assert v.valid
+
+
+# ---------------------------------------------------------------------------
+# Circular dependency detection
+# ---------------------------------------------------------------------------
+
+class TestCircularDependency:
+    """Tests for circular dependency detection."""
+
+    def test_simple_cycle(self, service):
+        """A -> B -> A is a cycle."""
+        issues = [
+            _issue("a", blocked_by=["b"]),
+            _issue("b", blocked_by=["a"]),
+        ]
+        v = service.validate(_result(issues), auto_fix=False)
+        assert not v.valid
+        assert any(e.code == "circular_dependency" for e in v.errors)
+
+    def test_three_node_cycle(self, service):
+        """A -> B -> C -> A is a cycle."""
+        issues = [
+            _issue("a", blocked_by=["c"]),
+            _issue("b", blocked_by=["a"]),
+            _issue("c", blocked_by=["b"]),
+        ]
+        v = service.validate(_result(issues), auto_fix=False)
+        assert not v.valid
+        assert any(e.code == "circular_dependency" for e in v.errors)
+
+    def test_self_dependency(self, service):
+        """A -> A is a self-ref."""
+        issues = [_issue("a", blocked_by=["a"])]
+        v = service.validate(_result(issues), auto_fix=False)
+        assert not v.valid
+        assert any(e.code == "self_dependency" for e in v.errors)
+
+    def test_cycle_auto_fix(self, service):
+        """Auto-fix breaks cycles by removing back-edges."""
+        issues = [
+            _issue("a", blocked_by=["b"]),
+            _issue("b", blocked_by=["a"]),
+        ]
+        v = service.validate(_result(issues), auto_fix=True)
+        assert v.fixed_result is not None
+        # After fix, at least one of the cycle edges should be removed
+        fixed_deps = {
+            di.temp_id: di.blocked_by for di in v.fixed_result.issues
+        }
+        # Not both can still point to each other
+        assert not (
+            "b" in fixed_deps.get("a", []) and "a" in fixed_deps.get("b", [])
+        )
+
+
+# ---------------------------------------------------------------------------
+# Invalid reference detection
+# ---------------------------------------------------------------------------
+
+class TestInvalidReferences:
+    """Tests for blocked_by references to non-existent temp_ids."""
+
+    def test_missing_dependency(self, service):
+        """Reference to non-existent temp_id."""
+        issues = [_issue("a", blocked_by=["nonexistent"])]
+        v = service.validate(_result(issues), auto_fix=False)
+        assert not v.valid
+        assert any(e.code == "invalid_dependency_ref" for e in v.errors)
+
+    def test_missing_dependency_auto_fix(self, service):
+        """Auto-fix removes invalid references."""
+        issues = [_issue("a", blocked_by=["nonexistent", "also_missing"])]
+        v = service.validate(_result(issues), auto_fix=True)
+        assert v.fixed_result is not None
+        fixed_a = next(di for di in v.fixed_result.issues if di.temp_id == "a")
+        assert fixed_a.blocked_by == []
+
+
+# ---------------------------------------------------------------------------
+# Duplicate temp_id detection
+# ---------------------------------------------------------------------------
+
+class TestDuplicateTempIds:
+    """Tests for duplicate temp_id detection."""
+
+    def test_duplicate_detected(self, service):
+        issues = [_issue("a"), _issue("a", title="Different title")]
+        v = service.validate(_result(issues), auto_fix=False)
+        assert not v.valid
+        assert any(e.code == "duplicate_temp_id" for e in v.errors)
+
+
+# ---------------------------------------------------------------------------
+# Scope warnings
+# ---------------------------------------------------------------------------
+
+class TestScopeWarnings:
+    """Tests for scope-related warnings."""
+
+    def test_empty_title_is_error(self, service):
+        issues = [_issue("a", title="")]
+        v = service.validate(_result(issues))
+        assert any(e.code == "empty_title" and e.severity == "error" for e in v.issues)
+
+    def test_empty_description_is_warning(self, service):
+        issues = [_issue("a", description="")]
+        v = service.validate(_result(issues))
+        assert any(e.code == "empty_description" and e.severity == "warning" for e in v.issues)
+
+    def test_no_acceptance_criteria_is_warning(self, service):
+        issues = [_issue("a", acceptance_criteria=[])]
+        v = service.validate(_result(issues))
+        assert any(e.code == "no_acceptance_criteria" and e.severity == "warning" for e in v.issues)
+
+    def test_warnings_dont_fail_validation(self, service):
+        """Warnings alone should not make the result invalid."""
+        issues = [_issue("a", description="", acceptance_criteria=[])]
+        v = service.validate(_result(issues))
+        assert v.valid  # Only errors cause invalid
+
+
+# ---------------------------------------------------------------------------
+# Self-reference auto-fix
+# ---------------------------------------------------------------------------
+
+class TestSelfRefAutoFix:
+    """Tests for self-reference auto-fix."""
+
+    def test_self_ref_removed(self, service):
+        issues = [_issue("a", blocked_by=["a"])]
+        v = service.validate(_result(issues), auto_fix=True)
+        assert v.fixed_result is not None
+        fixed_a = v.fixed_result.issues[0]
+        assert "a" not in fixed_a.blocked_by
+
+
+# ---------------------------------------------------------------------------
+# Integration: validate_decomposition function
+# ---------------------------------------------------------------------------
+
+class TestValidateFunction:
+    """Tests for the module-level validate_decomposition function."""
+
+    def test_direct_call(self):
+        issues = [_issue("a"), _issue("b", blocked_by=["a"])]
+        v = validate_decomposition(_result(issues))
+        assert v.valid
+
+    def test_mixed_errors_and_warnings(self):
+        issues = [
+            _issue("a", blocked_by=["missing"], description="", acceptance_criteria=[]),
+        ]
+        v = validate_decomposition(_result(issues), auto_fix=False)
+        assert not v.valid
+        assert len(v.errors) >= 1
+        assert len(v.warnings) >= 1

--- a/serving/tests/test_lead_compute_service.py
+++ b/serving/tests/test_lead_compute_service.py
@@ -1,0 +1,269 @@
+"""Unit tests for LeadComputeService.
+
+Tests PR review dispatch, timeout handling, and graceful degradation.
+All external services (SSE, Redis, MCP) are mocked.
+"""
+
+import asyncio
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.lead_compute_service import (
+    LeadComputeService,
+    LeadReviewResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def service():
+    return LeadComputeService(timeout=5)
+
+
+@pytest.fixture
+def disabled_service():
+    svc = LeadComputeService(timeout=5)
+    svc.enabled = False
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# LeadReviewResult
+# ---------------------------------------------------------------------------
+
+class TestLeadReviewResult:
+    def test_to_dict(self):
+        result = LeadReviewResult(
+            approved=False,
+            reviewer_id="compute-1",
+            summary="Found issues",
+            issues=[{"severity": "error", "file": "main.py", "message": "Bad import"}],
+        )
+        d = result.to_dict()
+        assert d["approved"] is False
+        assert d["reviewer_id"] == "compute-1"
+        assert len(d["issues"]) == 1
+
+    def test_defaults(self):
+        result = LeadReviewResult(approved=True, reviewer_id="test")
+        assert result.summary == ""
+        assert result.issues == []
+
+
+# ---------------------------------------------------------------------------
+# Disabled service
+# ---------------------------------------------------------------------------
+
+class TestDisabledService:
+    @pytest.mark.asyncio
+    async def test_returns_approved_when_disabled(self, disabled_service):
+        result = await disabled_service.review_pr(
+            project="myproject",
+            branch="f/issue-1/compute-1",
+            compute_id="compute-1",
+        )
+        assert result.approved is True
+        assert result.reviewer_id == "lead-review-disabled"
+
+
+# ---------------------------------------------------------------------------
+# Review context building
+# ---------------------------------------------------------------------------
+
+class TestBuildReviewContext:
+    def test_context_contains_project_and_branch(self, service):
+        ctx = service._build_review_context(
+            review_id="rev-123",
+            project="myproject",
+            branch="f/issue-1/compute-1",
+            work_title="Add auth",
+            work_description="Implement JWT auth",
+        )
+        assert "myproject" in ctx
+        assert "f/issue-1/compute-1" in ctx
+        assert "Add auth" in ctx
+        assert "Implement JWT auth" in ctx
+        assert "rev-123" in ctx
+
+    def test_context_no_description(self, service):
+        ctx = service._build_review_context(
+            review_id="rev-123",
+            project="proj",
+            branch="b",
+        )
+        assert "No description provided" in ctx
+
+
+# ---------------------------------------------------------------------------
+# No compute available
+# ---------------------------------------------------------------------------
+
+class TestNoComputeAvailable:
+    @pytest.mark.asyncio
+    async def test_auto_approves_when_no_compute(self, service):
+        mock_sse = MagicMock()
+        mock_sse.find_matching_connection = MagicMock(return_value=None)
+
+        mock_completion = MagicMock()
+        mock_completion.create_event = MagicMock()
+        mock_completion.get_event = MagicMock()
+        mock_completion.cleanup = MagicMock()
+
+        mock_mods = {
+            "services.completion_events": mock_completion,
+            "services.sse_connection_manager": MagicMock(
+                get_sse_connection_manager=MagicMock(return_value=mock_sse)
+            ),
+        }
+
+        with patch.dict(sys.modules, mock_mods):
+            result = await service.review_pr(
+                project="proj",
+                branch="b",
+                compute_id="c1",
+            )
+
+        assert result.approved is True
+        assert "no-reviewer-available" in result.reviewer_id.lower() or "no" in result.reviewer_id
+
+
+# ---------------------------------------------------------------------------
+# Dispatch failure
+# ---------------------------------------------------------------------------
+
+class TestDispatchFailure:
+    @pytest.mark.asyncio
+    async def test_auto_approves_on_dispatch_error(self, service):
+        """If dispatching review fails entirely, auto-approve."""
+        mock_completion = MagicMock()
+        mock_completion.create_event = MagicMock(side_effect=Exception("event system down"))
+        mock_completion.cleanup = MagicMock()
+
+        mock_mods = {
+            "services.completion_events": mock_completion,
+        }
+
+        with patch.dict(sys.modules, mock_mods):
+            result = await service.review_pr(
+                project="proj",
+                branch="b",
+                compute_id="c1",
+            )
+
+        assert result.approved is True
+
+
+# ---------------------------------------------------------------------------
+# Successful review
+# ---------------------------------------------------------------------------
+
+class TestSuccessfulReview:
+    @pytest.mark.asyncio
+    async def test_approved_review(self, service):
+        """Test a full successful review flow."""
+        mock_event = asyncio.Event()
+        mock_event.set()  # Pre-set so wait() returns immediately
+
+        mock_connection = MagicMock()
+        mock_connection.compute_id = "reviewer-1"
+
+        mock_sse = MagicMock()
+        mock_sse.find_matching_connection = MagicMock(return_value=mock_connection)
+        mock_sse.send_work_assigned = AsyncMock(return_value=True)
+
+        mock_redis = MagicMock()
+        mock_redis.get = AsyncMock(return_value=json.dumps({
+            "approved": True,
+            "summary": "LGTM",
+            "issues": [],
+        }))
+
+        mock_mods = {
+            "services.completion_events": MagicMock(
+                create_event=MagicMock(),
+                get_event=MagicMock(return_value=mock_event),
+                cleanup=MagicMock(),
+            ),
+            "services.sse_connection_manager": MagicMock(
+                get_sse_connection_manager=MagicMock(return_value=mock_sse),
+            ),
+            "services.marketplace_client": MagicMock(
+                get_marketplace_client=MagicMock(side_effect=Exception("skip")),
+            ),
+            "mcp.auth": MagicMock(
+                generate_api_key=MagicMock(return_value="key-123"),
+                register_compute_key=AsyncMock(),
+            ),
+            "git.redis_client": MagicMock(
+                get_redis=AsyncMock(return_value=mock_redis),
+            ),
+        }
+
+        with patch.dict(sys.modules, mock_mods):
+            result = await service.review_pr(
+                project="proj",
+                branch="b",
+                compute_id="author-1",
+            )
+
+        assert result.approved is True
+        assert result.reviewer_id == "reviewer-1"
+        assert result.summary == "LGTM"
+
+    @pytest.mark.asyncio
+    async def test_rejected_review(self, service):
+        """Test a review that rejects the PR."""
+        mock_event = asyncio.Event()
+        mock_event.set()
+
+        mock_connection = MagicMock()
+        mock_connection.compute_id = "reviewer-1"
+
+        mock_sse = MagicMock()
+        mock_sse.find_matching_connection = MagicMock(return_value=mock_connection)
+        mock_sse.send_work_assigned = AsyncMock(return_value=True)
+
+        mock_redis = MagicMock()
+        mock_redis.get = AsyncMock(return_value=json.dumps({
+            "approved": False,
+            "summary": "Missing DB migration",
+            "issues": [{"severity": "error", "file": "models.py", "message": "No migration"}],
+        }))
+
+        mock_mods = {
+            "services.completion_events": MagicMock(
+                create_event=MagicMock(),
+                get_event=MagicMock(return_value=mock_event),
+                cleanup=MagicMock(),
+            ),
+            "services.sse_connection_manager": MagicMock(
+                get_sse_connection_manager=MagicMock(return_value=mock_sse),
+            ),
+            "services.marketplace_client": MagicMock(
+                get_marketplace_client=MagicMock(side_effect=Exception("skip")),
+            ),
+            "mcp.auth": MagicMock(
+                generate_api_key=MagicMock(return_value="key-123"),
+                register_compute_key=AsyncMock(),
+            ),
+            "git.redis_client": MagicMock(
+                get_redis=AsyncMock(return_value=mock_redis),
+            ),
+        }
+
+        with patch.dict(sys.modules, mock_mods):
+            result = await service.review_pr(
+                project="proj",
+                branch="b",
+                compute_id="author-1",
+            )
+
+        assert result.approved is False
+        assert result.reviewer_id == "reviewer-1"
+        assert len(result.issues) == 1

--- a/serving/tests/test_work_context_enrichment.py
+++ b/serving/tests/test_work_context_enrichment.py
@@ -1,0 +1,293 @@
+"""Unit tests for WorkContextEnrichmentService.
+
+Tests context enrichment with goal, dependency, sibling, and project info.
+All external services are mocked.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.work_context_enrichment_service import WorkContextEnrichmentService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def service():
+    return WorkContextEnrichmentService()
+
+
+@pytest.fixture
+def base_context():
+    return {
+        "task_type": "execution",
+        "goal_id": "goal-123",
+        "issue_id": "issue-456",
+        "repo_url": "http://serving:8002/repos/myproject",
+    }
+
+
+def _mock_goal(title="Build auth", description="Implement authentication", intent_type=None):
+    goal = MagicMock()
+    goal.title = title
+    goal.description = description
+    goal.intent_type = intent_type
+    return goal
+
+
+def _mock_work(work_id, title="Some work", status_val="pending", depends_on=None, blocks=None):
+    work = MagicMock()
+    work.work_id = work_id
+    work.title = title
+    work.status.value = status_val
+    work.depends_on = depends_on or []
+    work.blocks = blocks or []
+    return work
+
+
+def _mock_issue(issue_id, title="Some issue", status_val="ready", area_val="api"):
+    issue = MagicMock()
+    issue.issue_id = issue_id
+    issue.title = title
+    issue.status.value = status_val
+    issue.area.value = area_val
+    return issue
+
+
+def _patch_service_module(service_name, mock_getter):
+    """Create a mock module that provides the getter function.
+
+    The enrichment service does `from services.X import get_X` inside methods.
+    We need to ensure the module exists in sys.modules with the getter.
+    """
+    module_name = f"services.{service_name}"
+    mock_module = MagicMock()
+    setattr(mock_module, f"get_{service_name}", mock_getter)
+    return patch.dict(sys.modules, {module_name: mock_module})
+
+
+# ---------------------------------------------------------------------------
+# Goal context
+# ---------------------------------------------------------------------------
+
+class TestGoalContext:
+    @pytest.mark.asyncio
+    async def test_goal_context_included(self, service, base_context):
+        mock_goal_svc = MagicMock()
+        mock_goal_svc.get_goal = AsyncMock(return_value=_mock_goal())
+
+        mock_mod = MagicMock()
+        mock_mod.get_goal_service = MagicMock(return_value=mock_goal_svc)
+
+        with patch.dict(sys.modules, {"services.goal_service": mock_mod}):
+            result = await service._get_goal_context(base_context)
+
+        assert result is not None
+        assert result["goal_title"] == "Build auth"
+        assert "Implement authentication" in result["goal_description"]
+
+    @pytest.mark.asyncio
+    async def test_no_goal_id(self, service):
+        result = await service._get_goal_context({})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_goal_not_found(self, service, base_context):
+        mock_goal_svc = MagicMock()
+        mock_goal_svc.get_goal = AsyncMock(return_value=None)
+        mock_mod = MagicMock()
+        mock_mod.get_goal_service = MagicMock(return_value=mock_goal_svc)
+
+        with patch.dict(sys.modules, {"services.goal_service": mock_mod}):
+            result = await service._get_goal_context(base_context)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_goal_service_error(self, service, base_context):
+        mock_mod = MagicMock()
+        mock_mod.get_goal_service = MagicMock(side_effect=Exception("DB error"))
+
+        with patch.dict(sys.modules, {"services.goal_service": mock_mod}):
+            result = await service._get_goal_context(base_context)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Dependency context
+# ---------------------------------------------------------------------------
+
+class TestDependencyContext:
+    @pytest.mark.asyncio
+    async def test_depends_on_included(self, service):
+        main_work = _mock_work("w-1", depends_on=["w-0"], blocks=[])
+        dep_work = _mock_work("w-0", title="Setup DB")
+
+        mock_wm_svc = MagicMock()
+        mock_wm_svc.get_work = AsyncMock(side_effect=lambda wid: {
+            "w-1": main_work, "w-0": dep_work
+        }.get(wid))
+        mock_mod = MagicMock()
+        mock_mod.get_work_map_service = MagicMock(return_value=mock_wm_svc)
+
+        with patch.dict(sys.modules, {"services.work_map_service": mock_mod}):
+            result = await service._get_dependency_context("w-1")
+
+        assert result is not None
+        assert len(result["depends_on"]) == 1
+        assert result["depends_on"][0]["title"] == "Setup DB"
+
+    @pytest.mark.asyncio
+    async def test_blocks_included(self, service):
+        main_work = _mock_work("w-1", depends_on=[], blocks=["w-2"])
+        blocked_work = _mock_work("w-2", title="Frontend")
+
+        mock_wm_svc = MagicMock()
+        mock_wm_svc.get_work = AsyncMock(side_effect=lambda wid: {
+            "w-1": main_work, "w-2": blocked_work
+        }.get(wid))
+        mock_mod = MagicMock()
+        mock_mod.get_work_map_service = MagicMock(return_value=mock_wm_svc)
+
+        with patch.dict(sys.modules, {"services.work_map_service": mock_mod}):
+            result = await service._get_dependency_context("w-1")
+
+        assert result is not None
+        assert result["blocks"][0]["title"] == "Frontend"
+
+    @pytest.mark.asyncio
+    async def test_no_dependencies(self, service):
+        work = _mock_work("w-1")
+        mock_wm_svc = MagicMock()
+        mock_wm_svc.get_work = AsyncMock(return_value=work)
+        mock_mod = MagicMock()
+        mock_mod.get_work_map_service = MagicMock(return_value=mock_wm_svc)
+
+        with patch.dict(sys.modules, {"services.work_map_service": mock_mod}):
+            result = await service._get_dependency_context("w-1")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Sibling context
+# ---------------------------------------------------------------------------
+
+class TestSiblingContext:
+    @pytest.mark.asyncio
+    async def test_siblings_included(self, service, base_context):
+        issues = [
+            _mock_issue("issue-456", title="Current issue"),
+            _mock_issue("issue-789", title="Sibling issue"),
+        ]
+        mock_is_svc = MagicMock()
+        mock_is_svc.list_issues = AsyncMock(return_value=issues)
+        mock_mod = MagicMock()
+        mock_mod.get_issue_service = MagicMock(return_value=mock_is_svc)
+
+        with patch.dict(sys.modules, {"services.issue_service": mock_mod}):
+            result = await service._get_sibling_context(base_context)
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["title"] == "Sibling issue"
+
+    @pytest.mark.asyncio
+    async def test_no_goal_id(self, service):
+        result = await service._get_sibling_context({})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_only_self(self, service, base_context):
+        issues = [_mock_issue("issue-456", title="Only me")]
+        mock_is_svc = MagicMock()
+        mock_is_svc.list_issues = AsyncMock(return_value=issues)
+        mock_mod = MagicMock()
+        mock_mod.get_issue_service = MagicMock(return_value=mock_is_svc)
+
+        with patch.dict(sys.modules, {"services.issue_service": mock_mod}):
+            result = await service._get_sibling_context(base_context)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Full enrichment
+# ---------------------------------------------------------------------------
+
+class TestFullEnrichment:
+    @pytest.mark.asyncio
+    async def test_enrichment_adds_all_sections(self, service, base_context):
+        mock_goal_svc = MagicMock()
+        mock_goal_svc.get_goal = AsyncMock(return_value=_mock_goal())
+
+        main_work = _mock_work("w-1", depends_on=["w-0"])
+        dep_work = _mock_work("w-0", title="Setup DB")
+        mock_wm_svc = MagicMock()
+        mock_wm_svc.get_work = AsyncMock(side_effect=lambda wid: {
+            "w-1": main_work, "w-0": dep_work
+        }.get(wid))
+
+        issues = [_mock_issue("issue-456"), _mock_issue("issue-789", title="Sibling")]
+        mock_is_svc = MagicMock()
+        mock_is_svc.list_issues = AsyncMock(return_value=issues)
+
+        mock_project = MagicMock()
+        mock_project.tech_stack = "Python, FastAPI"
+        mock_project.conventions = "PEP 8"
+        mock_project.description = "AI orchestration platform"
+        mock_ps_svc = MagicMock()
+        mock_ps_svc.get_project = AsyncMock(return_value=mock_project)
+
+        mock_mods = {
+            "services.goal_service": MagicMock(get_goal_service=MagicMock(return_value=mock_goal_svc)),
+            "services.work_map_service": MagicMock(get_work_map_service=MagicMock(return_value=mock_wm_svc)),
+            "services.issue_service": MagicMock(get_issue_service=MagicMock(return_value=mock_is_svc)),
+            "services.project_service": MagicMock(get_project_service=MagicMock(return_value=mock_ps_svc)),
+        }
+
+        with patch.dict(sys.modules, mock_mods):
+            result = await service.enrich(base_context, "w-1", "proj-1")
+
+        assert result["task_type"] == "execution"
+        assert "goal_context" in result
+        assert "dependency_context" in result
+        assert "sibling_issues" in result
+        assert "project_context" in result
+
+    @pytest.mark.asyncio
+    async def test_enrichment_graceful_on_failures(self, service, base_context):
+        """If all service imports fail, enrichment returns original context."""
+        mock_mods = {
+            "services.goal_service": MagicMock(get_goal_service=MagicMock(side_effect=Exception("fail"))),
+            "services.work_map_service": MagicMock(get_work_map_service=MagicMock(side_effect=Exception("fail"))),
+            "services.issue_service": MagicMock(get_issue_service=MagicMock(side_effect=Exception("fail"))),
+            "services.project_service": MagicMock(get_project_service=MagicMock(side_effect=Exception("fail"))),
+        }
+
+        with patch.dict(sys.modules, mock_mods):
+            result = await service.enrich(base_context, "w-1", "proj-1")
+
+        assert result["task_type"] == "execution"
+        assert "goal_context" not in result
+
+    @pytest.mark.asyncio
+    async def test_original_context_not_mutated(self, service, base_context):
+        original = dict(base_context)
+
+        mock_goal_svc = MagicMock()
+        mock_goal_svc.get_goal = AsyncMock(return_value=_mock_goal())
+        mock_mods = {
+            "services.goal_service": MagicMock(get_goal_service=MagicMock(return_value=mock_goal_svc)),
+            "services.work_map_service": MagicMock(get_work_map_service=MagicMock(side_effect=Exception)),
+            "services.issue_service": MagicMock(get_issue_service=MagicMock(side_effect=Exception)),
+            "services.project_service": MagicMock(get_project_service=MagicMock(side_effect=Exception)),
+        }
+
+        with patch.dict(sys.modules, mock_mods):
+            result = await service.enrich(base_context, "w-1", "proj-1")
+
+        assert base_context == original
+        assert "goal_context" in result
+        assert "goal_context" not in base_context

--- a/serving/tests/unit/test_compute_auth_status.py
+++ b/serving/tests/unit/test_compute_auth_status.py
@@ -2,6 +2,7 @@
 
 import pytest
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch, MagicMock
 
 from models.compute import (
     ComputeInstance,
@@ -229,6 +230,66 @@ class TestRegistryAuthStatus:
 
         retrieved = await registry.get_instance("test-001")
         assert retrieved.auth_status == ComputeAuthStatus.AUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_register_syncs_auth_status_from_existing_token(self, registry):
+        """Registration should sync auth_status when an active token exists."""
+        from api.compute import register_instance
+        from models.compute import RegistrationRequest, InstanceCapabilities
+
+        request = RegistrationRequest(
+            instance_id="node-001",
+            name="Node 001",
+            endpoint="http://compute:8000",
+            capabilities=InstanceCapabilities(agents=["agent-a"]),
+        )
+
+        mock_instance = _make_instance(instance_id="node-001")
+        registry.add_instance = AsyncMock(return_value=mock_instance)
+        registry.update_auth_status = AsyncMock(return_value=mock_instance)
+
+        mock_auth_svc = MagicMock()
+        mock_auth_svc.get_token_info.return_value = {
+            "component_id": "node-001",
+            "status": "active",
+            "expires_at": "2027-03-04T03:56:23.900627+00:00",
+            "component_type": "compute",
+        }
+
+        with patch("services.claude_auth_service.get_claude_auth_service", return_value=mock_auth_svc), \
+             patch("services.observability_event_bus.get_event_bus", return_value=None):
+            await register_instance(request, registry=registry)
+
+        registry.update_auth_status.assert_called_once()
+        call_args = registry.update_auth_status.call_args
+        assert call_args[0][0] == "node-001"
+        assert call_args[0][1] == ComputeAuthStatus.AUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_register_stays_unauthorized_without_token(self, registry):
+        """Registration should not set AUTHORIZED when no token exists."""
+        from api.compute import register_instance
+        from models.compute import RegistrationRequest, InstanceCapabilities
+
+        request = RegistrationRequest(
+            instance_id="node-002",
+            name="Node 002",
+            endpoint="http://compute:8000",
+            capabilities=InstanceCapabilities(agents=["agent-a"]),
+        )
+
+        mock_instance = _make_instance(instance_id="node-002")
+        registry.add_instance = AsyncMock(return_value=mock_instance)
+        registry.update_auth_status = AsyncMock()
+
+        mock_auth_svc = MagicMock()
+        mock_auth_svc.get_token_info.return_value = None
+
+        with patch("services.claude_auth_service.get_claude_auth_service", return_value=mock_auth_svc), \
+             patch("services.observability_event_bus.get_event_bus", return_value=None):
+            await register_instance(request, registry=registry)
+
+        registry.update_auth_status.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_stats_include_auth_breakdown(self, registry):

--- a/serving/tests/unit/test_system_integrity_monitor.py
+++ b/serving/tests/unit/test_system_integrity_monitor.py
@@ -39,7 +39,7 @@ class FakeWorkItem:
 
 @dataclass
 class FakeIssue:
-    id: str
+    issue_id: str
     status: object
     project_id: str = "proj_test"
     goal_id: str = "goal_1"
@@ -47,7 +47,7 @@ class FakeIssue:
 
 @dataclass
 class FakeGoal:
-    id: str
+    goal_id: str
     status: object
     project_id: str = "proj_test"
 
@@ -278,7 +278,7 @@ class TestStuckIssues:
 
         from models.work_map import IssueStatus, WorkStatus
 
-        fake_issue = FakeIssue(id="issue_1", status=IssueStatus.IN_PROGRESS)
+        fake_issue = FakeIssue(issue_id="issue_1", status=IssueStatus.IN_PROGRESS)
         fake_work = FakeWorkItem(
             work_id="w1", status=WorkStatus.COMPLETED, issue_id="issue_1"
         )
@@ -305,7 +305,7 @@ class TestStuckIssues:
 
         from models.work_map import IssueStatus, WorkStatus
 
-        fake_issue = FakeIssue(id="issue_1", status=IssueStatus.IN_PROGRESS)
+        fake_issue = FakeIssue(issue_id="issue_1", status=IssueStatus.IN_PROGRESS)
         fake_work = FakeWorkItem(
             work_id="w1", status=WorkStatus.IN_PROGRESS, issue_id="issue_1"
         )
@@ -336,10 +336,10 @@ class TestStuckGoals:
 
         from models.work_map import GoalStatus, IssueStatus
 
-        fake_goal = FakeGoal(id="goal_1", status=GoalStatus.IN_PROGRESS)
+        fake_goal = FakeGoal(goal_id="goal_1", status=GoalStatus.IN_PROGRESS)
         fake_issues = [
-            FakeIssue(id="i1", status=IssueStatus.DONE),
-            FakeIssue(id="i2", status=IssueStatus.DONE),
+            FakeIssue(issue_id="i1", status=IssueStatus.DONE),
+            FakeIssue(issue_id="i2", status=IssueStatus.DONE),
         ]
 
         mock_wm = AsyncMock()
@@ -361,10 +361,10 @@ class TestStuckGoals:
 
         from models.work_map import GoalStatus, IssueStatus
 
-        fake_goal = FakeGoal(id="goal_1", status=GoalStatus.IN_PROGRESS)
+        fake_goal = FakeGoal(goal_id="goal_1", status=GoalStatus.IN_PROGRESS)
         fake_issues = [
-            FakeIssue(id="i1", status=IssueStatus.DONE),
-            FakeIssue(id="i2", status=IssueStatus.IN_PROGRESS),
+            FakeIssue(issue_id="i1", status=IssueStatus.DONE),
+            FakeIssue(issue_id="i2", status=IssueStatus.IN_PROGRESS),
         ]
 
         mock_wm = AsyncMock()

--- a/serving/tests/unit/test_system_integrity_monitor.py
+++ b/serving/tests/unit/test_system_integrity_monitor.py
@@ -157,7 +157,27 @@ class TestThrottling:
 # ---------------------------------------------------------------------------
 
 class TestNotification:
-    def test_notify_warning_below_threshold(self):
+    def test_success_notification(self):
+        monitor = SystemIntegrityMonitor()
+        anomaly = AnomalyResult(
+            check_type="merged_not_finalized",
+            entity_type="work",
+            entity_id="w1",
+            project_id="proj_test",
+            description="Work w1 auto-finalized",
+            remediation_action="finalize_work",
+        )
+
+        with patch(NOTIF_PATCH) as mock_get:
+            mock_svc = MagicMock()
+            mock_get.return_value = mock_svc
+            monitor._notify_success(anomaly)
+            mock_svc.emit.assert_called_once()
+            from models.notification import NotificationLevel
+            call_kwargs = mock_svc.emit.call_args
+            assert call_kwargs.kwargs.get("level") == NotificationLevel.SUCCESS
+
+    def test_failure_warning_below_threshold(self):
         monitor = SystemIntegrityMonitor()
         anomaly = AnomalyResult(
             check_type="stuck_goal",
@@ -171,13 +191,14 @@ class TestNotification:
         with patch(NOTIF_PATCH) as mock_get:
             mock_svc = MagicMock()
             mock_get.return_value = mock_svc
-            monitor._notify(anomaly, consecutive=1)
+            monitor._notify_failure(anomaly, consecutive=1)
             mock_svc.emit.assert_called_once()
             from models.notification import NotificationLevel
             call_kwargs = mock_svc.emit.call_args
             assert call_kwargs.kwargs.get("level") == NotificationLevel.WARNING
+            assert "Will retry" in call_kwargs.kwargs.get("message", "")
 
-    def test_notify_error_at_threshold(self):
+    def test_failure_error_at_threshold(self):
         monitor = SystemIntegrityMonitor()
         anomaly = AnomalyResult(
             check_type="stuck_goal",
@@ -191,11 +212,12 @@ class TestNotification:
         with patch(NOTIF_PATCH) as mock_get:
             mock_svc = MagicMock()
             mock_get.return_value = mock_svc
-            monitor._notify(anomaly, consecutive=ESCALATION_THRESHOLD)
+            monitor._notify_failure(anomaly, consecutive=ESCALATION_THRESHOLD)
             mock_svc.emit.assert_called_once()
             from models.notification import NotificationLevel
             call_kwargs = mock_svc.emit.call_args
             assert call_kwargs.kwargs.get("level") == NotificationLevel.ERROR
+            assert "Manual intervention" in call_kwargs.kwargs.get("message", "")
 
 
 # ---------------------------------------------------------------------------

--- a/serving/tests/unit/test_system_integrity_monitor.py
+++ b/serving/tests/unit/test_system_integrity_monitor.py
@@ -530,6 +530,7 @@ class TestStats:
         assert "orphaned_work" in stats["by_check_type"]
         assert "failed_work_impact" in stats["by_check_type"]
         assert "stuck_planning_goal" in stats["by_check_type"]
+        assert "failed_issue_merged_pr" in stats["by_check_type"]
 
 
 # ---------------------------------------------------------------------------
@@ -813,3 +814,130 @@ class TestStuckPlanningGoals:
             results = await monitor._check_stuck_planning_goals()
 
         assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# Check 10: Failed Issue with Merged PR
+# ---------------------------------------------------------------------------
+
+class TestFailedIssueMergedPR:
+    @pytest.mark.asyncio
+    async def test_detects_failed_issue_with_merged_pr(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import IssueStatus, WorkStatus
+        from git.pr_service import PRStatus
+
+        fake_issue = FakeIssue(
+            issue_id="issue_1", status=IssueStatus.FAILED, project_id="proj_a"
+        )
+        fake_work = FakeWorkItem(
+            work_id="w1", status=WorkStatus.FAILED,
+            branch_name="f/issue_1/compute-001", project_id="proj_a",
+            issue_id="issue_1",
+        )
+        fake_pr = FakePR(branch="f/issue_1/compute-001", status=PRStatus.MERGED)
+
+        mock_wm = AsyncMock()
+        mock_wm.list_issues = AsyncMock(
+            return_value=FakeListResult(items=[fake_issue])
+        )
+        mock_wm._work_items = {"w1": fake_work}
+
+        mock_pr_svc = AsyncMock()
+        mock_pr_svc.get_pr = AsyncMock(return_value=fake_pr)
+
+        with patch(WM_PATCH, return_value=mock_wm), \
+             patch(PR_PATCH, return_value=mock_pr_svc):
+            results = await monitor._check_failed_issue_merged_pr()
+
+        assert len(results) == 1
+        assert results[0].check_type == "failed_issue_merged_pr"
+        assert results[0].remediation_action == "recover_failed_issue"
+
+    @pytest.mark.asyncio
+    async def test_no_flag_when_pr_not_merged(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import IssueStatus, WorkStatus
+        from git.pr_service import PRStatus
+
+        fake_issue = FakeIssue(
+            issue_id="issue_1", status=IssueStatus.FAILED, project_id="proj_a"
+        )
+        fake_work = FakeWorkItem(
+            work_id="w1", status=WorkStatus.FAILED,
+            branch_name="f/issue_1/compute-001", project_id="proj_a",
+            issue_id="issue_1",
+        )
+        fake_pr = FakePR(branch="f/issue_1/compute-001", status=PRStatus.PENDING)
+
+        mock_wm = AsyncMock()
+        mock_wm.list_issues = AsyncMock(
+            return_value=FakeListResult(items=[fake_issue])
+        )
+        mock_wm._work_items = {"w1": fake_work}
+
+        mock_pr_svc = AsyncMock()
+        mock_pr_svc.get_pr = AsyncMock(return_value=fake_pr)
+
+        with patch(WM_PATCH, return_value=mock_wm), \
+             patch(PR_PATCH, return_value=mock_pr_svc):
+            results = await monitor._check_failed_issue_merged_pr()
+
+        assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_flag_when_no_work_items(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import IssueStatus
+
+        fake_issue = FakeIssue(
+            issue_id="issue_1", status=IssueStatus.FAILED, project_id="proj_a"
+        )
+
+        mock_wm = AsyncMock()
+        mock_wm.list_issues = AsyncMock(
+            return_value=FakeListResult(items=[fake_issue])
+        )
+        mock_wm._work_items = {}
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            results = await monitor._check_failed_issue_merged_pr()
+
+        assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_recover_remediation(self):
+        """Test the full recovery: FAILED → IN_PROGRESS → IMPLEMENTED → DONE."""
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import IssueStatus
+
+        mock_wm = AsyncMock()
+        mock_issue_svc = AsyncMock()
+        mock_wm._issue_service = mock_issue_svc
+
+        # First call (IN_PROGRESS) succeeds, finalize_issue succeeds
+        mock_issue_svc.update_issue_status = AsyncMock(return_value=True)
+        mock_issue_svc.finalize_issue = AsyncMock(return_value=True)
+
+        anomaly = AnomalyResult(
+            check_type="failed_issue_merged_pr",
+            entity_type="issue",
+            entity_id="issue_1",
+            project_id="proj_a",
+            description="test",
+            remediation_action="recover_failed_issue",
+            context={"branch": "f/issue_1/c1"},
+        )
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            success = await monitor._attempt_remediation(anomaly)
+
+        assert success
+        # Should have called update_issue_status(IN_PROGRESS) then finalize_issue
+        mock_issue_svc.update_issue_status.assert_awaited()
+        first_call = mock_issue_svc.update_issue_status.call_args_list[0]
+        assert first_call.args[1] == IssueStatus.IN_PROGRESS

--- a/serving/tests/unit/test_system_integrity_monitor.py
+++ b/serving/tests/unit/test_system_integrity_monitor.py
@@ -1,0 +1,565 @@
+"""Tests for SystemIntegrityMonitor."""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from dataclasses import dataclass
+
+from services.system_integrity_monitor import (
+    SystemIntegrityMonitor,
+    AnomalyResult,
+    COOLDOWNS,
+    ESCALATION_THRESHOLD,
+)
+
+
+# Patch targets — lazy imports inside methods resolve from the source module
+WM_PATCH = "services.work_map_service.get_work_map_service"
+PR_PATCH = "api.git.get_pr_service"
+SSE_PATCH = "services.sse_connection_manager.get_sse_connection_manager"
+NOTIF_PATCH = "services.notification_service.get_notification_service"
+DISPATCH_PATCH = "services.work_dispatcher.get_work_dispatcher"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FakeWorkItem:
+    work_id: str
+    status: object
+    branch_name: str = ""
+    project_id: str = "proj_test"
+    assigned_to: str = None
+    issue_id: str = "issue_1"
+    progress_percent: int = 0
+    last_activity_at: datetime = None
+
+
+@dataclass
+class FakeIssue:
+    id: str
+    status: object
+    project_id: str = "proj_test"
+    goal_id: str = "goal_1"
+
+
+@dataclass
+class FakeGoal:
+    id: str
+    status: object
+    project_id: str = "proj_test"
+
+
+@dataclass
+class FakePR:
+    branch: str
+    status: object
+    updated_at: datetime = None
+
+
+@dataclass
+class FakeListResult:
+    items: list
+
+
+@dataclass
+class FakeSSEConnection:
+    compute_id: str
+    status: str = "idle"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle Tests
+# ---------------------------------------------------------------------------
+
+class TestLifecycle:
+    def test_init_defaults(self):
+        monitor = SystemIntegrityMonitor()
+        assert monitor.check_interval == 60
+        assert not monitor.is_running()
+        assert monitor.get_stats()["cycles"] == 0
+
+    def test_custom_interval(self):
+        monitor = SystemIntegrityMonitor(check_interval=30)
+        assert monitor.check_interval == 30
+
+    @pytest.mark.asyncio
+    async def test_start_stop(self):
+        monitor = SystemIntegrityMonitor(check_interval=9999)
+        await monitor.start()
+        assert monitor.is_running()
+        await monitor.stop()
+        assert not monitor.is_running()
+
+    @pytest.mark.asyncio
+    async def test_double_start(self):
+        monitor = SystemIntegrityMonitor(check_interval=9999)
+        await monitor.start()
+        await monitor.start()  # Should not error
+        assert monitor.is_running()
+        await monitor.stop()
+
+
+# ---------------------------------------------------------------------------
+# Throttling Tests
+# ---------------------------------------------------------------------------
+
+class TestThrottling:
+    def test_first_attempt_not_throttled(self):
+        monitor = SystemIntegrityMonitor()
+        assert not monitor._should_throttle("merged:w1", "merged_not_finalized")
+
+    def test_throttled_within_cooldown(self):
+        monitor = SystemIntegrityMonitor()
+        monitor._record_attempt("merged:w1")
+        assert monitor._should_throttle("merged:w1", "merged_not_finalized")
+
+    def test_not_throttled_after_cooldown(self):
+        monitor = SystemIntegrityMonitor()
+        monitor._record_attempt("merged:w1")
+        monitor._attempt_tracker["merged:w1"]["last_attempt"] = (
+            datetime.now(timezone.utc) - timedelta(seconds=COOLDOWNS["merged_not_finalized"] + 1)
+        )
+        assert not monitor._should_throttle("merged:w1", "merged_not_finalized")
+
+    def test_attempt_count_increments(self):
+        monitor = SystemIntegrityMonitor()
+        monitor._record_attempt("key1")
+        monitor._record_attempt("key1")
+        monitor._record_attempt("key1")
+        assert monitor._attempt_tracker["key1"]["attempt_count"] == 3
+
+    def test_cleanup_removes_stale_entries(self):
+        monitor = SystemIntegrityMonitor()
+        monitor._record_attempt("old_key")
+        # 2000s > 1800s threshold → should be cleaned
+        monitor._attempt_tracker["old_key"]["last_attempt"] = (
+            datetime.now(timezone.utc) - timedelta(seconds=2000)
+        )
+        monitor._cleanup_tracker()
+        assert "old_key" not in monitor._attempt_tracker
+
+    def test_cleanup_keeps_recent_entries(self):
+        monitor = SystemIntegrityMonitor()
+        monitor._record_attempt("recent_key")
+        # 60s < 1800s threshold → should stay
+        monitor._attempt_tracker["recent_key"]["last_attempt"] = (
+            datetime.now(timezone.utc) - timedelta(seconds=60)
+        )
+        monitor._cleanup_tracker()
+        assert "recent_key" in monitor._attempt_tracker
+
+
+# ---------------------------------------------------------------------------
+# Notification Tests
+# ---------------------------------------------------------------------------
+
+class TestNotification:
+    def test_notify_warning_below_threshold(self):
+        monitor = SystemIntegrityMonitor()
+        anomaly = AnomalyResult(
+            check_type="stuck_goal",
+            entity_type="goal",
+            entity_id="g1",
+            project_id="proj_test",
+            description="Goal stuck",
+            remediation_action=None,
+        )
+
+        with patch(NOTIF_PATCH) as mock_get:
+            mock_svc = MagicMock()
+            mock_get.return_value = mock_svc
+            monitor._notify(anomaly, consecutive=1)
+            mock_svc.emit.assert_called_once()
+            from models.notification import NotificationLevel
+            call_kwargs = mock_svc.emit.call_args
+            assert call_kwargs.kwargs.get("level") == NotificationLevel.WARNING
+
+    def test_notify_error_at_threshold(self):
+        monitor = SystemIntegrityMonitor()
+        anomaly = AnomalyResult(
+            check_type="stuck_goal",
+            entity_type="goal",
+            entity_id="g1",
+            project_id="proj_test",
+            description="Goal stuck",
+            remediation_action=None,
+        )
+
+        with patch(NOTIF_PATCH) as mock_get:
+            mock_svc = MagicMock()
+            mock_get.return_value = mock_svc
+            monitor._notify(anomaly, consecutive=ESCALATION_THRESHOLD)
+            mock_svc.emit.assert_called_once()
+            from models.notification import NotificationLevel
+            call_kwargs = mock_svc.emit.call_args
+            assert call_kwargs.kwargs.get("level") == NotificationLevel.ERROR
+
+
+# ---------------------------------------------------------------------------
+# Check 1: Merged Not Finalized
+# ---------------------------------------------------------------------------
+
+class TestMergedNotFinalized:
+    @pytest.mark.asyncio
+    async def test_detects_merged_branch_with_active_work(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import WorkStatus
+        from git.pr_service import PRStatus
+
+        fake_work = FakeWorkItem(
+            work_id="w1", status=WorkStatus.IN_PROGRESS,
+            branch_name="f/issue_123", project_id="proj_a",
+        )
+        fake_pr = FakePR(branch="f/issue_123", status=PRStatus.MERGED)
+
+        async def list_work_by_status(status=None, **kwargs):
+            if status == WorkStatus.IN_PROGRESS:
+                return FakeListResult(items=[fake_work])
+            return FakeListResult(items=[])
+
+        mock_wm = AsyncMock()
+        mock_wm.list_work = AsyncMock(side_effect=list_work_by_status)
+
+        mock_pr_svc = AsyncMock()
+        mock_pr_svc.get_pr = AsyncMock(return_value=fake_pr)
+
+        with patch(WM_PATCH, return_value=mock_wm), \
+             patch(PR_PATCH, return_value=mock_pr_svc):
+            results = await monitor._check_merged_not_finalized()
+
+        assert len(results) == 1
+        assert results[0].check_type == "merged_not_finalized"
+        assert results[0].entity_id == "w1"
+        assert results[0].remediation_action == "finalize_work"
+
+    @pytest.mark.asyncio
+    async def test_no_anomaly_when_pr_not_merged(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import WorkStatus
+        from git.pr_service import PRStatus
+
+        fake_work = FakeWorkItem(
+            work_id="w1", status=WorkStatus.IN_PROGRESS,
+            branch_name="f/issue_123", project_id="proj_a",
+        )
+        fake_pr = FakePR(branch="f/issue_123", status=PRStatus.IN_REVIEW)
+
+        async def list_work_by_status(status=None, **kwargs):
+            if status == WorkStatus.IN_PROGRESS:
+                return FakeListResult(items=[fake_work])
+            return FakeListResult(items=[])
+
+        mock_wm = AsyncMock()
+        mock_wm.list_work = AsyncMock(side_effect=list_work_by_status)
+
+        mock_pr_svc = AsyncMock()
+        mock_pr_svc.get_pr = AsyncMock(return_value=fake_pr)
+
+        with patch(WM_PATCH, return_value=mock_wm), \
+             patch(PR_PATCH, return_value=mock_pr_svc):
+            results = await monitor._check_merged_not_finalized()
+
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# Check 2: Stuck Issues
+# ---------------------------------------------------------------------------
+
+class TestStuckIssues:
+    @pytest.mark.asyncio
+    async def test_detects_issue_with_all_work_completed(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import IssueStatus, WorkStatus
+
+        fake_issue = FakeIssue(id="issue_1", status=IssueStatus.IN_PROGRESS)
+        fake_work = FakeWorkItem(
+            work_id="w1", status=WorkStatus.COMPLETED, issue_id="issue_1"
+        )
+
+        async def list_issues_by_status(status=None, **kwargs):
+            if status == IssueStatus.IN_PROGRESS:
+                return FakeListResult(items=[fake_issue])
+            return FakeListResult(items=[])
+
+        mock_wm = AsyncMock()
+        mock_wm.list_issues = AsyncMock(side_effect=list_issues_by_status)
+        mock_wm._work_items = {"w1": fake_work}
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            results = await monitor._check_stuck_issues()
+
+        assert len(results) == 1
+        assert results[0].check_type == "stuck_issue"
+        assert results[0].remediation_action == "finalize_issue"
+
+    @pytest.mark.asyncio
+    async def test_no_anomaly_when_work_still_active(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import IssueStatus, WorkStatus
+
+        fake_issue = FakeIssue(id="issue_1", status=IssueStatus.IN_PROGRESS)
+        fake_work = FakeWorkItem(
+            work_id="w1", status=WorkStatus.IN_PROGRESS, issue_id="issue_1"
+        )
+
+        async def list_issues_by_status(status=None, **kwargs):
+            if status == IssueStatus.IN_PROGRESS:
+                return FakeListResult(items=[fake_issue])
+            return FakeListResult(items=[])
+
+        mock_wm = AsyncMock()
+        mock_wm.list_issues = AsyncMock(side_effect=list_issues_by_status)
+        mock_wm._work_items = {"w1": fake_work}
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            results = await monitor._check_stuck_issues()
+
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# Check 3: Stuck Goals
+# ---------------------------------------------------------------------------
+
+class TestStuckGoals:
+    @pytest.mark.asyncio
+    async def test_detects_goal_with_all_issues_done(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import GoalStatus, IssueStatus
+
+        fake_goal = FakeGoal(id="goal_1", status=GoalStatus.IN_PROGRESS)
+        fake_issues = [
+            FakeIssue(id="i1", status=IssueStatus.DONE),
+            FakeIssue(id="i2", status=IssueStatus.DONE),
+        ]
+
+        mock_wm = AsyncMock()
+        mock_wm.list_goals = AsyncMock(
+            return_value=FakeListResult(items=[fake_goal])
+        )
+        mock_wm.get_goal_issues = AsyncMock(return_value=fake_issues)
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            results = await monitor._check_stuck_goals()
+
+        assert len(results) == 1
+        assert results[0].check_type == "stuck_goal"
+        assert results[0].remediation_action == "check_goal_completion"
+
+    @pytest.mark.asyncio
+    async def test_no_anomaly_when_issues_not_all_done(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import GoalStatus, IssueStatus
+
+        fake_goal = FakeGoal(id="goal_1", status=GoalStatus.IN_PROGRESS)
+        fake_issues = [
+            FakeIssue(id="i1", status=IssueStatus.DONE),
+            FakeIssue(id="i2", status=IssueStatus.IN_PROGRESS),
+        ]
+
+        mock_wm = AsyncMock()
+        mock_wm.list_goals = AsyncMock(
+            return_value=FakeListResult(items=[fake_goal])
+        )
+        mock_wm.get_goal_issues = AsyncMock(return_value=fake_issues)
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            results = await monitor._check_stuck_goals()
+
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# Check 6: Pipeline Stall
+# ---------------------------------------------------------------------------
+
+class TestPipelineStall:
+    @pytest.mark.asyncio
+    async def test_detects_pending_work_with_idle_computes(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import WorkStatus
+
+        fake_work = FakeWorkItem(work_id="w1", status=WorkStatus.PENDING)
+
+        mock_wm = AsyncMock()
+        mock_wm.list_work = AsyncMock(
+            return_value=FakeListResult(items=[fake_work])
+        )
+
+        mock_sse = MagicMock()
+        mock_sse.list_connections.return_value = [
+            FakeSSEConnection(compute_id="c1", status="idle")
+        ]
+
+        with patch(WM_PATCH, return_value=mock_wm), \
+             patch(SSE_PATCH, return_value=mock_sse):
+            results = await monitor._check_pipeline_stall()
+
+        assert len(results) == 1
+        assert results[0].check_type == "pipeline_stall"
+        assert results[0].remediation_action == "trigger_dispatch"
+
+    @pytest.mark.asyncio
+    async def test_no_stall_when_no_idle_computes(self):
+        monitor = SystemIntegrityMonitor()
+
+        mock_sse = MagicMock()
+        mock_sse.list_connections.return_value = [
+            FakeSSEConnection(compute_id="c1", status="busy")
+        ]
+
+        with patch(SSE_PATCH, return_value=mock_sse):
+            results = await monitor._check_pipeline_stall()
+
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# Check 7: Orphaned Work
+# ---------------------------------------------------------------------------
+
+class TestOrphanedWork:
+    @pytest.mark.asyncio
+    async def test_detects_work_on_disconnected_compute(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import WorkStatus
+
+        fake_work = FakeWorkItem(
+            work_id="w1", status=WorkStatus.IN_PROGRESS,
+            assigned_to="dead-compute-001",
+        )
+
+        async def list_work_by_status(status=None, **kwargs):
+            if status == WorkStatus.IN_PROGRESS:
+                return FakeListResult(items=[fake_work])
+            return FakeListResult(items=[])
+
+        mock_wm = AsyncMock()
+        mock_wm.list_work = AsyncMock(side_effect=list_work_by_status)
+
+        mock_sse = MagicMock()
+        mock_sse.list_connections.return_value = [
+            FakeSSEConnection(compute_id="alive-compute-001", status="idle")
+        ]
+
+        with patch(WM_PATCH, return_value=mock_wm), \
+             patch(SSE_PATCH, return_value=mock_sse):
+            results = await monitor._check_orphaned_work()
+
+        assert len(results) == 1
+        assert results[0].check_type == "orphaned_work"
+        assert results[0].remediation_action == "requeue_orphaned"
+
+    @pytest.mark.asyncio
+    async def test_no_orphan_when_compute_connected(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import WorkStatus
+
+        fake_work = FakeWorkItem(
+            work_id="w1", status=WorkStatus.IN_PROGRESS,
+            assigned_to="c1",
+        )
+
+        async def list_work_by_status(status=None, **kwargs):
+            if status == WorkStatus.IN_PROGRESS:
+                return FakeListResult(items=[fake_work])
+            return FakeListResult(items=[])
+
+        mock_wm = AsyncMock()
+        mock_wm.list_work = AsyncMock(side_effect=list_work_by_status)
+
+        mock_sse = MagicMock()
+        mock_sse.list_connections.return_value = [
+            FakeSSEConnection(compute_id="c1", status="busy")
+        ]
+
+        with patch(WM_PATCH, return_value=mock_wm), \
+             patch(SSE_PATCH, return_value=mock_sse):
+            results = await monitor._check_orphaned_work()
+
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+class TestStats:
+    def test_stats_structure(self):
+        monitor = SystemIntegrityMonitor()
+        stats = monitor.get_stats()
+        assert stats["cycles"] == 0
+        assert stats["running"] is False
+        assert "by_check_type" in stats
+        assert "merged_not_finalized" in stats["by_check_type"]
+        assert "orphaned_work" in stats["by_check_type"]
+
+
+# ---------------------------------------------------------------------------
+# Remediation
+# ---------------------------------------------------------------------------
+
+class TestRemediation:
+    @pytest.mark.asyncio
+    async def test_finalize_work_remediation(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import WorkStatus
+
+        fake_work = FakeWorkItem(
+            work_id="w1", status=WorkStatus.IMPLEMENTED,
+        )
+
+        mock_wm = AsyncMock()
+        mock_wm._work_items = {"w1": fake_work}
+        mock_wm.finalize_work = AsyncMock(return_value=fake_work)
+
+        anomaly = AnomalyResult(
+            check_type="merged_not_finalized",
+            entity_type="work",
+            entity_id="w1",
+            project_id="proj_test",
+            description="test",
+            remediation_action="finalize_work",
+            context={"branch": "f/test"},
+        )
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            success = await monitor._attempt_remediation(anomaly)
+
+        assert success
+        mock_wm.finalize_work.assert_awaited_once_with("w1")
+
+    @pytest.mark.asyncio
+    async def test_trigger_dispatch_remediation(self):
+        monitor = SystemIntegrityMonitor()
+
+        mock_dispatcher = MagicMock()
+
+        anomaly = AnomalyResult(
+            check_type="pipeline_stall",
+            entity_type="system",
+            entity_id="stall",
+            project_id=None,
+            description="test",
+            remediation_action="trigger_dispatch",
+        )
+
+        with patch(DISPATCH_PATCH, return_value=mock_dispatcher):
+            success = await monitor._attempt_remediation(anomaly)
+
+        assert success
+        mock_dispatcher.trigger.assert_called_once_with(reason="integrity_pipeline_stall")

--- a/serving/tests/unit/test_system_integrity_monitor.py
+++ b/serving/tests/unit/test_system_integrity_monitor.py
@@ -888,6 +888,45 @@ class TestFailedIssueMergedPR:
         assert len(results) == 0
 
     @pytest.mark.asyncio
+    async def test_detects_via_fallback_branch_scan(self):
+        """Work item has stale branch_name — fallback scans merged PRs by issue prefix."""
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import IssueStatus, WorkStatus
+        from git.pr_service import PRStatus
+
+        fake_issue = FakeIssue(
+            issue_id="issue_2d364", status=IssueStatus.FAILED, project_id="proj_a"
+        )
+        # Work item has python-002 branch (stale), but merged PR is on python-001
+        fake_work = FakeWorkItem(
+            work_id="w1", status=WorkStatus.FAILED,
+            branch_name="f/issue_2d364/python-002", project_id="proj_a",
+            issue_id="issue_2d364",
+        )
+        # Direct lookup returns nothing (no PR for python-002)
+        # But list_prs returns a merged PR on python-001
+        merged_pr = FakePR(branch="f/issue_2d364/python-001", status=PRStatus.MERGED)
+
+        mock_wm = AsyncMock()
+        mock_wm.list_issues = AsyncMock(
+            return_value=FakeListResult(items=[fake_issue])
+        )
+        mock_wm._work_items = {"w1": fake_work}
+
+        mock_pr_svc = AsyncMock()
+        mock_pr_svc.get_pr = AsyncMock(return_value=None)  # Direct lookup misses
+        mock_pr_svc.list_prs = AsyncMock(return_value=[merged_pr])
+
+        with patch(WM_PATCH, return_value=mock_wm), \
+             patch(PR_PATCH, return_value=mock_pr_svc):
+            results = await monitor._check_failed_issue_merged_pr()
+
+        assert len(results) == 1
+        assert results[0].check_type == "failed_issue_merged_pr"
+        assert "python-001" in results[0].description
+
+    @pytest.mark.asyncio
     async def test_no_flag_when_no_work_items(self):
         monitor = SystemIntegrityMonitor()
 

--- a/serving/tests/unit/test_system_integrity_monitor.py
+++ b/serving/tests/unit/test_system_integrity_monitor.py
@@ -528,6 +528,8 @@ class TestStats:
         assert "by_check_type" in stats
         assert "merged_not_finalized" in stats["by_check_type"]
         assert "orphaned_work" in stats["by_check_type"]
+        assert "failed_work_impact" in stats["by_check_type"]
+        assert "stuck_planning_goal" in stats["by_check_type"]
 
 
 # ---------------------------------------------------------------------------
@@ -585,3 +587,229 @@ class TestRemediation:
 
         assert success
         mock_dispatcher.trigger.assert_called_once_with(reason="integrity_pipeline_stall")
+
+    @pytest.mark.asyncio
+    async def test_fail_parent_issue_remediation(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import IssueStatus
+
+        mock_wm = AsyncMock()
+        mock_wm._issue_service = AsyncMock()
+
+        anomaly = AnomalyResult(
+            check_type="failed_work_impact",
+            entity_type="issue",
+            entity_id="issue_1",
+            project_id="proj_test",
+            description="test",
+            remediation_action="fail_parent_issue",
+        )
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            success = await monitor._attempt_remediation(anomaly)
+
+        assert success
+        mock_wm._issue_service.update_issue_status.assert_awaited_once_with(
+            "issue_1", IssueStatus.FAILED
+        )
+
+    @pytest.mark.asyncio
+    async def test_fail_stuck_planning_goal_remediation(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import GoalStatus
+
+        fake_goal = FakeGoal(goal_id="g1", status=GoalStatus.PLANNING)
+
+        mock_wm = AsyncMock()
+        mock_wm._goals = {"g1": fake_goal}
+
+        anomaly = AnomalyResult(
+            check_type="stuck_planning_goal",
+            entity_type="goal",
+            entity_id="g1",
+            project_id="proj_test",
+            description="test",
+            remediation_action="fail_stuck_planning_goal",
+        )
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            success = await monitor._attempt_remediation(anomaly)
+
+        assert success
+        assert fake_goal.status == GoalStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Check 8: Failed Work Impact
+# ---------------------------------------------------------------------------
+
+class TestFailedWorkImpact:
+    @pytest.mark.asyncio
+    async def test_detects_issue_with_all_work_failed(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import IssueStatus, WorkStatus
+
+        fake_issue = FakeIssue(issue_id="issue_1", status=IssueStatus.IN_PROGRESS)
+        fake_work_1 = FakeWorkItem(
+            work_id="w1", status=WorkStatus.FAILED, issue_id="issue_1"
+        )
+        fake_work_2 = FakeWorkItem(
+            work_id="w2", status=WorkStatus.FAILED, issue_id="issue_1"
+        )
+
+        async def list_issues_by_status(status=None, **kwargs):
+            if status == IssueStatus.IN_PROGRESS:
+                return FakeListResult(items=[fake_issue])
+            return FakeListResult(items=[])
+
+        mock_wm = AsyncMock()
+        mock_wm.list_issues = AsyncMock(side_effect=list_issues_by_status)
+        mock_wm._work_items = {"w1": fake_work_1, "w2": fake_work_2}
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            results = await monitor._check_failed_work_impact()
+
+        assert len(results) == 1
+        assert results[0].check_type == "failed_work_impact"
+        assert results[0].remediation_action == "fail_parent_issue"
+        assert "2/2" in results[0].description
+
+    @pytest.mark.asyncio
+    async def test_detects_mixed_completed_and_failed(self):
+        """Issue with some COMPLETED + some FAILED work should still flag."""
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import IssueStatus, WorkStatus
+
+        fake_issue = FakeIssue(issue_id="issue_1", status=IssueStatus.IN_PROGRESS)
+        fake_work_1 = FakeWorkItem(
+            work_id="w1", status=WorkStatus.COMPLETED, issue_id="issue_1"
+        )
+        fake_work_2 = FakeWorkItem(
+            work_id="w2", status=WorkStatus.FAILED, issue_id="issue_1"
+        )
+
+        async def list_issues_by_status(status=None, **kwargs):
+            if status == IssueStatus.IN_PROGRESS:
+                return FakeListResult(items=[fake_issue])
+            return FakeListResult(items=[])
+
+        mock_wm = AsyncMock()
+        mock_wm.list_issues = AsyncMock(side_effect=list_issues_by_status)
+        mock_wm._work_items = {"w1": fake_work_1, "w2": fake_work_2}
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            results = await monitor._check_failed_work_impact()
+
+        assert len(results) == 1
+        assert "1/2" in results[0].description
+
+    @pytest.mark.asyncio
+    async def test_no_flag_when_work_still_active(self):
+        """Don't flag if some work is still IN_PROGRESS."""
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import IssueStatus, WorkStatus
+
+        fake_issue = FakeIssue(issue_id="issue_1", status=IssueStatus.IN_PROGRESS)
+        fake_work_1 = FakeWorkItem(
+            work_id="w1", status=WorkStatus.FAILED, issue_id="issue_1"
+        )
+        fake_work_2 = FakeWorkItem(
+            work_id="w2", status=WorkStatus.IN_PROGRESS, issue_id="issue_1"
+        )
+
+        async def list_issues_by_status(status=None, **kwargs):
+            if status == IssueStatus.IN_PROGRESS:
+                return FakeListResult(items=[fake_issue])
+            return FakeListResult(items=[])
+
+        mock_wm = AsyncMock()
+        mock_wm.list_issues = AsyncMock(side_effect=list_issues_by_status)
+        mock_wm._work_items = {"w1": fake_work_1, "w2": fake_work_2}
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            results = await monitor._check_failed_work_impact()
+
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# Check 9: Stuck Planning Goals
+# ---------------------------------------------------------------------------
+
+class TestStuckPlanningGoals:
+    @pytest.mark.asyncio
+    async def test_detects_goal_stuck_in_planning(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import GoalStatus
+
+        fake_goal = FakeGoal(goal_id="g1", status=GoalStatus.PLANNING)
+        # Created 20 minutes ago (> 15 min threshold)
+        fake_goal.created_at = (
+            datetime.now(timezone.utc) - timedelta(minutes=20)
+        )
+
+        mock_wm = AsyncMock()
+        mock_wm.list_goals = AsyncMock(
+            return_value=FakeListResult(items=[fake_goal])
+        )
+        mock_wm.get_goal_issues = AsyncMock(return_value=[])
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            results = await monitor._check_stuck_planning_goals()
+
+        assert len(results) == 1
+        assert results[0].check_type == "stuck_planning_goal"
+        assert results[0].remediation_action == "fail_stuck_planning_goal"
+
+    @pytest.mark.asyncio
+    async def test_no_flag_within_grace_period(self):
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import GoalStatus
+
+        fake_goal = FakeGoal(goal_id="g1", status=GoalStatus.PLANNING)
+        # Created 5 minutes ago (< 15 min threshold)
+        fake_goal.created_at = (
+            datetime.now(timezone.utc) - timedelta(minutes=5)
+        )
+
+        mock_wm = AsyncMock()
+        mock_wm.list_goals = AsyncMock(
+            return_value=FakeListResult(items=[fake_goal])
+        )
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            results = await monitor._check_stuck_planning_goals()
+
+        assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_flag_when_issues_exist(self):
+        """If decomposition produced issues, goal is transitioning — don't flag."""
+        monitor = SystemIntegrityMonitor()
+
+        from models.work_map import GoalStatus, IssueStatus
+
+        fake_goal = FakeGoal(goal_id="g1", status=GoalStatus.PLANNING)
+        fake_goal.created_at = (
+            datetime.now(timezone.utc) - timedelta(minutes=20)
+        )
+
+        mock_wm = AsyncMock()
+        mock_wm.list_goals = AsyncMock(
+            return_value=FakeListResult(items=[fake_goal])
+        )
+        mock_wm.get_goal_issues = AsyncMock(return_value=[
+            FakeIssue(issue_id="i1", status=IssueStatus.READY)
+        ])
+
+        with patch(WM_PATCH, return_value=mock_wm):
+            results = await monitor._check_stuck_planning_goals()
+
+        assert len(results) == 0


### PR DESCRIPTION
## Summary

Replaces the ReconciliationManager with an active SystemIntegrityMonitor, fixes the merge pipeline to be a self-contained conflict resolution loop, adds system-wide pause/resume, and provides full pipeline observability via the plan page activity log.

## Key Changes

### SystemIntegrityMonitor (replaces ReconciliationManager)
- 10 anomaly checks with per-entity throttling and escalating notifications
- Detects: un-finalized merges, stuck issues/goals/PRs, stale work, pipeline stalls, orphaned work, failed work impact, stuck planning goals, failed issues with merged PRs
- Short-circuits sweep after high-priority remediation to let state settle
- Emits activity events for every detection, fix, and failure — no more silent operations

### Merge Pipeline (self-contained conflict resolution loop)
- First merge wins, subsequent conflicts dispatch rebase to the correct compute
- Compute held in "merging" state until PR pipeline completes (no double-assignment)
- Conflict resolution uses the correct work item per branch (not caller's)
- Other branches that merge in the same queue run get finalized immediately
- PENDING PRs with conflicts and stale PENDING PRs both handled
- `_auto_create_and_merge_pr` returns "merged"/"pending"/"revert" (not bool) to distinguish infrastructure failures from code issues

### Observability
- Activity events emitted across full work lifecycle (started, completed, failed, PR created, merged, conflict, rebase, quality gates, finalized)
- Plan page "Activity Log" shows events from project service (replaces decision traces in "Other Activity")
- Integrity monitor actions visible in activity log
- Sweep heartbeat logging every 10th cycle
- Live WebSocket messages now render when user hasn't typed (frontend fix)

### UI/UX
- Pause/Resume button on plan tab header (system-wide work dispatch control)
- Paused banner with inline resume button
- "Merged" column renamed to "Done" (matches actual state machine)
- Status update groups capped at 20 per box
- GoalCompletionCard simplified to "N issues created"
- AI agent only notified for user-typed messages (no more reviewing system status)

### Bug Fixes
- Duplicate `claude_code_completed` no longer reverts IMPLEMENTED work
- Missing `get_work_map_service` import in finalize path (root cause of test2 stall)
- PR lookup uses resolved git project name (not raw project_id)
- Goal save uses correct `_save_goal_to_redis` (not WorkItem serializer)
- `check_mergeable` returning `mergeable: true` for diverged branches no longer causes silent merge failures

## Issues

Closes #260
Closes #261
Closes #263
Closes #264
Closes #265
Closes #277

## Testing

- 62 unit tests passing (39 integrity monitor + 23 compute events)
- Frontend builds clean
- Live tested on test2 project: 12/17 issues completed through full pipeline, conflict resolution loop verified, activity log showing events

## Notes

- Issue #282 (adaptive integrity monitor interval) raised but not implemented — tracked for future
- Issue #262 (project manifest) closed as unnecessary — git main + forced rebases handle consistency
- ReconciliationManager still present in codebase but unused — #277 tracks full removal after validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)