### PR TITLE
feat: Display specific tool names in timing observable block (#280)

### DIFF
--- a/serving/frontend/src/components/dashboard/RightPanels.jsx
+++ b/serving/frontend/src/components/dashboard/RightPanels.jsx
@@ -418,9 +418,12 @@ function TimingPanel({ aggregates, totalWorkItems, workItems, showNotification, 
               {phaseRows.map((phase) => {
                 const pct = maxPhaseMs > 0 ? (phase.avg_ms / maxPhaseMs) * 100 : 0
                 const color = PHASE_COLORS[phase.phase] || 'var(--text-muted)'
-                const label = PHASE_SHORT_NAMES[phase.phase] || phase.phase
+                const label = phase.tool_name || PHASE_SHORT_NAMES[phase.phase] || phase.phase
+                const key = phase.tool_name
+                  ? `${phase.phase}:${phase.tool_name}`
+                  : phase.phase
                 return (
-                  <div key={phase.phase} className="rp-timing-bar-row">
+                  <div key={key} className="rp-timing-bar-row">
                     <span className="rp-timing-bar-label">{label}</span>
                     <div className="rp-timing-bar-track">
                       <div


### PR DESCRIPTION
## Summary
- Show specific tool names (e.g. `create_branch`, `get_backlog`) instead of generic phase labels ("MCP", "Tools") in the control center timing observable block

## Changes
- `serving/frontend/src/components/dashboard/RightPanels.jsx`: Use `phase.tool_name` when available, fall back to `PHASE_SHORT_NAMES` mapping. Updated React keys to be unique per tool_name.

## Testing
- [x] Existing RightPanels unit tests passing (9/9)
- [x] No new rendering tests needed — change is a 3-line template fix

## Issues
Closes #280