### PR TITLE
fix: Persist orchestrator pause/resume state to Redis (#281)

### DIFF
--- a/serving/api/orchestrator.py
+++ b/serving/api/orchestrator.py
@@ -57,7 +57,7 @@ async def pause_orchestrator():
             detail="Work orchestrator is not running"
         )
 
-    orchestrator.pause()
+    await orchestrator.pause()
 
     return {
         "status": "paused",
@@ -88,7 +88,7 @@ async def resume_orchestrator():
             detail="Work orchestrator is not running"
         )
 
-    orchestrator.resume()
+    await orchestrator.resume()
 
     return {
         "status": "running",

--- a/serving/services/work_orchestrator.py
+++ b/serving/services/work_orchestrator.py
@@ -164,6 +164,9 @@ class WorkOrchestrator:
             logger.warning("Work orchestrator already running")
             return
 
+        # Restore persisted pause state before entering loop
+        await self._load_pause_state()
+
         self._running = True
         self._task = asyncio.create_task(self._orchestration_loop())
 
@@ -205,15 +208,47 @@ class WorkOrchestrator:
 
         logger.info("Work orchestrator stopped")
 
-    def pause(self) -> None:
-        """Pause orchestration (stops spawning new work)."""
+    async def pause(self) -> None:
+        """Pause orchestration (stops spawning new work).
+
+        Persists pause state to Redis so it survives restarts.
+        """
         self._paused = True
+        await self._persist_pause_state(True)
         logger.info("Work orchestrator paused")
 
-    def resume(self) -> None:
-        """Resume orchestration."""
+    async def resume(self) -> None:
+        """Resume orchestration.
+
+        Persists resume state to Redis so it survives restarts.
+        """
         self._paused = False
+        await self._persist_pause_state(False)
         logger.info("Work orchestrator resumed")
+
+    async def _persist_pause_state(self, paused: bool) -> None:
+        """Persist pause state to Redis."""
+        try:
+            from git.redis_client import get_redis
+            r = await get_redis()
+            await r.set("claudevn:orchestrator:paused", "1" if paused else "0")
+        except Exception as e:
+            logger.warning(f"Failed to persist pause state to Redis: {e}")
+
+    async def _load_pause_state(self) -> None:
+        """Load pause state from Redis on startup.
+
+        Falls back to running (unpaused) if Redis is unavailable.
+        """
+        try:
+            from git.redis_client import get_redis
+            r = await get_redis()
+            value = await r.get("claudevn:orchestrator:paused")
+            if value == "1":
+                self._paused = True
+                logger.info("Restored paused state from Redis — orchestrator is paused")
+        except Exception as e:
+            logger.warning(f"Failed to load pause state from Redis, defaulting to running: {e}")
 
     def is_running(self) -> bool:
         """Check if orchestrator is running."""

--- a/serving/tests/unit/test_error_recovery.py
+++ b/serving/tests/unit/test_error_recovery.py
@@ -713,7 +713,9 @@ class TestOrchestratorErrorRecovery:
         """Paused orchestrator does not process work."""
         orchestrator = WorkOrchestrator(poll_interval=1)
 
-        orchestrator.pause()
+        mock_redis = AsyncMock()
+        with patch("git.redis_client.get_redis", new_callable=AsyncMock, return_value=mock_redis):
+            await orchestrator.pause()
         assert orchestrator.is_paused()
 
         result = await orchestrator.trigger_immediate()

--- a/serving/tests/unit/test_work_orchestrator.py
+++ b/serving/tests/unit/test_work_orchestrator.py
@@ -57,22 +57,73 @@ class TestWorkOrchestrator:
         assert stats["paused"] is False
         assert stats["active_spawns"] == 0
 
-    def test_pause_resume(self, orchestrator):
-        """Test pause and resume."""
+    @pytest.mark.asyncio
+    async def test_pause_resume(self, orchestrator):
+        """Test pause and resume persists state to Redis."""
         assert not orchestrator.is_paused()
 
-        orchestrator.pause()
+        mock_redis = AsyncMock()
+        with patch("git.redis_client.get_redis", new_callable=AsyncMock, return_value=mock_redis):
+            await orchestrator.pause()
+            assert orchestrator.is_paused()
+            mock_redis.set.assert_called_with("claudevn:orchestrator:paused", "1")
+
+            await orchestrator.resume()
+            assert not orchestrator.is_paused()
+            mock_redis.set.assert_called_with("claudevn:orchestrator:paused", "0")
+
+    @pytest.mark.asyncio
+    async def test_pause_redis_failure_graceful(self, orchestrator):
+        """Test pause still works locally when Redis is unavailable."""
+        with patch("git.redis_client.get_redis", new_callable=AsyncMock, side_effect=Exception("Redis down")):
+            await orchestrator.pause()
         assert orchestrator.is_paused()
 
-        orchestrator.resume()
-        assert not orchestrator.is_paused()
+    @pytest.mark.asyncio
+    async def test_load_pause_state_from_redis(self):
+        """Test startup loads paused state from Redis."""
+        orch = WorkOrchestrator(poll_interval=1)
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value="1")
+
+        with patch("git.redis_client.get_redis", new_callable=AsyncMock, return_value=mock_redis):
+            await orch.start()
+
+        assert orch.is_paused()
+        mock_redis.get.assert_called_with("claudevn:orchestrator:paused")
+        await orch.stop()
+
+    @pytest.mark.asyncio
+    async def test_load_pause_state_not_paused(self):
+        """Test startup with Redis returning not-paused."""
+        orch = WorkOrchestrator(poll_interval=1)
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value="0")
+
+        with patch("git.redis_client.get_redis", new_callable=AsyncMock, return_value=mock_redis):
+            await orch.start()
+
+        assert not orch.is_paused()
+        await orch.stop()
+
+    @pytest.mark.asyncio
+    async def test_load_pause_state_redis_unavailable(self):
+        """Test startup defaults to running when Redis is unavailable."""
+        orch = WorkOrchestrator(poll_interval=1)
+
+        with patch("git.redis_client.get_redis", new_callable=AsyncMock, side_effect=Exception("Redis down")):
+            await orch.start()
+
+        assert not orch.is_paused()
+        await orch.stop()
 
     @pytest.mark.asyncio
     async def test_start_stop(self, orchestrator):
         """Test start and stop."""
         assert not orchestrator.is_running()
 
-        await orchestrator.start()
+        with patch("git.redis_client.get_redis", new_callable=AsyncMock, return_value=AsyncMock(get=AsyncMock(return_value=None))):
+            await orchestrator.start()
         assert orchestrator.is_running()
 
         await orchestrator.stop()
@@ -81,8 +132,9 @@ class TestWorkOrchestrator:
     @pytest.mark.asyncio
     async def test_start_twice_warns(self, orchestrator, caplog):
         """Test starting twice logs warning."""
-        await orchestrator.start()
-        await orchestrator.start()  # Should warn
+        with patch("git.redis_client.get_redis", new_callable=AsyncMock, return_value=AsyncMock(get=AsyncMock(return_value=None))):
+            await orchestrator.start()
+            await orchestrator.start()  # Should warn
 
         await orchestrator.stop()
         assert "already running" in caplog.text.lower()
@@ -211,7 +263,9 @@ class TestOrchestratorTrigger:
     @pytest.mark.asyncio
     async def test_trigger_when_paused(self, orchestrator):
         """Test trigger when paused returns paused status."""
-        orchestrator.pause()
+        mock_redis = AsyncMock()
+        with patch("git.redis_client.get_redis", new_callable=AsyncMock, return_value=mock_redis):
+            await orchestrator.pause()
         result = await orchestrator.trigger_immediate()
 
         assert result["status"] == "paused"


### PR DESCRIPTION
## Summary
- Persist work orchestrator pause/resume state to Redis key `claudevn:orchestrator:paused`
- Load persisted pause state on startup before entering the dispatch loop
- Graceful fallback to running (unpaused) if Redis is unavailable

## Changes
- `serving/services/work_orchestrator.py`: Made `pause()`/`resume()` async, added `_persist_pause_state()` and `_load_pause_state()` methods, called `_load_pause_state()` in `start()`
- `serving/api/orchestrator.py`: Updated pause/resume endpoints to `await` the now-async methods
- `serving/tests/unit/test_work_orchestrator.py`: Updated existing pause/resume test, added 4 new tests for Redis persistence (paused restore, unpaused restore, Redis unavailable fallback, Redis failure graceful handling)
- `serving/tests/unit/test_error_recovery.py`: Updated `test_paused_orchestrator_skips_processing` for async pause

## Testing
- [x] Tier 1 unit tests added/updated
- [x] All Tier 1 unit tests passing (`./scripts/run_unit_tests.sh`)

## Issues
Closes #281